### PR TITLE
feat: add nano banana Pro model to RunningHub provider

### DIFF
--- a/server/generators/running-hub-generator.ts
+++ b/server/generators/running-hub-generator.ts
@@ -48,6 +48,14 @@ function isGrokImaginePro(modelId?: string, apiUrl?: string): boolean {
   return target.includes('rhart-imagine-image-quality');
 }
 
+// rhart-image-n-pro shares the default rhart payload shape but its
+// reference-image endpoint is `/edit` (imageUrls, max 10) instead of
+// `/image-to-image`.
+function isRhartImageNPro(modelId?: string, apiUrl?: string): boolean {
+  const target = `${modelId || ''} ${apiUrl || ''}`.toLowerCase();
+  return target.includes('rhart-image-n-pro');
+}
+
 // Seedream 5.0 Pro takes explicit width/height (240 - 8192). Its `resolution`
 // enum overrides width*height when present, so we only send width/height to
 // preserve the user's aspect-ratio choice.
@@ -164,9 +172,11 @@ export class RunningHubGenerator extends ImageGenerator {
     const isGrok = isGrokImaginePro(modelId, reqApiUrl);
     const isSeedream = isSeedream5Pro(modelId, reqApiUrl);
     const isWan = isWan27Pro(modelId, reqApiUrl);
-    // Qwen uses `/image-edit`, Grok Imagine Pro uses `/edit`, Wan 2.7 uses
-    // `/image-edit-pro`, the rhart model uses `/image-to-image`.
-    const refEndpointType = isQwen ? 'image-edit' : isGrok ? 'edit' : isWan ? 'image-edit-pro' : 'image-to-image';
+    const isNanoPro = isRhartImageNPro(modelId, reqApiUrl);
+    // Qwen uses `/image-edit`, Grok Imagine Pro and rhart-image-n-pro use
+    // `/edit`, Wan 2.7 uses `/image-edit-pro`, the rhart flash model uses
+    // `/image-to-image`.
+    const refEndpointType = isQwen ? 'image-edit' : (isGrok || isNanoPro) ? 'edit' : isWan ? 'image-edit-pro' : 'image-to-image';
     const endpointType = isTextToImage ? (isWan ? 'text-to-image-pro' : 'text-to-image') : refEndpointType;
 
     let actualSubmitUrl = reqApiUrl;

--- a/src/types.ts
+++ b/src/types.ts
@@ -527,6 +527,18 @@ export const PROVIDER_MODELS_MAP: Record<ProviderType, ModelConfig[]> = {
       },
     },
     {
+      id: 'runninghub-nano-banana-2-pro',
+      name: 'nano banana 2 Pro',
+      generatorId: 'RunningHub',
+      modelId: 'rhart-image-n-pro',
+      category: 'image',
+      promptLimit: { value: 20000, unit: 'characters' },
+      options: {
+        aspectRatios: ['1:1', '16:9', '9:16', '4:3', '3:4', '3:2', '2:3', '5:4', '4:5', '21:9', 'auto'],
+        qualities: ['1K', '2K', '4K'],
+      },
+    },
+    {
       id: 'runninghub-gpt-image-2',
       name: 'GPT Image 2',
       generatorId: 'RunningHub',

--- a/src/types.ts
+++ b/src/types.ts
@@ -527,8 +527,8 @@ export const PROVIDER_MODELS_MAP: Record<ProviderType, ModelConfig[]> = {
       },
     },
     {
-      id: 'runninghub-nano-banana-2-pro',
-      name: 'nano banana 2 Pro',
+      id: 'runninghub-nano-banana-pro',
+      name: 'nano banana Pro',
       generatorId: 'RunningHub',
       modelId: 'rhart-image-n-pro',
       category: 'image',


### PR DESCRIPTION
## What changed

- Registered **nano banana Pro** (`rhart-image-n-pro`) as a new image model under the RunningHub provider in `src/types.ts`, with the documented aspect-ratio enum (plus `auto`, since `aspectRatio` is optional and omitting it lets the API adapt automatically), 1K/2K/4K resolutions, and a 20,000-character prompt limit.
- Added an `isRhartImageNPro` matcher in `server/generators/running-hub-generator.ts` and routed the model's reference-image requests to the `/edit` endpoint (`imageUrls`, max 10) instead of `/image-to-image`.

## Why

The rhart-image-n-pro standard-model API shares the default rhart payload shape (prompt, lowercase `resolution`, optional `aspectRatio`, `imageUrls`), so no payload changes were needed — text-to-image already resolves to `/text-to-image` via the generic modelId-based URL construction. Only the edit endpoint name differs.

## Notes for reviewers

- Typecheck (`tsc --noEmit`) passes.
- The matcher checks for the `rhart-image-n-pro` substring, which does not collide with the existing `rhart-image-n-g31-flash` or `rhart-imagine-image-quality` matchers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
