### PR TITLE
Fix async UI consistency across project workflows

### DIFF
--- a/server/db/prisma-repository.ts
+++ b/server/db/prisma-repository.ts
@@ -80,6 +80,7 @@ export class PrismaRepository implements IRepository {
   updateProject(userId: string, projectId: string, updates: Partial<Project>) { return this.projects.updateProject(userId, projectId, updates); }
   deleteProject(userId: string, projectId: string) { return this.projects.deleteProject(userId, projectId); }
   deleteProjectJob(userId: string, projectId: string, jobId: string) { return this.projects.deleteProjectJob(userId, projectId, jobId); }
+  deleteProjectJobs(userId: string, projectId: string, jobIds: string[]) { return this.projects.deleteProjectJobs(userId, projectId, jobIds); }
   rewriteJobStorageKeys(userId: string, projectId: string, oldPrefix: string, newPrefix: string) {
     return this.projects.rewriteJobStorageKeys(userId, projectId, oldPrefix, newPrefix);
   }

--- a/server/db/project-repository.ts
+++ b/server/db/project-repository.ts
@@ -475,6 +475,16 @@ export class ProjectRepository {
     });
   }
 
+  async deleteProjectJobs(userId: string, projectId: string, jobIds: string[]): Promise<number> {
+    const ids = Array.from(new Set(jobIds.map((id) => id.trim()).filter(Boolean)));
+    if (ids.length === 0) return 0;
+
+    const result = await this.prisma.job.deleteMany({
+      where: { id: { in: ids }, projectId, userId, status: { not: 'processing' } },
+    });
+    return result.count;
+  }
+
   async addAlbumItem(userId: string, projectId: string, item: AlbumItem): Promise<void> {
     await this.assertOwnedProject(userId, projectId);
 

--- a/server/db/repository.ts
+++ b/server/db/repository.ts
@@ -57,6 +57,7 @@ export interface IRepository {
   updateProject(userId: string, projectId: string, updates: Partial<Project>): Promise<void>;
   deleteProject(userId: string, projectId: string): Promise<void>;
   deleteProjectJob(userId: string, projectId: string, jobId: string): Promise<void>;
+  deleteProjectJobs(userId: string, projectId: string, jobIds: string[]): Promise<number>;
   rewriteJobStorageKeys(userId: string, projectId: string, oldPrefix: string, newPrefix: string): Promise<void>;
 
   // === Album CRUD ===

--- a/server/routes/projects.ts
+++ b/server/routes/projects.ts
@@ -431,6 +431,34 @@ export function createProjectRouter(repository: IRepository, userRepository: Use
     }
   });
 
