### PR TITLE
Fix Album cache regressions

### DIFF
--- a/src/components/ProjectViewer.tsx
+++ b/src/components/ProjectViewer.tsx
@@ -135,6 +135,7 @@ export function ProjectViewer({ project, libraries, onUpdate: onUpdateProp, onDe
   const [localProject, setLocalProject] = useState<Project>(project);
   const [localJobs, setLocalJobs] = useState<Job[]>((project.jobs || []).filter(j => j.status !== 'completed'));
   const [localAlbum, setLocalAlbum] = useState<AlbumItem[]>(project.album || []);
+  const [albumPreviewItems, setAlbumPreviewItems] = useState<AlbumItem[]>(() => (project.album || []).slice(0, 5));
   const [albumTotal, setAlbumTotal] = useState<number>(0);
   const [albumPages, setAlbumPages] = useState<number>(1);
   const [albumTotalSize, setAlbumTotalSize] = useState<number>(0);
@@ -293,6 +294,7 @@ export function ProjectViewer({ project, libraries, onUpdate: onUpdateProp, onDe
     setIsLoadingAlbum(true);
     setIsLoadingCompleted(true);
     setLocalAlbum([]);
+    setAlbumPreviewItems([]);
     setAlbumTotal(0);
     setAlbumPages(1);
     setAlbumTotalSize(0);
@@ -319,9 +321,12 @@ export function ProjectViewer({ project, libraries, onUpdate: onUpdateProp, onDe
       fetchProjectJobs(project.id, { excludeStatus: ['completed'] }).then((jobs) => {
         if (jobsFetchTokenRef.current === jobsFetchToken) setLocalJobs(jobs);
       }).catch(console.error),
-      // Fetch metadata only. Album rows are loaded at their real page size the
-      // first time the Album tab is opened and then kept in memory across tabs.
-      fetchProjectAlbum(project.id, { page: 1, limit: 1 }).then(res => {
+      // Keep a small, independent newest-items cache for the Draft canvas.
+      // Album rows themselves are still loaded at their real page size only
+      // when the Album tab is opened.
+      fetchProjectAlbum(project.id, { page: 1, limit: 5, sort: 'newest' }).then(res => {
+        if (prevAlbumProjectIdRef.current !== project.id) return;
+        setAlbumPreviewItems(res.items);
         if (albumLoadedKeyRef.current) return;
         setAlbumTotal(res.total);
         setAlbumTotalSize(res.totalSize);
@@ -359,6 +364,9 @@ export function ProjectViewer({ project, libraries, onUpdate: onUpdateProp, onDe
       setAlbumPages(res.pages);
       setAlbumTotalSize(res.totalSize);
       setAlbumAspectRatioCounts(res.aspectRatioCounts);
+      if (albumPage === 1 && albumSort === 'newest' && albumSelectedRatios.length === 0) {
+        setAlbumPreviewItems(res.items.slice(0, 5));
+      }
       albumLoadedKeyRef.current = albumQueryKey;
       albumFetchedAtRef.current = Date.now();
     } catch (e) {
@@ -668,9 +676,8 @@ export function ProjectViewer({ project, libraries, onUpdate: onUpdateProp, onDe
             }).catch(() => null)
           : fetchProjectAlbum(localProject.id, {
               page: 1,
-              limit: 1,
-              sort: query.albumSort,
-              aspectRatios: query.albumSelectedRatios.length > 0 ? query.albumSelectedRatios : undefined,
+              limit: 5,
+              sort: 'newest',
             }).catch(() => null),
         tab === 'completed'
           ? fetchProjectCompletedJobs(localProject.id, {
@@ -705,10 +712,14 @@ export function ProjectViewer({ project, libraries, onUpdate: onUpdateProp, onDe
           if (JSON.stringify(updatedAlbumRes.items) !== JSON.stringify(localAlbumRef.current)) {
             setLocalAlbum(updatedAlbumRes.items);
           }
+          if (query.albumPage === 1 && query.albumSort === 'newest' && query.albumSelectedRatios.length === 0) {
+            setAlbumPreviewItems(updatedAlbumRes.items.slice(0, 5));
+          }
           setAlbumPages(updatedAlbumRes.pages);
           albumLoadedKeyRef.current = query.albumQueryKey;
           albumFetchedAtRef.current = Date.now();
         } else {
+          setAlbumPreviewItems(updatedAlbumRes.items.slice(0, 5));
           // Keep the cached rows intact while the user is on another tab. Mark
           // them stale so returning to Album shows the cache immediately and
           // revalidates it in the background.
@@ -1959,6 +1970,7 @@ export function ProjectViewer({ project, libraries, onUpdate: onUpdateProp, onDe
       // refetch (and a fresh round of signed image URLs).
       ++albumFetchTokenRef.current;
       setLocalAlbum((current) => current.filter((item) => !itemIdsSet.has(item.id)));
+      setAlbumPreviewItems((current) => current.filter((item) => !itemIdsSet.has(item.id)));
 
       const nextAlbumTotal = Math.max(0, albumTotal - itemIds.length);
       const pageSize = query.albumPageSize === 'all' ? Math.max(nextAlbumTotal, 1) : query.albumPageSize;
@@ -2226,7 +2238,7 @@ export function ProjectViewer({ project, libraries, onUpdate: onUpdateProp, onDe
               expandedJobId={expandedJobId} toggleJobExpand={toggleJobExpand} toggleDraftSelection={toggleDraftSelection}
               getProviderName={getProviderName} getModelName={getModelName} runJob={runDraftJob}
               setJobToDeleteId={setJobToDeleteId} setLightboxData={setLightboxData}
-              albumItems={albumItems}
+              albumItems={albumPreviewItems}
               onSwitchToAlbum={() => setActiveTab('album')}
               projectType={localProject.type || 'image'}
               projectName={localProject.name}

--- a/src/components/ProjectViewer.tsx
+++ b/src/components/ProjectViewer.tsx
@@ -1952,38 +1952,50 @@ export function ProjectViewer({ project, libraries, onUpdate: onUpdateProp, onDe
       if (itemIds.length === 1) await moveToTrash(localProject.id, itemIds[0]); else await moveToTrashBatch(localProject.id, itemIds);
 
       const query = liveQueryRef.current;
-      const limit = query.albumPageSize === 'all' ? 999999 : query.albumPageSize;
-      const fetchAlbumPage = (page: number) => fetchProjectAlbum(localProject.id, {
-        page,
-        limit,
-        sort: query.albumSort,
-        aspectRatios: query.albumSelectedRatios.length > 0 ? query.albumSelectedRatios : undefined,
-      });
+      const itemIdsSet = new Set(itemIds);
 
-      // Invalidate reads started before the delete, then wait for a confirmed
-      // server snapshot before changing anything visible in the Album UI.
+      // The delete endpoint has already committed the mutation. Update the
+      // cached page immediately instead of blocking the UI on a full page
+      // refetch (and a fresh round of signed image URLs).
       ++albumFetchTokenRef.current;
-      let updatedAlbumRes = await fetchAlbumPage(query.albumPage);
-      if (query.albumPage > updatedAlbumRes.pages) {
-        updatedAlbumRes = await fetchAlbumPage(updatedAlbumRes.pages);
-        updateAlbumParams({ page: updatedAlbumRes.pages });
+      setLocalAlbum((current) => current.filter((item) => !itemIdsSet.has(item.id)));
+
+      const nextAlbumTotal = Math.max(0, albumTotal - itemIds.length);
+      const pageSize = query.albumPageSize === 'all' ? Math.max(nextAlbumTotal, 1) : query.albumPageSize;
+      const nextAlbumPages = Math.max(1, Math.ceil(nextAlbumTotal / pageSize));
+      setAlbumTotal(nextAlbumTotal);
+      setAlbumPages(nextAlbumPages);
+
+      const removedSize = items.reduce((total, item) => total + Number(item.size || 0), 0);
+      setAlbumTotalSize((current) => Math.max(0, current - removedSize));
+
+      const removedAspectRatios = items.reduce<Record<string, number>>((counts, item) => {
+        const ratio = item.aspectRatio?.trim();
+        if (ratio) counts[ratio] = (counts[ratio] || 0) + 1;
+        return counts;
+      }, {});
+      if (Object.keys(removedAspectRatios).length > 0) {
+        setAlbumAspectRatioCounts((current) => current
+          .map(({ ratio, count }) => ({
+            ratio,
+            count: Math.max(0, count - (removedAspectRatios[ratio] || 0)),
+          }))
+          .filter(({ count }) => count > 0));
       }
 
-      ++albumFetchTokenRef.current;
-      setLocalAlbum(updatedAlbumRes.items);
-      setAlbumTotal(updatedAlbumRes.total);
-      setAlbumPages(updatedAlbumRes.pages);
-      setAlbumTotalSize(updatedAlbumRes.totalSize);
-      setAlbumAspectRatioCounts(updatedAlbumRes.aspectRatioCounts);
-      albumLoadedKeyRef.current = query.albumPage === updatedAlbumRes.page ? query.albumQueryKey : null;
+      albumLoadedKeyRef.current = query.albumQueryKey;
       albumFetchedAtRef.current = Date.now();
 
-      const itemIdsSet = new Set(itemIds);
       setSelectedAlbumIds(prev => {
         const next = new Set(prev);
         itemIdsSet.forEach(id => next.delete(id));
         return next;
       });
+
+      if (query.albumPage > nextAlbumPages) {
+        albumLoadedKeyRef.current = null;
+        updateAlbumParams({ page: nextAlbumPages });
+      }
     } catch (e: any) {
       console.error('Failed to move items to trash:', e);
       toast.error(`Failed to move items to trash: ${e.message}`);


### PR DESCRIPTION
## What changed

- Remove deleted Album items directly from cached client state after the recycle-bin endpoint succeeds.
- Update Album totals, page count, stored-size total, aspect-ratio counts, selection, and lightbox state locally.
- Restore a separate five-item newest-image preview cache for the Draft Canvas stacked gallery.
- Refresh that preview cache during project initialization and live updates without loading or replacing the full paginated Album cache.

## Why

The cache split introduced in `9883692` created two regressions. Album deletion waited for a complete page refetch and newly signed image URLs before advancing the lightbox. The same change also reduced the initial Album request to metadata only and stopped populating `localAlbum`, while the Draft Canvas still used `localAlbum` as its image source. As a result, the stacked gallery was empty until the Album tab had been opened.

## Impact

Album deletion now advances immediately from existing client state after server confirmation. Draft Canvas previews load as soon as the project opens, while Album pagination remains lazy and cached independently.

## Validation

- `npm run lint`
- `npm run build`
- `git diff --check`