### PR TITLE
feat: add nano banana 2 Lite model to Google AI and Vertex AI providers

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -258,6 +258,18 @@ export const PROVIDER_MODELS_MAP: Record<ProviderType, ModelConfig[]> = {
       },
     },
     {
+      id: 'google-nano-banana-2-lite',
+      name: 'nano banana 2 Lite',
+      generatorId: 'GoogleAI',
+      modelId: 'gemini-3.1-flash-lite-image',
+      category: 'image',
+      promptLimit: { value: 131072, unit: 'tokens' },
+      options: {
+        aspectRatios: ['1:1', '4:3', '3:4', '16:9', '9:16', '2:3', '3:2', '4:5', '5:4', '21:9'],
+        qualities: ['1K'],
+      },
+    },
+    {
       id: 'google-gemini-3.5-flash-text',
       name: 'Gemini 3.5 Flash',
       generatorId: 'GoogleAI',
@@ -409,6 +421,18 @@ export const PROVIDER_MODELS_MAP: Record<ProviderType, ModelConfig[]> = {
       options: {
         aspectRatios: ['1:1', '4:3', '3:4', '16:9', '9:16', '2:3', '3:2', '1:4', '4:1', '1:8', '8:1', '4:5', '5:4', '21:9', '9:21'],
         qualities: ['1K', '2K', '4K'],
+      },
+    },
+    {
+      id: 'vertex-nano-banana-2-lite',
+      name: 'nano banana 2 Lite',
+      generatorId: 'VertexAI',
+      modelId: 'gemini-3.1-flash-lite-image',
+      category: 'image',
+      promptLimit: { value: 131072, unit: 'tokens' },
+      options: {
+        aspectRatios: ['1:1', '4:3', '3:4', '16:9', '9:16', '2:3', '3:2', '4:5', '5:4', '21:9'],
+        qualities: ['1K'],
       },
     },
     {


### PR DESCRIPTION
## What changed

Adds the **nano banana 2 Lite** image model (`gemini-3.1-flash-lite-image`) to both the Google AI and Vertex AI provider model lists in `src/types.ts`, alongside the existing nano banana 2 entries.

## Why

Google released Nano Banana 2 Lite (June 30, 2026) as the fastest and most cost-efficient model in the Nano Banana family, available on both the Gemini API and Vertex AI.

## Notes for reviewers

- The model ID is GA with no `-preview` suffix, unlike nano banana 2 (`gemini-3.1-flash-image-preview`). The same ID is used on both providers.
- Per the [Gemini API image docs](https://ai.google.dev/gemini-api/docs/image-generation), the Lite model supports **1K resolution only**, so `qualities` is `['1K']`, and only ten aspect ratios (no extreme ratios like 1:8 or 9:21).
- Prompt limit is kept at 131,072 tokens to match the rest of the Gemini image family; Google doesn't publish a separate figure for the Lite variant.
- Docs describe it as text-to-image without search grounding; image-editing/reference-image support is not documented, so that path may warrant testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)