### PR TITLE
fix: truncate Wan 2.7 prompts to 2048-char API limit

### DIFF
--- a/server/generators/running-hub-generator.ts
+++ b/server/generators/running-hub-generator.ts
@@ -101,6 +101,9 @@ function isWan27Pro(modelId?: string, apiUrl?: string): boolean {
   return target.includes('wan-2.7');
 }
 
+// Wan 2.7 rejects prompts longer than 2048 characters (API error 1007).
+const WAN_MAX_PROMPT_LENGTH = 2048;
+
 export class RunningHubGenerator extends ImageGenerator {
   private apiKey: string;
   private submitUrl: string;
@@ -221,8 +224,13 @@ export class RunningHubGenerator extends ImageGenerator {
       }
     } else if (isSeedream || isWan) {
       const [width, height] = resolveSeedreamSize(aspectRatio, imageSize);
+      let wanPrompt = prompt;
+      if (isWan && prompt.length > WAN_MAX_PROMPT_LENGTH) {
+        console.log(`[RunningHubGenerator] Truncating Wan 2.7 prompt from ${prompt.length} to ${WAN_MAX_PROMPT_LENGTH} chars`);
+        wanPrompt = prompt.slice(0, WAN_MAX_PROMPT_LENGTH);
+      }
       payload = {
-        prompt,
+        prompt: wanPrompt,
         width,
         height,
       };


### PR DESCRIPTION
## What changed

The RunningHub Wan 2.7 endpoints reject prompts longer than 2048 characters with `Submit API error 1007`. The generator now clips the prompt to 2048 characters before submitting — Wan 2.7 only; Seedream and other RunningHub models are unaffected since the limit isn't documented for them. A server log line records the original and clipped lengths whenever truncation occurs.

## Why

A 2845-character prompt failed with:

```
Submit API error 1007: field 'prompt' length 2845 is greater than the maximum length 2048
```

## Notes for reviewers

Truncation is silent from the user's perspective (aside from the server log) — the tail of an over-long prompt is dropped from the generation. Failing fast with a clear error was the alternative; truncation was chosen so generations still succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)