### PR TITLE
feat: add Seedream V5 Pro standard model to RunningHub provider

### DIFF
--- a/server/generators/running-hub-generator.ts
+++ b/server/generators/running-hub-generator.ts
@@ -82,7 +82,7 @@ function resolveSeedreamSize(aspectRatio?: string, imageSize?: string): [number,
 
 function isSeedream5Pro(modelId?: string, apiUrl?: string): boolean {
   const target = `${modelId || ''} ${apiUrl || ''}`.toLowerCase();
-  return target.includes('dola-seedream-5.0-pro');
+  return target.includes('dola-seedream-5.0-pro') || target.includes('seedream-v5-pro');
 }
 
 export class RunningHubGenerator extends ImageGenerator {

--- a/src/types.ts
+++ b/src/types.ts
@@ -574,6 +574,18 @@ export const PROVIDER_MODELS_MAP: Record<ProviderType, ModelConfig[]> = {
       },
     },
     {
+      id: 'runninghub-seedream-v5-pro',
+      name: 'Seedream V5 Pro',
+      generatorId: 'RunningHub',
+      modelId: 'seedream-v5-pro',
+      category: 'image',
+      promptLimit: { value: 2000, unit: 'characters' },
+      options: {
+        aspectRatios: ['1:1', '4:3', '3:4', '16:9', '9:16', '3:2', '2:3', '21:9'],
+        qualities: ['1K', '2K'],
+      },
+    },
+    {
       id: 'runninghub-seedance-2-0-global-video',
       name: 'Seedance 2.0 Global',
       generatorId: 'RunningHub',


### PR DESCRIPTION
## What changed

- Registered **Seedream V5 Pro** (`modelId: seedream-v5-pro`) as a new RunningHub image model in `src/types.ts`, with a 2000-character prompt limit (the API accepts 5–2000), 1K/2K qualities, and the same aspect-ratio set as the existing Seedream entry.
- Widened the `isSeedream5Pro` matcher in `server/generators/running-hub-generator.ts` to also recognize `seedream-v5-pro`, routing it through the existing Seedream payload branch.

## Why

RunningHub exposes Seedream 5.0 Pro as an official standard-model API under the `seedream-v5-pro` slug, with both `text-to-image` and `image-to-image` endpoints. The request shape matches the existing `dola-Seedream-5.0-pro` branch: explicit `width`/`height` (240–8192), `imageUrls` for reference images, `outputFormat`, and a `resolution` enum that overrides width×height when present — so the generator keeps omitting `resolution` and maps quality + aspect ratio to concrete pixel dimensions.

## Notes for reviewers

- No new endpoint-routing code was needed: the existing URL builder already produces `/openapi/v2/seedream-v5-pro/text-to-image` when no reference images are attached and `.../image-to-image` when they are, matching the API docs.
- The earlier `dola-Seedream-5.0-pro` model is left in place; this PR adds the official slug alongside it.
- `npx tsc --noEmit` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)