### PR TITLE
Fix album lightbox deletion refresh

### DIFF
--- a/src/components/ProjectViewer/ImageLightbox.tsx
+++ b/src/components/ProjectViewer/ImageLightbox.tsx
@@ -476,8 +476,8 @@ export function ImageLightbox({ images, startIndex, onClose, onDelete, onIndexCh
         />
       )}
       <img
-        key={slideshowOn && transition !== 'none' ? `${boundedIndex}-${transition}` : undefined}
-        src={images[boundedIndex]}
+        key={`${currentSrc}-${slideshowOn && transition !== 'none' ? transition : 'static'}`}
+        src={currentSrc}
         alt={t('projectViewer.imageLightbox.previewAlt', { index: boundedIndex + 1 })}
         className={`${imageSizeClass} object-contain select-none ${prevSrc ? 'relative' : ''} ${slideshowOn ? TRANSITION_CLASS[transition] : ''}`}
         onClick={(e) => e.stopPropagation()}


### PR DESCRIPTION
## What changed

- Remount the lightbox image element whenever the active image source changes.
- Render the active `currentSrc` directly instead of re-reading the image array in the JSX.

## Why

After deleting the image currently shown in the Album lightbox, the parent image list was updated correctly, but the lightbox reused the same `<img>` DOM node when the next image occupied the same index. That could leave the deleted image visible even though the Album grid had already removed it.

## Impact

After a successful Album deletion, the lightbox immediately displays the next valid image (or closes when the deleted image was the last one) and no longer retains the deleted bitmap.

## Validation

- `npm run lint`
- `npm run build`
- `git diff --check`
