### PR TITLE
feat: support auto aspect ratio for RunningHub nano banana 2

### DIFF
--- a/server/generators/running-hub-generator.ts
+++ b/server/generators/running-hub-generator.ts
@@ -164,9 +164,12 @@ export class RunningHubGenerator extends ImageGenerator {
     } else {
       payload = {
         prompt,
-        aspectRatio,
         resolution: imageSize.toLowerCase(), // API expects "1k", not "1K"
       };
+      // aspectRatio is optional; "auto" means letting the API decide, so omit the field.
+      if (aspectRatio !== 'auto') {
+        payload.aspectRatio = aspectRatio;
+      }
       if (!isTextToImage) {
         payload.imageUrls = imageUrls;
       }

--- a/src/types.ts
+++ b/src/types.ts
@@ -522,7 +522,7 @@ export const PROVIDER_MODELS_MAP: Record<ProviderType, ModelConfig[]> = {
       modelId: 'rhart-image-n-g31-flash',
       category: 'image',
       options: {
-        aspectRatios: ['1:1', '4:3', '3:4', '16:9', '9:16', '2:3', '3:2', '1:4', '4:1', '1:8', '8:1', '4:5', '5:4', '21:9', '9:21'],
+        aspectRatios: ['1:1', '4:3', '3:4', '16:9', '9:16', '2:3', '3:2', '1:4', '4:1', '1:8', '8:1', '4:5', '5:4', '21:9', '9:21', 'auto'],
         qualities: ['1K', '2K', '4K'],
       },
     },


### PR DESCRIPTION
## What changed

- Added an `auto` option to the aspect ratio list for the RunningHub `rhart-image-n-g31-flash` (nano banana 2) image model in `src/types.ts`.
- When `auto` is selected, `RunningHubGenerator` omits the `aspectRatio` field from the submit payload entirely, letting the API pick the ratio. Any concrete ratio is passed through unchanged.

## Why

The RunningHub v2 API documents `aspectRatio` as an optional parameter with a fixed enum of ratios. Leaving the field out is the documented way to let the model decide, so the UI now exposes that as an `auto` choice.

## Notes for reviewers

- `auto` is appended at the end of the options list, matching the convention used by other models that offer it (OpenAI, Kling), so the default-highlighted first option in the settings panel is unchanged.
- The payload branch is shared with GPT Image 2 on RunningHub (`rhart-image-g-2`), but that model does not list `auto` in its options, so its behavior is unchanged.
- The field is omitted rather than sent as an empty string because an empty string is not in the documented enum and could fail server-side validation.
- `tsc --noEmit` passes. Not yet verified against the live API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)