+  router.post('/api/projects/:id/jobs/delete-batch', authMiddleware, async (c) => {
+    try {
+      const user = c.get('user') as JwtPayload;
+      const projectId = c.req.param('id');
+      const body = await c.req.json().catch(() => ({}));
+      const rawJobIds: unknown[] = Array.isArray(body?.jobIds) ? body.jobIds : [];
+      const jobIds: string[] = Array.from(new Set(
+        rawJobIds
+          .filter((id): id is string => typeof id === 'string' && id.trim().length > 0)
+          .map((id) => id.trim()),
+      ));
+      if (!projectId || jobIds.length === 0) {
+        return c.json({ error: 'Project id and jobIds are required' }, 400);
+      }
+
+      const deleted = await repository.deleteProjectJobs(user.userId, projectId, jobIds);
+      projectEvents?.notifyProjectChanged({
+        userId: user.userId,
+        projectId,
+        reason: 'job.deleted',
+      });
+      return c.json({ success: true, deleted });
+    } catch (e) {
+      console.error('[POST /api/projects/:id/jobs/delete-batch]', e);
+      return c.json({ error: 'Failed to delete jobs' }, 500);
+    }
+  });
+
   router.get('/api/projects/:id/album', authMiddleware, async (c) => {
     try {
       const user = c.get('user') as JwtPayload;

--- a/src/api.ts
+++ b/src/api.ts
@@ -522,6 +522,15 @@ export async function deleteProjectJob(id: string, jobId: string): Promise<void>
   await handleResponse<{ success: boolean }>(res, 'Failed to delete job');
 }
 
+export async function deleteProjectJobs(id: string, jobIds: string[]): Promise<{ deleted: number }> {
+  const res = await apiFetch(`/api/projects/${id}/jobs/delete-batch`, {
+    method: 'POST',
+    headers: getHeaders(),
+    body: JSON.stringify({ jobIds }),
+  });
+  return handleResponse<{ success: boolean; deleted: number }>(res, 'Failed to delete jobs');
+}
+
 export async function fetchProjectAlbum(
   id: string,
   options: { page?: number; limit?: number; sort?: 'newest' | 'oldest'; aspectRatios?: string[] } = {},

--- a/src/components/Assistant/ApprovedToolsModal.tsx
+++ b/src/components/Assistant/ApprovedToolsModal.tsx
@@ -55,8 +55,6 @@ export function ApprovedToolsModal({ isOpen, conversationId, onClose }: Approved
     if (mode === 'always') next.add(toolName);
     else next.delete(toolName);
 
-    const previous = approved;
-    setApproved(next);
     setSavingTool(toolName);
     try {
       const result = await updateAssistantConversationApprovedTools(
@@ -65,7 +63,6 @@ export function ApprovedToolsModal({ isOpen, conversationId, onClose }: Approved
       );
       setApproved(new Set(result.tools));
     } catch (e: any) {
-      setApproved(previous);
       toast.error(e?.message ?? t('assistant.approvedTools.saveFailed', 'Failed to update tool approval'));
     } finally {
       setSavingTool(null);

--- a/src/components/ConfirmDialog.tsx
+++ b/src/components/ConfirmDialog.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { AlertCircle, X } from 'lucide-react';
+import React, { useState } from 'react';
+import { AlertCircle, Loader2, X } from 'lucide-react';
 import { cn } from '../lib/utils';
 
 interface ConfirmDialogProps {
@@ -9,7 +9,7 @@ interface ConfirmDialogProps {
   confirmLabel?: string;
   cancelLabel?: string;
   confirmDisabled?: boolean;
-  onConfirm: () => void;
+  onConfirm: () => void | Promise<void>;
   onCancel: () => void;
   variant?: 'danger' | 'primary';
 }
@@ -25,14 +25,29 @@ export function ConfirmDialog({
   onCancel,
   variant = 'primary',
 }: ConfirmDialogProps) {
+  const [isConfirming, setIsConfirming] = useState(false);
+  const isBusy = confirmDisabled || isConfirming;
+
   if (!isOpen) return null;
 
+  const handleConfirm = async () => {
+    setIsConfirming(true);
+    try {
+      await onConfirm();
+    } catch {
+      // The caller owns the user-facing error. Keeping this promise contained
+      // prevents an unhandled click-handler rejection while the dialog stays open.
+    } finally {
+      setIsConfirming(false);
+    }
+  };
+
   return (
-    <div className="fixed inset-0 z-[100] flex items-center justify-center p-4">
+    <div className="fixed inset-0 z-[100] flex items-center justify-center p-4" aria-busy={isBusy}>
       {/* Backdrop */}
       <div 
         className="absolute inset-0 bg-black/60 backdrop-blur-sm" 
-        onClick={onCancel}
+        onClick={isBusy ? undefined : onCancel}
       />
       
       {/* Dialog */}
@@ -55,7 +70,8 @@ export function ConfirmDialog({
           </div>
           <button 
             onClick={onCancel}
-            className="h-8 w-8 flex items-center justify-center rounded-lg text-neutral-400 hover:bg-neutral-100 dark:hover:bg-white/5 transition-colors"
+            disabled={isBusy}
+            className="h-8 w-8 flex items-center justify-center rounded-lg text-neutral-400 hover:bg-neutral-100 dark:hover:bg-white/5 transition-colors disabled:cursor-not-allowed disabled:opacity-50"
           >
             <X className="h-4 w-4" />
           </button>
@@ -64,18 +80,20 @@ export function ConfirmDialog({
         <div className="mt-6 flex justify-end gap-3">
           <button
             onClick={onCancel}
-            className="rounded-xl px-4 py-2 text-sm font-bold text-neutral-600 hover:bg-neutral-100 dark:text-neutral-300 dark:hover:bg-white/10 transition-colors"
+            disabled={isBusy}
+            className="rounded-xl px-4 py-2 text-sm font-bold text-neutral-600 hover:bg-neutral-100 dark:text-neutral-300 dark:hover:bg-white/10 transition-colors disabled:cursor-not-allowed disabled:opacity-50"
           >
             {cancelLabel}
           </button>
           <button
-            onClick={onConfirm}
-            disabled={confirmDisabled}
+            onClick={() => void handleConfirm()}
+            disabled={isBusy}
             className={cn(
               "rounded-xl px-4 py-2 text-sm font-bold text-white transition-all active:scale-95 disabled:cursor-not-allowed disabled:opacity-60",
               variant === 'danger' ? "bg-red-600 hover:bg-red-700" : "bg-indigo-600 hover:bg-indigo-700"
             )}
           >
+            {isBusy && <Loader2 className="h-4 w-4 animate-spin" />}
             {confirmLabel}
           </button>
         </div>

--- a/src/components/Home.tsx
+++ b/src/components/Home.tsx
@@ -88,8 +88,8 @@ export function Home() {
     setIsDeletingProject(true);
     try {
       await deleteProject(deleteTarget.id);
-      setDeleteTarget(null);
       await loadProjects();
+      setDeleteTarget(null);
     } catch (err) {
       console.error('Failed to delete project:', err);
     } finally {

--- a/src/components/LibraryEditor.tsx
+++ b/src/components/LibraryEditor.tsx
@@ -207,13 +207,14 @@ export function LibraryEditor({ library, onUpdate, onDelete }: Props) {
       for (const id of idsToDelete) {
         await apiDeleteLibraryItem(library.id, id);
       }
+      await loadItems();
       setSelectedItemIds(new Set());
       setLastSelectedIndex(null);
-      await loadItems();
+      setShowDeleteSelectedModal(false);
     } catch (e) {
       console.error('Failed to delete items:', e);
+      throw e;
     }
-    setShowDeleteSelectedModal(false);
   };
 
   const handleBatchTagSave = async (tagsToAdd: string[]) => {

--- a/src/components/ProjectViewer.tsx
+++ b/src/components/ProjectViewer.tsx
@@ -21,7 +21,7 @@ import {
   serializeAudioProjectConfig,
   truncatePromptToLimit,
 } from '../types';
-import { saveImage, saveVideo, saveAudio, fetchProviders, fetchProjectWorkflow, fetchProjectJobs, fetchProjectCompletedJobs, fetchProjectAlbum, fetchProjectJobConfiguration, updateProject as apiUpdateProject, startProjectJobs as apiStartProjectJobs, imageDisplayUrl as apiImageDisplayUrl, moveToTrash, moveToTrashBatch, renameAlbumItem as apiRenameAlbumItem, fetchLibraries, fetchLibrary, clearFailedQueueJobs, deleteProjectJob as apiDeleteProjectJob, createLibraryItem } from '../api';
+import { saveImage, saveVideo, saveAudio, fetchProviders, fetchProjectWorkflow, fetchProjectJobs, fetchProjectCompletedJobs, fetchProjectAlbum, fetchProjectJobConfiguration, updateProject as apiUpdateProject, startProjectJobs as apiStartProjectJobs, imageDisplayUrl as apiImageDisplayUrl, moveToTrash, moveToTrashBatch, renameAlbumItem as apiRenameAlbumItem, fetchLibraries, fetchLibrary, clearFailedQueueJobs, deleteProjectJobs as apiDeleteProjectJobs, createLibraryItem } from '../api';
 import { CheckCircle2, List, Grid, ChevronLeft, Plus, Loader2 } from 'lucide-react';
 import { toast } from 'sonner';
 import { countWorkflowCombinations, generateJobs } from '../lib/remixEngine';
@@ -237,6 +237,11 @@ export function ProjectViewer({ project, libraries, onUpdate: onUpdateProp, onDe
   const [albumItemsToDelete, setAlbumItemsToDelete] = useState<AlbumItem[] | null>(null);
   const [selectedCompletedIds, setSelectedCompletedIds] = useState<Set<string>>(new Set());
   const [isAddingDrafts, setIsAddingDrafts] = useState(false);
+  const [isStartingDraftBatch, setIsStartingDraftBatch] = useState(false);
+  const [startingDraftJobIds, setStartingDraftJobIds] = useState<Set<string>>(new Set());
+  const [isRetryingQueueBatch, setIsRetryingQueueBatch] = useState(false);
+  const [retryingQueueJobIds, setRetryingQueueJobIds] = useState<Set<string>>(new Set());
+  const [isTogglingArchive, setIsTogglingArchive] = useState(false);
   const [draftsProgress, setDraftsProgress] = useState<{ current: number; total: number; stage: 'composing' | 'saving' } | null>(null);
   const [promptLimitDialog, setPromptLimitDialog] = useState<PromptLimitDialogState | null>(null);
   const [liveLibraries, setLiveLibraries] = useState<Library[]>(libraries);
@@ -254,6 +259,11 @@ export function ProjectViewer({ project, libraries, onUpdate: onUpdateProp, onDe
     if (el) el.scrollTo({ top: 0, behavior: 'smooth' });
   }, []);
   const albumFetchTokenRef = useRef(0);
+  const jobsFetchTokenRef = useRef(0);
+  const isClearingFailedJobsRef = useRef(false);
+  const isStartingDraftJobsRef = useRef(false);
+  const isMutatingJobsRef = useRef(false);
+  const isDeletingAlbumItemsRef = useRef(false);
   const albumLoadedKeyRef = useRef<string | null>(null);
   const albumFetchedAtRef = useRef<number>(0);
   const prevAlbumProjectIdRef = useRef<string | null>(null);
@@ -263,6 +273,15 @@ export function ProjectViewer({ project, libraries, onUpdate: onUpdateProp, onDe
   const runProjectLiveRefreshRef = useRef<() => void>(() => {});
 
   useEffect(() => {
+    const jobsFetchToken = ++jobsFetchTokenRef.current;
+    isClearingFailedJobsRef.current = false;
+    isStartingDraftJobsRef.current = false;
+    isMutatingJobsRef.current = false;
+    isDeletingAlbumItemsRef.current = false;
+    setIsStartingDraftBatch(false);
+    setStartingDraftJobIds(new Set());
+    setIsRetryingQueueBatch(false);
+    setRetryingQueueJobIds(new Set());
     albumFetchTokenRef.current += 1;
     albumLoadedKeyRef.current = null;
     albumFetchedAtRef.current = 0;
@@ -297,12 +316,14 @@ export function ProjectViewer({ project, libraries, onUpdate: onUpdateProp, onDe
     setCompletedPage(1);
     Promise.all([
       fetchProjectWorkflow(project.id).then(w => setLocalProject(prev => ({ ...prev, workflow: w }))).catch(console.error),
-      fetchProjectJobs(project.id, { excludeStatus: ['completed'] }).then(j => setLocalJobs(j)).catch(console.error),
-      fetchProjectAlbum(project.id, { page: 1, limit: 5 }).then(res => {
+      fetchProjectJobs(project.id, { excludeStatus: ['completed'] }).then((jobs) => {
+        if (jobsFetchTokenRef.current === jobsFetchToken) setLocalJobs(jobs);
+      }).catch(console.error),
+      // Fetch metadata only. Album rows are loaded at their real page size the
+      // first time the Album tab is opened and then kept in memory across tabs.
+      fetchProjectAlbum(project.id, { page: 1, limit: 1 }).then(res => {
         if (albumLoadedKeyRef.current) return;
-        setLocalAlbum(res.items);
         setAlbumTotal(res.total);
-        setAlbumPages(res.pages);
         setAlbumTotalSize(res.totalSize);
         setAlbumAspectRatioCounts(res.aspectRatioCounts);
       }).catch(console.error),
@@ -332,7 +353,7 @@ export function ProjectViewer({ project, libraries, onUpdate: onUpdateProp, onDe
         sort: albumSort,
         aspectRatios: albumSelectedRatios.length > 0 ? albumSelectedRatios : undefined,
       });
-      if (albumFetchTokenRef.current !== signalToken) return;
+      if (albumFetchTokenRef.current !== signalToken || isDeletingAlbumItemsRef.current) return;
       setLocalAlbum(res.items);
       setAlbumTotal(res.total);
       setAlbumPages(res.pages);
@@ -633,6 +654,9 @@ export function ProjectViewer({ project, libraries, onUpdate: onUpdateProp, onDe
     try {
       const tab = activeTabRef.current;
       const query = liveQueryRef.current;
+      const jobsFetchToken = ++jobsFetchTokenRef.current;
+      const albumFetchToken = ++albumFetchTokenRef.current;
+      const completedFetchToken = ++completedFetchTokenRef.current;
       const [updatedJobs, updatedAlbumRes, updatedCompletedRes] = await Promise.all([
         fetchProjectJobs(localProject.id, { excludeStatus: ['completed'] }).catch(() => null),
         tab === 'album'
@@ -642,7 +666,12 @@ export function ProjectViewer({ project, libraries, onUpdate: onUpdateProp, onDe
               sort: query.albumSort,
               aspectRatios: query.albumSelectedRatios.length > 0 ? query.albumSelectedRatios : undefined,
             }).catch(() => null)
-          : fetchProjectAlbum(localProject.id, { page: 1, limit: 5 }).catch(() => null),
+          : fetchProjectAlbum(localProject.id, {
+              page: 1,
+              limit: 1,
+              sort: query.albumSort,
+              aspectRatios: query.albumSelectedRatios.length > 0 ? query.albumSelectedRatios : undefined,
+            }).catch(() => null),
         tab === 'completed'
           ? fetchProjectCompletedJobs(localProject.id, {
               page: query.completedPage,
@@ -652,25 +681,46 @@ export function ProjectViewer({ project, libraries, onUpdate: onUpdateProp, onDe
           : fetchProjectCompletedJobs(localProject.id, { page: 1, limit: 1 }).catch(() => null),
       ]);
 
-      if (updatedJobs && JSON.stringify(updatedJobs) !== JSON.stringify(localJobsRef.current)) {
-        setLocalJobs(updatedJobs);
+      if (
+        updatedJobs
+        && jobsFetchTokenRef.current === jobsFetchToken
+        && !isClearingFailedJobsRef.current
+        && !isStartingDraftJobsRef.current
+        && !isMutatingJobsRef.current
+      ) {
+        if (JSON.stringify(updatedJobs) !== JSON.stringify(localJobsRef.current)) {
+          setLocalJobs(updatedJobs);
+        }
       }
 
-      if (updatedAlbumRes) {
-        if (JSON.stringify(updatedAlbumRes.items) !== JSON.stringify(localAlbumRef.current)) {
-          setLocalAlbum(updatedAlbumRes.items);
-        }
+      if (
+        updatedAlbumRes
+        && albumFetchTokenRef.current === albumFetchToken
+        && !isDeletingAlbumItemsRef.current
+      ) {
         setAlbumTotal(updatedAlbumRes.total);
-        setAlbumPages(updatedAlbumRes.pages);
         setAlbumTotalSize(updatedAlbumRes.totalSize);
         setAlbumAspectRatioCounts(updatedAlbumRes.aspectRatioCounts);
         if (tab === 'album') {
+          if (JSON.stringify(updatedAlbumRes.items) !== JSON.stringify(localAlbumRef.current)) {
+            setLocalAlbum(updatedAlbumRes.items);
+          }
+          setAlbumPages(updatedAlbumRes.pages);
           albumLoadedKeyRef.current = query.albumQueryKey;
           albumFetchedAtRef.current = Date.now();
+        } else {
+          // Keep the cached rows intact while the user is on another tab. Mark
+          // them stale so returning to Album shows the cache immediately and
+          // revalidates it in the background.
+          albumFetchedAtRef.current = 0;
         }
       }
 
-      if (updatedCompletedRes) {
+      if (
+        updatedCompletedRes
+        && completedFetchTokenRef.current === completedFetchToken
+        && !isMutatingJobsRef.current
+      ) {
         if (tab === 'completed') {
           setCompletedJobs(updatedCompletedRes.items);
           completedLoadedKeyRef.current = query.completedQueryKey;
@@ -1488,44 +1538,113 @@ export function ProjectViewer({ project, libraries, onUpdate: onUpdateProp, onDe
 
   const toggleJobExpand = (jobId: string) => setExpandedJobId(prev => prev === jobId ? null : jobId);
 
-  const restoreAfterStartFailure = (previousJobs: Job[], error: unknown, label: string) => {
-    console.error(label, error);
-    toast.error(error instanceof Error
-      ? error.message
-      : t('projectViewer.toasts.startJobsFailed', { defaultValue: 'Failed to start jobs' }));
-    setLocalJobs(previousJobs);
-    void runProjectLiveRefresh();
+  const startDraftJobsAndOpenQueue = async (
+    request: { mode: 'allDrafts' } | { mode: 'selected'; jobIds: string[] },
+    expectedJobIds: string[],
+    errorLabel: string,
+  ) => {
+    isStartingDraftJobsRef.current = true;
+    try {
+      await apiStartProjectJobs(localProject.id, request);
+
+      // The start endpoint has committed the status transition and enqueued the
+      // work. Read it back before changing tabs so Queue never renders guessed
+      // client state.
+      ++jobsFetchTokenRef.current;
+      const confirmedJobs = await fetchProjectJobs(localProject.id, { excludeStatus: ['completed'] });
+      ++jobsFetchTokenRef.current;
+
+      const expectedJobIdSet = new Set(expectedJobIds);
+      const confirmedQueueJobIds = new Set(
+        confirmedJobs
+          .filter((job) => expectedJobIdSet.has(job.id) && ['pending', 'processing', 'failed'].includes(job.status))
+          .map((job) => job.id),
+      );
+
+      setLocalJobs(confirmedJobs);
+      setSelectedDraftIds((current) => {
+        const next = new Set(current);
+        for (const jobId of confirmedQueueJobIds) next.delete(jobId);
+        return next;
+      });
+
+      if (confirmedQueueJobIds.size !== expectedJobIdSet.size) {
+        toast.error(t('projectViewer.toasts.startedJobsNotVisible', {
+          defaultValue: 'Some submitted jobs are not visible in the queue yet.',
+        }));
+        return;
+      }
+
+      setActiveTab('queue');
+    } catch (error) {
+      console.error(errorLabel, error);
+      toast.error(error instanceof Error
+        ? error.message
+        : t('projectViewer.toasts.startJobsFailed', { defaultValue: 'Failed to start jobs' }));
+    } finally {
+      isStartingDraftJobsRef.current = false;
+    }
+  };
+
+  const runDraftJob = async (jobId: string) => {
+    const targetJob = localJobsRef.current.find((job) => job.id === jobId);
+    if (!targetJob || targetJob.status !== 'draft' || isStartingDraftJobsRef.current) return;
+
+    setStartingDraftJobIds((current) => new Set(current).add(jobId));
+    try {
+      await startDraftJobsAndOpenQueue(
+        { mode: 'selected', jobIds: [jobId] },
+        [jobId],
+        'Failed to run draft job:',
+      );
+    } finally {
+      setStartingDraftJobIds((current) => {
+        const next = new Set(current);
+        next.delete(jobId);
+        return next;
+      });
+    }
   };
 
   const runJob = async (jobId: string) => {
-    const previousJobs = localJobsRef.current;
-    const targetJob = previousJobs.find(j => j.id === jobId);
-    if (!targetJob || !['draft', 'failed', 'pending'].includes(targetJob.status)) return;
+    const targetJob = localJobsRef.current.find((job) => job.id === jobId);
+    if (!targetJob || !['failed', 'pending'].includes(targetJob.status) || isMutatingJobsRef.current) return;
 
-    const updatedJobs = previousJobs.map(j => j.id === jobId ? { ...j, status: 'pending' as const, error: undefined } : j);
-    setLocalJobs(updatedJobs);
-    setActiveTab('queue');
+    isMutatingJobsRef.current = true;
+    setRetryingQueueJobIds((current) => new Set(current).add(jobId));
     try {
-      const result = await apiStartProjectJobs(localProject.id, { mode: 'selected', jobIds: [jobId] });
-      if (result.started < 1) void runProjectLiveRefresh();
+      await apiStartProjectJobs(localProject.id, { mode: 'selected', jobIds: [jobId] });
+      ++jobsFetchTokenRef.current;
+      const confirmedJobs = await fetchProjectJobs(localProject.id, { excludeStatus: ['completed'] });
+      ++jobsFetchTokenRef.current;
+      setLocalJobs(confirmedJobs);
     } catch (e) {
-      restoreAfterStartFailure(previousJobs, e, 'Failed to run job:');
+      console.error('Failed to retry job:', e);
+      toast.error(e instanceof Error ? e.message : t('projectViewer.toasts.startJobsFailed'));
+    } finally {
+      isMutatingJobsRef.current = false;
+      setRetryingQueueJobIds((current) => {
+        const next = new Set(current);
+        next.delete(jobId);
+        return next;
+      });
     }
   };
 
   const runAllDrafts = async () => {
     const previousJobs = localJobsRef.current;
-    const draftCount = previousJobs.filter(j => j.status === 'draft').length;
-    if (draftCount === 0) return;
+    const draftJobIds = previousJobs.filter((job) => job.status === 'draft').map((job) => job.id);
+    if (draftJobIds.length === 0 || isStartingDraftJobsRef.current) return;
 
-    const updatedJobs = previousJobs.map(j => j.status === 'draft' ? { ...j, status: 'pending' as const, error: undefined } : j);
-    setLocalJobs(updatedJobs);
-    setActiveTab('queue');
+    setIsStartingDraftBatch(true);
     try {
-      const result = await apiStartProjectJobs(localProject.id, { mode: 'allDrafts' });
-      if (result.started < draftCount) void runProjectLiveRefresh();
-    } catch (e) {
-      restoreAfterStartFailure(previousJobs, e, 'Failed to run all drafts:');
+      await startDraftJobsAndOpenQueue(
+        { mode: 'allDrafts' },
+        draftJobIds,
+        'Failed to run all drafts:',
+      );
+    } finally {
+      setIsStartingDraftBatch(false);
     }
   };
 
@@ -1535,47 +1654,95 @@ export function ProjectViewer({ project, libraries, onUpdate: onUpdateProp, onDe
     const jobIds = previousJobs
       .filter(j => previousSelectedDraftIds.has(j.id) && j.status === 'draft')
       .map(j => j.id);
-    if (jobIds.length === 0) return;
+    if (jobIds.length === 0 || isStartingDraftJobsRef.current) return;
 
-    const startJobIds = new Set(jobIds);
-    const updatedJobs = previousJobs.map(j => startJobIds.has(j.id) ? { ...j, status: 'pending' as const, error: undefined } : j);
-    setLocalJobs(updatedJobs);
-    setSelectedDraftIds(new Set());
-    setActiveTab('queue');
+    setIsStartingDraftBatch(true);
     try {
-      const result = await apiStartProjectJobs(localProject.id, { mode: 'selected', jobIds });
-      if (result.started < jobIds.length) void runProjectLiveRefresh();
-    } catch (e) {
-      setSelectedDraftIds(previousSelectedDraftIds);
-      restoreAfterStartFailure(previousJobs, e, 'Failed to run selected drafts:');
+      await startDraftJobsAndOpenQueue(
+        { mode: 'selected', jobIds },
+        jobIds,
+        'Failed to run selected drafts:',
+      );
+    } finally {
+      setIsStartingDraftBatch(false);
+    }
+  };
+
+  const reconcileJobsAfterMutation = async (includeCompleted = false) => {
+    ++jobsFetchTokenRef.current;
+    if (includeCompleted) ++completedFetchTokenRef.current;
+
+    const [confirmedJobs, confirmedCompleted] = await Promise.all([
+      fetchProjectJobs(localProject.id, { excludeStatus: ['completed'] }),
+      includeCompleted
+        ? fetchProjectCompletedJobs(localProject.id, {
+            page: completedPage,
+            limit: completedPageSize === 'all' ? 999999 : completedPageSize,
+            sort: completedSort,
+          })
+        : Promise.resolve(null),
+    ]);
+
+    ++jobsFetchTokenRef.current;
+    setLocalJobs(confirmedJobs);
+
+    if (confirmedCompleted) {
+      ++completedFetchTokenRef.current;
+      let completedResult = confirmedCompleted;
+      if (completedPage > completedResult.pages) {
+        completedResult = await fetchProjectCompletedJobs(localProject.id, {
+          page: completedResult.pages,
+          limit: completedPageSize === 'all' ? 999999 : completedPageSize,
+          sort: completedSort,
+        });
+        setCompletedPage(completedResult.pages);
+      }
+      setCompletedJobs(completedResult.items);
+      setCompletedTotal(completedResult.total);
+      setCompletedPages(completedResult.pages);
+      completedLoadedKeyRef.current = null;
+      completedFetchedAtRef.current = Date.now();
+    }
+  };
+
+  const deleteJobsAndReconcile = async (jobIds: string[], includeCompleted = false) => {
+    if (jobIds.length === 0) return;
+    if (isMutatingJobsRef.current) {
+      const error = new Error(t('projectViewer.toasts.jobMutationInProgress', {
+        defaultValue: 'Another job update is still in progress.',
+      }));
+      toast.error(error.message);
+      throw error;
+    }
+    isMutatingJobsRef.current = true;
+    try {
+      await apiDeleteProjectJobs(localProject.id, jobIds);
+      await reconcileJobsAfterMutation(includeCompleted);
+    } catch (error) {
+      console.error('Failed to delete jobs:', error);
+      toast.error(error instanceof Error
+        ? error.message
+        : t('projectViewer.toasts.deleteJobsFailed', { defaultValue: 'Failed to delete jobs' }));
+      throw error;
+    } finally {
+      isMutatingJobsRef.current = false;
     }
   };
 
   const deleteJob = async (jobId: string) => {
-    const isCompletedJob = completedJobs.some(j => j.id === jobId);
-    const updatedJobs = localJobs.filter(j => j.id !== jobId);
-    setLocalJobs(updatedJobs);
-    if (isCompletedJob) {
-      setCompletedJobs(prev => prev.filter(j => j.id !== jobId));
-      setCompletedTotal(prev => Math.max(0, prev - 1));
-      await apiDeleteProjectJob(localProject.id, jobId);
-    } else {
-      await apiUpdateProject(localProject.id, { jobs: updatedJobs });
-    }
+    await deleteJobsAndReconcile([jobId], completedJobs.some((job) => job.id === jobId));
   };
 
   const deleteSelectedDrafts = async () => {
-    const updatedJobs = localJobs.filter(j => !selectedDraftIds.has(j.id));
-    setLocalJobs(updatedJobs);
+    const jobIds = Array.from(selectedDraftIds);
+    await deleteJobsAndReconcile(jobIds);
     setSelectedDraftIds(new Set());
-    await apiUpdateProject(localProject.id, { jobs: updatedJobs });
   };
 
   const deleteAllDrafts = async () => {
-    const updatedJobs = localJobs.filter(j => j.status !== 'draft');
-    setLocalJobs(updatedJobs);
+    const jobIds = localJobsRef.current.filter((job) => job.status === 'draft').map((job) => job.id);
+    await deleteJobsAndReconcile(jobIds);
     setSelectedDraftIds(new Set());
-    await apiUpdateProject(localProject.id, { jobs: updatedJobs });
   };
 
   const toggleDraftSelection = (jobId: string, isShiftPressed: boolean, scopeIds: string[]) => {
@@ -1635,31 +1802,33 @@ export function ProjectViewer({ project, libraries, onUpdate: onUpdateProp, onDe
   };
 
   const retrySelectedQueue = async () => {
-    const previousJobs = localJobsRef.current;
-    const previousSelectedQueueIds = new Set(selectedQueueIds);
-    const jobIds = previousJobs
-      .filter(j => previousSelectedQueueIds.has(j.id) && (j.status === 'failed' || j.status === 'pending'))
+    const jobIds = localJobsRef.current
+      .filter(j => selectedQueueIds.has(j.id) && (j.status === 'failed' || j.status === 'pending'))
       .map(j => j.id);
-    if (jobIds.length === 0) return;
+    if (jobIds.length === 0 || isMutatingJobsRef.current) return;
 
-    const updatedJobs = previousJobs.map(j => previousSelectedQueueIds.has(j.id) && (j.status === 'failed' || j.status === 'pending') ? { ...j, status: 'pending' as const, error: undefined } : j);
-    setLocalJobs(updatedJobs);
-    setSelectedQueueIds(new Set());
-    setActiveTab('queue');
+    isMutatingJobsRef.current = true;
+    setIsRetryingQueueBatch(true);
     try {
-      const result = await apiStartProjectJobs(localProject.id, { mode: 'selected', jobIds });
-      if (result.started < jobIds.length) void runProjectLiveRefresh();
+      await apiStartProjectJobs(localProject.id, { mode: 'selected', jobIds });
+      ++jobsFetchTokenRef.current;
+      const confirmedJobs = await fetchProjectJobs(localProject.id, { excludeStatus: ['completed'] });
+      ++jobsFetchTokenRef.current;
+      setLocalJobs(confirmedJobs);
+      setSelectedQueueIds(new Set());
     } catch (e) {
-      setSelectedQueueIds(previousSelectedQueueIds);
-      restoreAfterStartFailure(previousJobs, e, 'Failed to retry selected:');
+      console.error('Failed to retry selected jobs:', e);
+      toast.error(e instanceof Error ? e.message : t('projectViewer.toasts.startJobsFailed'));
+    } finally {
+      isMutatingJobsRef.current = false;
+      setIsRetryingQueueBatch(false);
     }
   };
 
   const deleteSelectedQueue = async () => {
-    const updatedJobs = localJobs.filter(j => !selectedQueueIds.has(j.id));
-    setLocalJobs(updatedJobs);
+    const jobIds = Array.from(selectedQueueIds);
+    await deleteJobsAndReconcile(jobIds);
     setSelectedQueueIds(new Set());
-    await apiUpdateProject(localProject.id, { jobs: updatedJobs });
   };
 
   const clearAllFailed = async () => {
@@ -1669,12 +1838,39 @@ export function ProjectViewer({ project, libraries, onUpdate: onUpdateProp, onDe
     // stale relative to in-flight jobs (it used to wipe taskId on
     // 'processing' rows and strand them forever). The server endpoint deletes
     // only failed rows and re-enqueues remaining pending jobs atomically.
-    setSelectedQueueIds(new Set());
-    setLocalJobs(prev => prev.filter(j => j.status !== 'failed'));
+    if (!localJobsRef.current.some((job) => job.status === 'failed')) return;
+
+    isClearingFailedJobsRef.current = true;
+    let deleteCompleted = false;
     try {
       await clearFailedQueueJobs({ projectId: localProject.id });
+      deleteCompleted = true;
+
+      // Do not change the visible list until both the deletion and the
+      // authoritative follow-up read have completed. This intentionally favors
+      // correctness over an optimistic response for a destructive bulk action.
+      ++jobsFetchTokenRef.current;
+      const updatedJobs = await fetchProjectJobs(localProject.id, { excludeStatus: ['completed'] });
+
+      // Make this confirmed read authoritative over any concurrent live refresh.
+      ++jobsFetchTokenRef.current;
+      setLocalJobs(updatedJobs);
+      setSelectedQueueIds(new Set());
     } catch (e) {
-      console.error("Failed to clear failed jobs:", e);
+      if (deleteCompleted) {
+        console.error('Failed to refresh jobs after clearing failed jobs:', e);
+        toast.error(t('projectViewer.toasts.refreshAfterClearFailedJobsFailed', {
+          defaultValue: 'Failed jobs were cleared, but the list could not be refreshed.',
+        }));
+      } else {
+        console.error('Failed to clear failed jobs:', e);
+        toast.error(t('projectViewer.toasts.clearFailedJobsFailed', {
+          defaultValue: 'Failed to clear failed jobs. Please try again.',
+        }));
+      }
+      throw e;
+    } finally {
+      isClearingFailedJobsRef.current = false;
     }
   };
 
@@ -1709,11 +1905,8 @@ export function ProjectViewer({ project, libraries, onUpdate: onUpdateProp, onDe
   const deleteSelectedCompleted = async () => {
     const idsToDelete = Array.from(selectedCompletedIds);
     if (idsToDelete.length === 0) return;
-    const remainingCompleted = completedJobs.filter(j => !selectedCompletedIds.has(j.id));
-    setCompletedJobs(remainingCompleted);
-    setCompletedTotal((prev) => Math.max(0, prev - idsToDelete.length));
+    await deleteJobsAndReconcile(idsToDelete, true);
     setSelectedCompletedIds(new Set());
-    await Promise.all(idsToDelete.map((jobId) => apiDeleteProjectJob(localProject.id, jobId)));
   };
 
   const toggleAlbumSelection = (id: string, isShiftPressed: boolean, scopeIds?: string[]) => {
@@ -1751,39 +1944,52 @@ export function ProjectViewer({ project, libraries, onUpdate: onUpdateProp, onDe
   };
 
   const deleteAlbumItems = async (items: AlbumItem[]) => {
+    if (items.length === 0) return;
+
+    isDeletingAlbumItemsRef.current = true;
     try {
       const itemIds = items.map(i => i.id);
       if (itemIds.length === 1) await moveToTrash(localProject.id, itemIds[0]); else await moveToTrashBatch(localProject.id, itemIds);
-      const itemIdsSet = new Set(itemIds);
-      const updatedAlbum = localAlbum.filter(item => !itemIdsSet.has(item.id));
-      const nextAlbumTotal = Math.max(0, albumTotal - itemIds.length);
-      setLocalAlbum(updatedAlbum);
-      setAlbumTotal(nextAlbumTotal);
-      setAlbumPages(Math.max(1, Math.ceil(nextAlbumTotal / (albumPageSize === 'all' ? Math.max(nextAlbumTotal, 1) : albumPageSize))));
-      const removedSize = items.reduce((acc, item) => acc + (item.size || 0), 0);
-      setAlbumTotalSize((prev) => Math.max(0, prev - removedSize));
-      const removedAspectRatios = items.reduce<Record<string, number>>((acc, item) => {
-        const ratio = item.aspectRatio?.trim();
-        if (ratio) acc[ratio] = (acc[ratio] || 0) + 1;
-        return acc;
-      }, {});
-      if (Object.keys(removedAspectRatios).length > 0) {
-        setAlbumAspectRatioCounts((prev) => (
-          prev
-            .map(({ ratio, count }) => ({ ratio, count: count - (removedAspectRatios[ratio] || 0) }))
-            .filter(({ count }) => count > 0)
-        ));
+
+      const query = liveQueryRef.current;
+      const limit = query.albumPageSize === 'all' ? 999999 : query.albumPageSize;
+      const fetchAlbumPage = (page: number) => fetchProjectAlbum(localProject.id, {
+        page,
+        limit,
+        sort: query.albumSort,
+        aspectRatios: query.albumSelectedRatios.length > 0 ? query.albumSelectedRatios : undefined,
+      });
+
+      // Invalidate reads started before the delete, then wait for a confirmed
+      // server snapshot before changing anything visible in the Album UI.
+      ++albumFetchTokenRef.current;
+      let updatedAlbumRes = await fetchAlbumPage(query.albumPage);
+      if (query.albumPage > updatedAlbumRes.pages) {
+        updatedAlbumRes = await fetchAlbumPage(updatedAlbumRes.pages);
+        updateAlbumParams({ page: updatedAlbumRes.pages });
       }
+
+      ++albumFetchTokenRef.current;
+      setLocalAlbum(updatedAlbumRes.items);
+      setAlbumTotal(updatedAlbumRes.total);
+      setAlbumPages(updatedAlbumRes.pages);
+      setAlbumTotalSize(updatedAlbumRes.totalSize);
+      setAlbumAspectRatioCounts(updatedAlbumRes.aspectRatioCounts);
+      albumLoadedKeyRef.current = query.albumPage === updatedAlbumRes.page ? query.albumQueryKey : null;
+      albumFetchedAtRef.current = Date.now();
+
+      const itemIdsSet = new Set(itemIds);
       setSelectedAlbumIds(prev => {
         const next = new Set(prev);
         itemIdsSet.forEach(id => next.delete(id));
         return next;
       });
-      return true;
     } catch (e: any) {
       console.error('Failed to move items to trash:', e);
       toast.error(`Failed to move items to trash: ${e.message}`);
-      return false;
+      throw e;
+    } finally {
+      isDeletingAlbumItemsRef.current = false;
     }
   };
 
@@ -1828,9 +2034,10 @@ export function ProjectViewer({ project, libraries, onUpdate: onUpdateProp, onDe
   const handleToggleArchive = async () => {
     const nextStatus: 'active' | 'archived' = isArchived ? 'active' : 'archived';
     const updated = { ...localProject, status: nextStatus };
-    setLocalProject(updated);
+    setIsTogglingArchive(true);
     try {
       await apiUpdateProject(localProject.id, { status: nextStatus });
+      setLocalProject(updated);
       toast.success(
         nextStatus === 'archived'
           ? t('projectViewer.toasts.archived', { name: localProject.name })
@@ -1839,8 +2046,9 @@ export function ProjectViewer({ project, libraries, onUpdate: onUpdateProp, onDe
       onUpdate(updated);
     } catch (e) {
       console.error('Failed to toggle archive status:', e);
-      setLocalProject(localProject);
       toast.error(t('projectViewer.toasts.archiveFailed'));
+    } finally {
+      setIsTogglingArchive(false);
     }
   };
 
@@ -1923,6 +2131,7 @@ export function ProjectViewer({ project, libraries, onUpdate: onUpdateProp, onDe
         onStartAssistantChat={handleStartAssistantChat}
         onShowDeleteProject={() => setShowDeleteProjectModal(true)}
         onToggleArchive={handleToggleArchive}
+        isTogglingArchive={isTogglingArchive}
         isArchived={isArchived}
         onAddWorkflowItem={addWorkflowItem}
         onDragStart={handleDragStart}
@@ -2001,8 +2210,9 @@ export function ProjectViewer({ project, libraries, onUpdate: onUpdateProp, onDe
               draftJobs={draftJobs} selectedDraftIds={selectedDraftIds} toggleSelectAllDrafts={toggleSelectAllDrafts}
               setShowDeleteSelectedModal={setShowDeleteSelectedModal} runSelectedDrafts={runSelectedDrafts}
               setShowDeleteAllDraftsModal={setShowDeleteAllDraftsModal} runAllDrafts={runAllDrafts}
+              isStartingDraftBatch={isStartingDraftBatch} startingDraftJobIds={startingDraftJobIds}
               expandedJobId={expandedJobId} toggleJobExpand={toggleJobExpand} toggleDraftSelection={toggleDraftSelection}
-              getProviderName={getProviderName} getModelName={getModelName} runJob={runJob}
+              getProviderName={getProviderName} getModelName={getModelName} runJob={runDraftJob}
               setJobToDeleteId={setJobToDeleteId} setLightboxData={setLightboxData}
               albumItems={albumItems}
               onSwitchToAlbum={() => setActiveTab('album')}
@@ -2020,6 +2230,7 @@ export function ProjectViewer({ project, libraries, onUpdate: onUpdateProp, onDe
             <QueueTab
               queueJobs={queueJobs} selectedQueueIds={selectedQueueIds} toggleSelectAllQueue={toggleSelectAllQueue}
               toggleQueueSelection={toggleQueueSelection} retrySelectedQueue={retrySelectedQueue} deleteSelectedQueue={() => setShowDeleteQueueSelectedModal(true)}
+              isRetryingQueueBatch={isRetryingQueueBatch} retryingQueueJobIds={retryingQueueJobIds}
               clearAllFailed={() => setShowClearAllFailedModal(true)} expandedJobId={expandedJobId} toggleJobExpand={toggleJobExpand}
               getProviderName={getProviderName} getModelName={getModelName} runJob={runJob}
               setJobToDeleteId={setJobToDeleteId} setLightboxData={setLightboxData}
@@ -2135,7 +2346,7 @@ export function ProjectViewer({ project, libraries, onUpdate: onUpdateProp, onDe
       <ConfirmModal isOpen={showDeleteSelectedModal} onClose={() => setShowDeleteSelectedModal(false)} onConfirm={deleteSelectedDrafts} title={t('projectViewer.confirm.deleteSelectedDrafts.title')} message={t('projectViewer.confirm.deleteSelectedDrafts.message', { count: selectedDraftIds.size })} confirmText={t('projectViewer.confirm.deleteSelectedDrafts.confirm')} type="danger" />
       <ConfirmModal isOpen={showDeleteAllDraftsModal} onClose={() => setShowDeleteAllDraftsModal(false)} onConfirm={deleteAllDrafts} title={t('projectViewer.confirm.deleteAllDrafts.title')} message={t('projectViewer.confirm.deleteAllDrafts.message', { count: draftJobs.length })} confirmText={t('projectViewer.confirm.deleteAllDrafts.confirm')} type="danger" />
       <ConfirmModal isOpen={showDeleteProjectModal} onClose={() => setShowDeleteProjectModal(false)} onConfirm={onDelete} title={t('projectViewer.confirm.deleteProject.title')} message={t('projectViewer.confirm.deleteProject.message', { name: localProject.name })} confirmText={t('projectViewer.confirm.deleteProject.confirm')} type="danger" />
-      <ConfirmModal isOpen={jobToDeleteId !== null} onClose={() => setJobToDeleteId(null)} onConfirm={() => { if (jobToDeleteId) { deleteJob(jobToDeleteId); setJobToDeleteId(null); } }} title={t('projectViewer.confirm.deleteJob.title')} message={t('projectViewer.confirm.deleteJob.message')} confirmText={t('projectViewer.confirm.deleteJob.confirm')} type="danger" />
+      <ConfirmModal isOpen={jobToDeleteId !== null} onClose={() => setJobToDeleteId(null)} onConfirm={async () => { if (jobToDeleteId) { await deleteJob(jobToDeleteId); setJobToDeleteId(null); } }} title={t('projectViewer.confirm.deleteJob.title')} message={t('projectViewer.confirm.deleteJob.message')} confirmText={t('projectViewer.confirm.deleteJob.confirm')} type="danger" />
       <LibrarySelectionModal
         isOpen={showLibrarySelector || changingLibraryItemId !== null || savingLibraryItemId !== null}
         onClose={() => {
@@ -2237,8 +2448,7 @@ export function ProjectViewer({ project, libraries, onUpdate: onUpdateProp, onDe
         onClose={() => { setShowDeleteAlbumModal(false); setAlbumItemsToDelete(null); }}
         onConfirm={async () => {
           if (albumItemsToDelete) {
-            const didDelete = await deleteAlbumItems(albumItemsToDelete);
-            if (!didDelete) return;
+            await deleteAlbumItems(albumItemsToDelete);
             updateLightboxAfterAlbumDelete(albumItemsToDelete);
             setShowDeleteAlbumModal(false);
             setAlbumItemsToDelete(null);

--- a/src/components/ProjectViewer/DraftsTab.tsx
+++ b/src/components/ProjectViewer/DraftsTab.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { Trash2, Play, Plus } from 'lucide-react';
+import { Trash2, Play, Plus, Loader2 } from 'lucide-react';
 import { Job, AlbumItem, ProjectType } from '../../types';
 import { imageDisplayUrl } from '../../api';
 import { SelectionToolbar } from './SelectionToolbar';
@@ -15,6 +15,8 @@ interface DraftsTabProps {
   runSelectedDrafts: () => void;
   setShowDeleteAllDraftsModal: (show: boolean) => void;
   runAllDrafts: () => void;
+  isStartingDraftBatch: boolean;
+  startingDraftJobIds: Set<string>;
   expandedJobId: string | null;
   toggleJobExpand: (id: string) => void;
   toggleDraftSelection: (id: string, isShiftPressed: boolean, scopeIds: string[]) => void;
@@ -38,6 +40,8 @@ export function DraftsTab({
   runSelectedDrafts,
   setShowDeleteAllDraftsModal,
   runAllDrafts,
+  isStartingDraftBatch,
+  startingDraftJobIds,
   expandedJobId,
   toggleJobExpand,
   toggleDraftSelection,
@@ -119,21 +123,24 @@ export function DraftsTab({
   );
 
   const isEmpty = draftJobs.length === 0;
+  const isStartingDrafts = isStartingDraftBatch || startingDraftJobIds.size > 0;
 
   return (
     <section className={`animate-in fade-in slide-in-from-bottom-4 duration-500 ${isEmpty ? 'h-full' : ''}`}>
       <div className={`flex flex-col gap-0 ${isEmpty ? 'h-full' : ''}`}>
         {draftJobs.length > 0 && (
-          <SelectionToolbar
-            totalCount={draftJobs.length}
-            selectedCount={selectedDraftIds.size}
-            onToggleSelectAll={toggleSelectAllDrafts}
-            mobileSingleLine
-            mobileActionsRight
-            rightActions={
-              <>
+          <>
+            <SelectionToolbar
+              totalCount={draftJobs.length}
+              selectedCount={selectedDraftIds.size}
+              onToggleSelectAll={toggleSelectAllDrafts}
+              mobileSingleLine
+              mobileActionsRight
+              rightActions={
+                <>
                 <button
                   onClick={selectedDraftIds.size > 0 ? () => setShowDeleteSelectedModal(true) : () => setShowDeleteAllDraftsModal(true)}
+                  disabled={isStartingDrafts}
                   className="flex items-center justify-center gap-1.5 min-h-8 min-w-8 px-2 sm:px-3 py-1.5 bg-red-500/10 hover:bg-red-500/20 text-red-500 text-[9px] font-black uppercase tracking-widest rounded-lg border border-red-500/20 transition-all"
                   title={selectedDraftIds.size > 0 ? t('projectViewer.common.deleteSelected') : t('projectViewer.drafts.deleteAllDrafts')}
                   aria-label={selectedDraftIds.size > 0 ? t('projectViewer.common.deleteSelected') : t('projectViewer.drafts.deleteAllDrafts')}
@@ -145,18 +152,31 @@ export function DraftsTab({
                 </button>
                 <button
                   onClick={selectedDraftIds.size > 0 ? runSelectedDrafts : runAllDrafts}
+                  disabled={isStartingDrafts}
                   title={selectedDraftIds.size > 0 ? t('projectViewer.drafts.startSelected') : t('projectViewer.drafts.startAllNow')}
                   aria-label={selectedDraftIds.size > 0 ? t('projectViewer.drafts.startSelected') : t('projectViewer.drafts.startAllNow')}
-                  className="flex items-center justify-center gap-1.5 min-h-8 min-w-8 px-2 sm:px-3 py-1.5 bg-blue-500/10 hover:bg-blue-500/20 text-blue-500 text-[9px] font-black uppercase tracking-widest rounded-lg border border-blue-500/20 transition-all"
+                  className="flex items-center justify-center gap-1.5 min-h-8 min-w-8 px-2 sm:px-3 py-1.5 bg-blue-500/10 hover:bg-blue-500/20 text-blue-500 text-[9px] font-black uppercase tracking-widest rounded-lg border border-blue-500/20 transition-all disabled:cursor-wait disabled:opacity-70"
                 >
-                  <Play className="w-3 h-3 fill-current" />
+                  {isStartingDrafts
+                    ? <Loader2 className="w-3 h-3 animate-spin" />
+                    : <Play className="w-3 h-3 fill-current" />}
                   <span className="hidden sm:inline">
-                    {selectedDraftIds.size > 0 ? t('projectViewer.drafts.startSelected') : t('projectViewer.drafts.startAllNow')}
+                    {isStartingDrafts
+                      ? t('projectViewer.drafts.starting', { defaultValue: 'Starting…' })
+                      : selectedDraftIds.size > 0
+                        ? t('projectViewer.drafts.startSelected')
+                        : t('projectViewer.drafts.startAllNow')}
                   </span>
                 </button>
-              </>
-            }
-          />
+                </>
+              }
+            />
+            {isStartingDrafts && (
+              <div className="h-1 overflow-hidden bg-blue-500/10" role="progressbar" aria-label={t('projectViewer.drafts.starting', { defaultValue: 'Starting jobs' })}>
+                <div className="h-full w-1/3 animate-draft-start-progress rounded-full bg-blue-500" />
+              </div>
+            )}
+          </>
         )}
         <div className={`space-y-0 ${isEmpty ? 'h-full' : ''}`}>
             {(() => {
@@ -164,6 +184,7 @@ export function DraftsTab({
               return draftJobs.map(task => {
               const isExpanded = expandedJobId === task.id;
               const isSelected = selectedDraftIds.has(task.id);
+              const isStartingThisJob = startingDraftJobIds.has(task.id);
               return (
                 <JobListItem
                   key={task.id}
@@ -214,10 +235,13 @@ export function DraftsTab({
                     <>
                       <button 
                         onClick={(e) => { e.stopPropagation(); runJob(task.id); }}
-                        className="p-1.5 text-blue-500 hover:bg-blue-500/10 rounded-lg transition-colors border border-transparent hover:border-blue-500/20"
+                        disabled={isStartingDrafts}
+                        className="p-1.5 text-blue-500 hover:bg-blue-500/10 rounded-lg transition-colors border border-transparent hover:border-blue-500/20 disabled:cursor-wait disabled:opacity-70"
                         title={t('projectViewer.drafts.runJob')}
                       >
-                        <Play className="w-3.5 h-3.5 fill-current" />
+                        {isStartingThisJob
+                          ? <Loader2 className="w-3.5 h-3.5 animate-spin" />
+                          : <Play className="w-3.5 h-3.5 fill-current" />}
                       </button>
                       <button 
                         onClick={(e) => { e.stopPropagation(); setJobToDeleteId(task.id); }}

--- a/src/components/ProjectViewer/QueueTab.tsx
+++ b/src/components/ProjectViewer/QueueTab.tsx
@@ -14,6 +14,8 @@ interface QueueTabProps {
   toggleSelectAllQueue: () => void;
   toggleQueueSelection: (id: string, isShiftPressed: boolean, scopeIds: string[]) => void;
   retrySelectedQueue: () => void;
+  isRetryingQueueBatch: boolean;
+  retryingQueueJobIds: Set<string>;
   deleteSelectedQueue: () => void;
   clearAllFailed: () => void;
   expandedJobId: string | null;
@@ -32,6 +34,8 @@ export function QueueTab({
   toggleSelectAllQueue,
   toggleQueueSelection,
   retrySelectedQueue,
+  isRetryingQueueBatch,
+  retryingQueueJobIds,
   deleteSelectedQueue,
   clearAllFailed,
   expandedJobId,
@@ -44,22 +48,25 @@ export function QueueTab({
   onReuse,
 }: QueueTabProps) {
   const { t } = useTranslation();
+  const isRetryingQueue = isRetryingQueueBatch || retryingQueueJobIds.size > 0;
   return (
     <section className="animate-in fade-in slide-in-from-bottom-4 duration-500">
       <div className="flex flex-col gap-0">
         {/* Queue Toolbar */}
         {queueJobs.length > 0 && (
-          <SelectionToolbar
-            totalCount={queueJobs.length}
-            selectedCount={selectedQueueIds.size}
-            onToggleSelectAll={toggleSelectAllQueue}
-            mobileSingleLine
-            mobileActionsRight
-            rightActions={
-              <>
+          <>
+            <SelectionToolbar
+              totalCount={queueJobs.length}
+              selectedCount={selectedQueueIds.size}
+              onToggleSelectAll={toggleSelectAllQueue}
+              mobileSingleLine
+              mobileActionsRight
+              rightActions={
+                <>
                 {selectedQueueIds.size > 0 && (
                   <button
                     onClick={deleteSelectedQueue}
+                    disabled={isRetryingQueue}
                     title={t('projectViewer.common.delete')}
                     aria-label={t('projectViewer.common.delete')}
                     className="flex items-center justify-center gap-1.5 min-h-8 min-w-8 px-2 sm:px-3 py-1.5 bg-red-500/10 hover:bg-red-500/20 text-red-500 text-[9px] font-black uppercase tracking-widest rounded-lg border border-red-500/20 transition-all"
@@ -71,17 +78,25 @@ export function QueueTab({
                 {queueJobs.some(j => selectedQueueIds.has(j.id) && j.status === 'failed') && (
                   <button
                     onClick={retrySelectedQueue}
+                    disabled={isRetryingQueue}
                     title={t('projectViewer.queue.retry')}
                     aria-label={t('projectViewer.queue.retry')}
                     className="flex items-center justify-center gap-1.5 min-h-8 min-w-8 px-2 sm:px-3 py-1.5 bg-blue-500/10 hover:bg-blue-500/20 text-blue-500 text-[9px] font-black uppercase tracking-widest rounded-lg border border-blue-500/20 transition-all"
                   >
-                    <Play className="w-3 h-3 fill-current" />
-                    <span className="hidden sm:inline">{t('projectViewer.queue.retry')}</span>
+                    {isRetryingQueueBatch
+                      ? <Loader2 className="w-3 h-3 animate-spin" />
+                      : <Play className="w-3 h-3 fill-current" />}
+                    <span className="hidden sm:inline">
+                      {isRetryingQueueBatch
+                        ? t('projectViewer.queue.retrying')
+                        : t('projectViewer.queue.retry')}
+                    </span>
                   </button>
                 )}
                 {queueJobs.some(j => j.status === 'failed') && (
                   <button
                     onClick={clearAllFailed}
+                    disabled={isRetryingQueue}
                     title={t('projectViewer.queue.clearAllFailed')}
                     aria-label={t('projectViewer.queue.clearAllFailed')}
                     className="flex items-center justify-center gap-1.5 min-h-8 min-w-8 px-2 sm:px-3 py-1.5 bg-red-500/10 hover:bg-red-500/20 text-red-400 text-[9px] font-black uppercase tracking-widest rounded-lg border border-red-500/20 transition-all"
@@ -90,9 +105,15 @@ export function QueueTab({
                     <span>{t('projectViewer.queue.clearAllFailed')}</span>
                   </button>
                 )}
-              </>
-            }
-          />
+                </>
+              }
+            />
+            {isRetryingQueue && (
+              <div className="h-1 overflow-hidden bg-blue-500/10" role="progressbar" aria-label={t('projectViewer.queue.retrying')}>
+                <div className="h-full w-1/3 animate-draft-start-progress rounded-full bg-blue-500" />
+              </div>
+            )}
+          </>
         )}
 
         {/* Active Jobs */}
@@ -102,6 +123,7 @@ export function QueueTab({
               return queueJobs.map(task => {
               const isExpanded = expandedJobId === task.id;
               const isSelected = selectedQueueIds.has(task.id);
+              const isRetryingThisJob = retryingQueueJobIds.has(task.id);
               return (
                 <JobListItem
                   key={task.id}
@@ -157,10 +179,13 @@ export function QueueTab({
                       {task.status === 'failed' && (
                         <button 
                           onClick={(e) => { e.stopPropagation(); runJob(task.id); }}
-                          className="p-1.5 text-blue-500 hover:bg-blue-500/10 rounded-lg transition-colors"
+                          disabled={isRetryingQueue}
+                          className="p-1.5 text-blue-500 hover:bg-blue-500/10 rounded-lg transition-colors disabled:cursor-wait disabled:opacity-70"
                           title={t('projectViewer.queue.retryJob')}
                         >
-                          <Play className="w-3.5 h-3.5 fill-current" />
+                          {isRetryingThisJob
+                            ? <Loader2 className="w-3.5 h-3.5 animate-spin" />
+                            : <Play className="w-3.5 h-3.5 fill-current" />}
                         </button>
                       )}
                       <button 

--- a/src/components/ProjectViewer/WorkflowPanel.tsx
+++ b/src/components/ProjectViewer/WorkflowPanel.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
-import { Archive, ArchiveRestore, Copy, Eraser, HardDrive, Hash, ImageIcon, Library as LibraryIcon, Maximize2, Minimize2, MoreVertical, Settings, Stars, Trash2, Type, Video as VideoIcon, Volume2, X } from 'lucide-react';
+import { Archive, ArchiveRestore, Copy, Eraser, HardDrive, Hash, ImageIcon, Library as LibraryIcon, Loader2, Maximize2, Minimize2, MoreVertical, Settings, Stars, Trash2, Type, Video as VideoIcon, Volume2, X } from 'lucide-react';
 import { Library, Project, Provider, WorkflowItem as WorkflowItemType, ProviderType, PROVIDER_MODELS_MAP, resolveCustomModels } from '../../types';
 import { WorkflowItem } from './WorkflowItem';
 import { SettingsPanel } from './SettingsPanel';
@@ -32,7 +32,8 @@ interface WorkflowPanelProps {
   onNavigateToDuplicate: () => void;
   onStartAssistantChat: () => void;
   onShowDeleteProject: () => void;
-  onToggleArchive: () => void;
+  onToggleArchive: () => Promise<void>;
+  isTogglingArchive: boolean;
   isArchived: boolean;
   onAddWorkflowItem: (type: 'text' | 'image' | 'video' | 'audio' | 'library') => void;
   onDragStart: (e: React.DragEvent, index: number) => void;
@@ -88,6 +89,7 @@ export function WorkflowPanel({
   onStartAssistantChat,
   onShowDeleteProject,
   onToggleArchive,
+  isTogglingArchive,
   isArchived,
   onAddWorkflowItem,
   onDragStart,
@@ -295,10 +297,18 @@ export function WorkflowPanel({
                   </button>
 
                   <button
-                    onClick={() => closeMenuAndRun(onToggleArchive)}
+                    onClick={async () => {
+                      await onToggleArchive();
+                      setIsActionMenuOpen(false);
+                    }}
+                    disabled={isTogglingArchive}
                     className={`${menuButtonBaseClass} text-amber-600/90 dark:text-amber-400/90 hover:text-amber-700 dark:hover:text-amber-300 hover:bg-amber-500/10`}
                   >
-                    {isArchived ? <ArchiveRestore className="w-3.5 h-3.5" /> : <Archive className="w-3.5 h-3.5" />}
+                    {isTogglingArchive
+                      ? <Loader2 className="w-3.5 h-3.5 animate-spin" />
+                      : isArchived
+                        ? <ArchiveRestore className="w-3.5 h-3.5" />
+                        : <Archive className="w-3.5 h-3.5" />}
                     {t(isArchived ? 'projectViewer.main.unarchiveProject' : 'projectViewer.main.archiveProject')}
                   </button>
 

--- a/src/index.css
+++ b/src/index.css
@@ -11,6 +11,7 @@
   --animate-spin-slow: spin-slow 4s linear infinite;
   --animate-material-spinner: material-spinner-spin 1.4s linear infinite;
   --animate-material-dash: material-spinner-dash 1.4s ease-in-out infinite;
+  --animate-draft-start-progress: draft-start-progress 1.2s ease-in-out infinite;
 
   /* Slideshow transition effects (re-triggered per image via React key) */
   --animate-slideshow-fade: slideshow-fade 1.05s ease both;
@@ -79,6 +80,11 @@
       stroke-dasharray: 90, 150;
       stroke-dashoffset: -124;
     }
+  }
+
+  @keyframes draft-start-progress {
+    from { transform: translateX(-110%); }
+    to { transform: translateX(310%); }
   }
 }
 

--- a/src/locales/en/project-viewer.json
+++ b/src/locales/en/project-viewer.json
@@ -48,7 +48,11 @@
       "unarchived": "Restored \"{{name}}\"",
       "archiveFailed": "Failed to change archive status. Please try again.",
       "savedToLibrary": "Saved to library",
-      "saveToLibraryFailed": "Failed to save to library"
+      "saveToLibraryFailed": "Failed to save to library",
+      "startJobsFailed": "Failed to start jobs. Please try again.",
+      "startedJobsNotVisible": "Some submitted jobs are not visible in the queue yet.",
+      "deleteJobsFailed": "Failed to delete jobs. Please try again.",
+      "jobMutationInProgress": "Another job update is still in progress."
     },
     "errors": {
       "missingWorkflowInfo_one": "Missing information in {{count}} workflow item.",
@@ -76,11 +80,13 @@
       "openAlbum": "Open Album",
       "startSelected": "Start Selected",
       "startAllNow": "Start All Now",
+      "starting": "Starting…",
       "deleteAllDrafts": "Delete All Drafts",
       "runJob": "Run Job"
     },
     "queue": {
       "retry": "Retry",
+      "retrying": "Retrying…",
       "clearAllFailed": "Clear All Failed",
       "running": "Running",
       "queued": "Queued",

--- a/src/locales/fr/project-viewer.json
+++ b/src/locales/fr/project-viewer.json
@@ -48,7 +48,11 @@
       "unarchived": "« {{name}} » restauré",
       "archiveFailed": "Échec du changement de statut d'archive. Veuillez réessayer.",
       "savedToLibrary": "Enregistré dans la bibliothèque",
-      "saveToLibraryFailed": "Échec de l'enregistrement dans la bibliothèque"
+      "saveToLibraryFailed": "Échec de l'enregistrement dans la bibliothèque",
+      "startJobsFailed": "Impossible de démarrer les tâches. Réessayez.",
+      "startedJobsNotVisible": "Certaines tâches envoyées ne sont pas encore visibles dans la file.",
+      "deleteJobsFailed": "Impossible de supprimer les tâches. Réessayez.",
+      "jobMutationInProgress": "Une autre mise à jour de tâche est toujours en cours."
     },
     "errors": {
       "missingWorkflowInfo_one": "Informations manquantes dans {{count}} élément du workflow.",
@@ -76,11 +80,13 @@
       "openAlbum": "Ouvrir l'album",
       "startSelected": "Lancer la sélection",
       "startAllNow": "Tout lancer maintenant",
+      "starting": "Démarrage…",
       "deleteAllDrafts": "Supprimer tous les brouillons",
       "runJob": "Exécuter la tâche"
     },
     "queue": {
       "retry": "Réessayer",
+      "retrying": "Nouvelle tentative…",
       "clearAllFailed": "Effacer tous les échecs",
       "running": "En cours",
       "queued": "En file",

--- a/src/locales/ja/project-viewer.json
+++ b/src/locales/ja/project-viewer.json
@@ -48,7 +48,11 @@
       "unarchived": "「{{name}}」を復元しました",
       "archiveFailed": "アーカイブ状態の変更に失敗しました。もう一度お試しください。",
       "savedToLibrary": "ライブラリに保存しました",
-      "saveToLibraryFailed": "ライブラリへの保存に失敗しました"
+      "saveToLibraryFailed": "ライブラリへの保存に失敗しました",
+      "startJobsFailed": "ジョブを開始できませんでした。もう一度お試しください。",
+      "startedJobsNotVisible": "送信した一部のジョブがまだキューに表示されていません。",
+      "deleteJobsFailed": "ジョブを削除できませんでした。もう一度お試しください。",
+      "jobMutationInProgress": "別のジョブ更新がまだ進行中です。"
     },
     "errors": {
       "missingWorkflowInfo_one": "{{count}} 件のワークフロー項目に情報がありません。",
@@ -76,11 +80,13 @@
       "openAlbum": "アルバムを開く",
       "startSelected": "選択を開始",
       "startAllNow": "すべて今すぐ開始",
+      "starting": "送信中…",
       "deleteAllDrafts": "すべての下書きを削除",
       "runJob": "ジョブを実行"
     },
     "queue": {
       "retry": "再試行",
+      "retrying": "再試行中…",
       "clearAllFailed": "失敗をすべてクリア",
       "running": "実行中",
       "queued": "待機中",

--- a/src/locales/ko/project-viewer.json
+++ b/src/locales/ko/project-viewer.json
@@ -48,7 +48,11 @@
       "unarchived": "\"{{name}}\" 복원됨",
       "archiveFailed": "보관 상태를 변경하지 못했습니다. 다시 시도하세요.",
       "savedToLibrary": "라이브러리에 저장했습니다",
-      "saveToLibraryFailed": "라이브러리에 저장하지 못했습니다"
+      "saveToLibraryFailed": "라이브러리에 저장하지 못했습니다",
+      "startJobsFailed": "작업을 시작하지 못했습니다. 다시 시도해 주세요.",
+      "startedJobsNotVisible": "제출된 일부 작업이 아직 대기열에 표시되지 않습니다.",
+      "deleteJobsFailed": "작업을 삭제하지 못했습니다. 다시 시도해 주세요.",
+      "jobMutationInProgress": "다른 작업 업데이트가 아직 진행 중입니다."
     },
     "errors": {
       "missingWorkflowInfo_one": "{{count}}개의 워크플로 항목에 정보가 없습니다.",
@@ -76,11 +80,13 @@
       "openAlbum": "앨범 열기",
       "startSelected": "선택 항목 시작",
       "startAllNow": "지금 모두 시작",
+      "starting": "제출 중…",
       "deleteAllDrafts": "모든 초안 삭제",
       "runJob": "작업 실행"
     },
     "queue": {
       "retry": "재시도",
+      "retrying": "재시도 중…",
       "clearAllFailed": "실패 항목 모두 지우기",
       "running": "실행 중",
       "queued": "대기 중",

--- a/src/locales/zh-CN/project-viewer.json
+++ b/src/locales/zh-CN/project-viewer.json
@@ -48,7 +48,11 @@
       "unarchived": "已恢复 “{{name}}”",
       "archiveFailed": "更改归档状态失败，请重试。",
       "savedToLibrary": "已保存到资料库",
-      "saveToLibraryFailed": "保存到资料库失败"
+      "saveToLibraryFailed": "保存到资料库失败",
+      "startJobsFailed": "启动任务失败，请重试。",
+      "startedJobsNotVisible": "部分已提交任务尚未出现在队列中。",
+      "deleteJobsFailed": "删除任务失败，请重试。",
+      "jobMutationInProgress": "另一个任务操作仍在进行中。"
     },
     "errors": {
       "missingWorkflowInfo_one": "{{count}} 个工作流项目缺少信息。",
@@ -76,11 +80,13 @@
       "openAlbum": "打开相册",
       "startSelected": "开始所选",
       "startAllNow": "立即全部开始",
+      "starting": "提交中…",
       "deleteAllDrafts": "删除所有草稿",
       "runJob": "运行任务"
     },
     "queue": {
       "retry": "重试",
+      "retrying": "重试中…",
       "clearAllFailed": "清除所有失败项",
       "running": "运行中",
       "queued": "排队中",

--- a/src/locales/zh-TW/project-viewer.json
+++ b/src/locales/zh-TW/project-viewer.json
@@ -48,7 +48,11 @@
       "unarchived": "已還原「{{name}}」",
       "archiveFailed": "變更封存狀態失敗，請再試一次。",
       "savedToLibrary": "已儲存到資料庫",
-      "saveToLibraryFailed": "儲存到資料庫失敗"
+      "saveToLibraryFailed": "儲存到資料庫失敗",
+      "startJobsFailed": "啟動任務失敗，請重試。",
+      "startedJobsNotVisible": "部分已提交任務尚未出現在佇列中。",
+      "deleteJobsFailed": "刪除任務失敗，請重試。",
+      "jobMutationInProgress": "另一個任務操作仍在進行中。"
     },
     "errors": {
       "missingWorkflowInfo_one": "{{count}} 個工作流程項目缺少資訊。",
@@ -76,11 +80,13 @@
       "openAlbum": "開啟相簿",
       "startSelected": "開始所選",
       "startAllNow": "立即全部開始",
+      "starting": "提交中…",
       "deleteAllDrafts": "刪除所有草稿",
       "runJob": "執行任務"
     },
     "queue": {
       "retry": "重試",
+      "retrying": "重試中…",
       "clearAllFailed": "清除所有失敗項",
       "running": "執行中",
       "queued": "排隊中",

--- a/src/pages/CampaignBatchActions.tsx
+++ b/src/pages/CampaignBatchActions.tsx
@@ -290,9 +290,9 @@ export function CampaignBatchActions() {
         await deletePost(postId);
         ok++;
       }
+      await loadData(true, false);
       toast.success(`Deleted ${ok} post${ok === 1 ? '' : 's'}`);
       setDeleteOpen(false);
-      await loadData(true, false);
     } catch (error: any) {
       toast.error(error?.message || 'Failed to delete posts');
     } finally {

--- a/src/pages/CampaignDetail.tsx
+++ b/src/pages/CampaignDetail.tsx
@@ -218,6 +218,7 @@ export function CampaignDetail() {
   const [quickSavingId, setQuickSavingId] = useState<string | null>(null);
   const [sendingPostId, setSendingPostId] = useState<string | null>(null);
   const [deletePostTarget, setDeletePostTarget] = useState<CampaignPost | null>(null);
+  const [deletingPost, setDeletingPost] = useState(false);
   const [deleteCampaignOpen, setDeleteCampaignOpen] = useState(false);
   const [deletingCampaign, setDeletingCampaign] = useState(false);
   const [aiPostId, setAiPostId] = useState<string | null>(null);
@@ -547,13 +548,16 @@ export function CampaignDetail() {
 
   const confirmDeletePost = async () => {
     if (!deletePostTarget) return;
+    setDeletingPost(true);
     try {
       await deletePost(deletePostTarget.id);
+      await loadPosts(true);
       toast.success('Post deleted');
       setDeletePostTarget(null);
-      await loadPosts(true);
     } catch (error: any) {
       toast.error(error?.message || 'Failed to delete post');
+    } finally {
+      setDeletingPost(false);
     }
   };
 
@@ -1171,8 +1175,11 @@ export function CampaignDetail() {
               <p className="mt-4 line-clamp-3 border-l-2 pl-3 text-sm italic text-neutral-500">"{deletePostTarget.textContent}"</p>
             )}
             <div className="mt-6 flex justify-end gap-3">
-              <button className="rounded-lg px-4 py-2 text-sm font-bold text-neutral-600 hover:bg-neutral-100 dark:text-neutral-300 dark:hover:bg-white/10" onClick={() => setDeletePostTarget(null)}>Cancel</button>
-              <button className="rounded-lg bg-red-600 px-4 py-2 text-sm font-bold text-white hover:bg-red-700" onClick={() => void confirmDeletePost()}>Delete Post</button>
+              <button className="rounded-lg px-4 py-2 text-sm font-bold text-neutral-600 hover:bg-neutral-100 disabled:cursor-not-allowed disabled:opacity-50 dark:text-neutral-300 dark:hover:bg-white/10" onClick={() => setDeletePostTarget(null)} disabled={deletingPost}>Cancel</button>
+              <button className="inline-flex items-center gap-2 rounded-lg bg-red-600 px-4 py-2 text-sm font-bold text-white hover:bg-red-700 disabled:cursor-wait disabled:opacity-70" onClick={() => void confirmDeletePost()} disabled={deletingPost}>
+                {deletingPost && <Loader2 className="h-4 w-4 animate-spin" />}
+                {deletingPost ? 'Deleting…' : 'Delete Post'}
+              </button>
             </div>
           </div>
         </div>

--- a/src/pages/McpConnections.tsx
+++ b/src/pages/McpConnections.tsx
@@ -128,15 +128,17 @@ export function McpConnections({ embedded = false }: McpConnectionsProps) {
     if (!revokeTarget) return;
     setIsRevoking(true);
     try {
+      let successMessage: string;
       if (revokeTarget.type === 'client') {
         await revokeOAuthClient(revokeTarget.clientId);
-        toast.success(t('mcpConnections.toasts.clientRevoked'));
+        successMessage = t('mcpConnections.toasts.clientRevoked');
       } else {
         await revokePersonalAccessToken(revokeTarget.id);
-        toast.success(t('mcpConnections.toasts.tokenRevoked'));
+        successMessage = t('mcpConnections.toasts.tokenRevoked');
       }
-      setRevokeTarget(null);
       await load();
+      toast.success(successMessage);
+      setRevokeTarget(null);
     } catch {
       toast.error(t('mcpConnections.toasts.revokeFailed'));
     } finally {

--- a/src/pages/PostForm.tsx
+++ b/src/pages/PostForm.tsx
@@ -115,6 +115,7 @@ export function PostForm() {
   const [newFiles, setNewFiles] = useState<File[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [isSaving, setIsSaving] = useState(false);
+  const [isReorderingMedia, setIsReorderingMedia] = useState(false);
   const [isDragging, setIsDragging] = useState(false);
   const [mediaToRemove, setMediaToRemove] = useState<string | null>(null);
   const [draggedReorderIndex, setDraggedReorderIndex] = useState<number | null>(null);
@@ -207,6 +208,7 @@ export function PostForm() {
   const handleMediaDrop = async (event: React.DragEvent, dropIndex: number) => {
     event.preventDefault();
     event.stopPropagation();
+    if (isReorderingMedia) return;
     const fromIndex = draggedReorderIndex;
     setDraggedReorderIndex(null);
     setDragOverReorderIndex(null);
@@ -231,20 +233,26 @@ export function PostForm() {
       .filter((slot): slot is Extract<Slot, { kind: 'new' }> => slot.kind === 'new')
       .map((slot) => slot.file);
 
+    const movedExistingOnly = fromIndex < visibleMediaCount || dropIndex < visibleMediaCount;
+    if (movedExistingOnly && postId && nextVisibleExisting.length > 0) {
+      setIsReorderingMedia(true);
+      try {
+        const res = await reorderPostMedia(postId, nextVisibleExisting.map((m) => m.id));
+        const removed = existingMedia.filter((media) => removedMediaIds.has(media.id));
+        setExistingMedia([...(res.media as PostMedia[]), ...removed]);
+        setNewFiles(nextNewFiles);
+      } catch (err: any) {
+        toast.error(err?.message || 'Failed to reorder media');
+        await loadData();
+      } finally {
+        setIsReorderingMedia(false);
+      }
+      return;
+    }
+
     const removed = existingMedia.filter((media) => removedMediaIds.has(media.id));
     setExistingMedia([...nextVisibleExisting, ...removed]);
     setNewFiles(nextNewFiles);
-
-    const movedExistingOnly = fromIndex < visibleMediaCount || dropIndex < visibleMediaCount;
-    if (movedExistingOnly && postId && nextVisibleExisting.length > 0) {
-      try {
-        const res = await reorderPostMedia(postId, nextVisibleExisting.map((m) => m.id));
-        setExistingMedia([...(res.media as PostMedia[]), ...removed]);
-      } catch (err: any) {
-        toast.error(err?.message || 'Failed to reorder media');
-        void loadData();
-      }
-    }
   };
 
   const handleSave = async () => {
@@ -338,6 +346,12 @@ export function PostForm() {
                   <div className="flex items-center justify-between gap-3">
                     <label className="font-semibold text-neutral-950 dark:text-white">Media</label>
                     <div className="flex items-center gap-3">
+                      {isReorderingMedia && (
+                        <span className="inline-flex items-center gap-1.5 text-xs font-bold text-indigo-500">
+                          <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                          Saving order…
+                        </span>
+                      )}
                       <span className="text-xs font-bold text-neutral-400">{totalMediaCount}/4</span>
                       <button
                         type="button"
@@ -376,7 +390,7 @@ export function PostForm() {
                         return (
                           <div
                             key={media.id}
-                            draggable
+                            draggable={!isReorderingMedia}
                             onDragStart={(e) => handleMediaDragStart(e, combinedIndex)}
                             onDragOver={(e) => handleMediaDragOver(e, combinedIndex)}
                             onDrop={(e) => handleMediaDrop(e, combinedIndex)}
@@ -413,7 +427,7 @@ export function PostForm() {
                         return (
                           <div
                             key={`${file.name}-${index}`}
-                            draggable
+                            draggable={!isReorderingMedia}
                             onDragStart={(e) => handleMediaDragStart(e, combinedIndex)}
                             onDragOver={(e) => handleMediaDragOver(e, combinedIndex)}
                             onDrop={(e) => handleMediaDrop(e, combinedIndex)}

--- a/src/pages/Projects.tsx
+++ b/src/pages/Projects.tsx
@@ -116,9 +116,9 @@ export function Projects() {
     setTogglingId(deleteTarget.id);
     try {
       await deleteProject(deleteTarget.id);
+      await loadProjects();
       toast.success(t('projects.deleteSuccess', { name: deleteTarget.name }));
       setDeleteTarget(null);
-      await loadProjects();
     } catch (e) {
       console.error(e);
       toast.error(t('projects.deleteFailed'));

--- a/src/pages/Providers.tsx
+++ b/src/pages/Providers.tsx
@@ -55,8 +55,8 @@ export function Providers() {
     setIsDeleting(true);
     try {
       await deleteProvider(deleteTarget.id);
-      setDeleteTarget(null);
       await load();
+      setDeleteTarget(null);
     } catch {
       setError(t('providers.errors.delete'));
     } finally {


### PR DESCRIPTION
## What changed

- Wait for destructive job and album mutations to commit, then reconcile from authoritative server data before updating the UI.
- Add a server-side atomic batch job deletion endpoint.
- Prevent stale WebSocket responses from restoring deleted or outdated rows.
- Keep Album rows cached in memory across Project Viewer tab switches and remove the five-item preview overwrite.
- Show progress while starting drafts and only navigate to Queue after submitted jobs are confirmed there.
- Add pending states for queue retries, project archive changes, media ordering, approval changes, and confirmation dialogs.
- Align project, provider, library, campaign, post, and MCP deletion flows so dialogs close after mutation and refresh work completes.

## Why

Several flows updated local React state optimistically before the database mutation or follow-up server read had completed. Concurrent polling and WebSocket refreshes could then reintroduce stale rows, causing deleted tasks to briefly return and Draft/Queue navigation to get ahead of persisted state.

## Impact

Destructive and state-transitioning operations now favor confirmed server state over fake immediacy. Users see a spinner or progress indicator while work is pending, Album tab switches reuse cached rows, and server events reconcile into the same guarded state without visual rollback.

## Validation

- npm run lint
- npm run build
- npm run i18n:check
- git diff --check origin/main...HEAD