### PR TITLE
Add new text models: Gemini 3.6/3.5, GPT-5.6 family, Claude Sonnet 5, Grok 4.5

### DIFF
--- a/agent/model-maintenance-guide.md
+++ b/agent/model-maintenance-guide.md
@@ -21,8 +21,8 @@ server/generators/                    -- One generator class per provider per ca
     +-- claude-text-generator.ts      -- Default model: claude-sonnet-4-6
     +-- openai-text-generator.ts      -- Default model: gpt-5.4
     +-- grok-text-generator.ts        -- Default model: grok-4.20-0309-non-reasoning
-    +-- google-ai-text-generator.ts   -- Default model: gemini-3-flash-preview
-    +-- vertex-ai-text-generator.ts   -- Default model: gemini-3-flash-preview
+    +-- google-ai-text-generator.ts   -- Default model: gemini-3.6-flash
+    +-- vertex-ai-text-generator.ts   -- Default model: gemini-3.6-flash
     +-- google-ai-generator.ts        -- Image gen (GoogleAI)
     +-- vertex-ai-generator.ts        -- Image gen (VertexAI)
     +-- google-ai-audio-generator.ts  -- Gemini TTS (GoogleAI)

--- a/docs-site/concepts/models.md
+++ b/docs-site/concepts/models.md
@@ -26,11 +26,11 @@ This matrix reflects the profiles shipped with the current release. Model availa
 
 | Provider | Supported Models |
 | :--- | :--- |
-| **Google AI** | `Gemini 3.5 Flash`, `Gemini 3.1 Pro`, `Gemini 3.1 Flash Lite`, `Gemma 4` |
-| **Vertex AI** | `Gemini 3.5 Flash`, `Gemini 3.1 Pro`, `Gemini 3.1 Flash Lite` |
-| **OpenAI** | `GPT-5.5`, `GPT-5.4`, `GPT-5.4 Mini`, `GPT-5.4 Nano` |
-| **Grok** | `Grok 4.20`, `Grok 4.3`, `Grok 4.1 Fast` |
-| **Claude** | `Claude Opus 4.7`, `Claude Sonnet 4.6`, `Claude Haiku 4.5` |
+| **Google AI** | `Gemini 3.6 Flash`, `Gemini 3.5 Flash`, `Gemini 3.5 Flash Lite`, `Gemini 3.1 Pro`, `Gemini 3.1 Flash Lite`, `Gemma 4` |
+| **Vertex AI** | `Gemini 3.6 Flash`, `Gemini 3.5 Flash`, `Gemini 3.5 Flash Lite`, `Gemini 3.1 Pro`, `Gemini 3.1 Flash Lite` |
+| **OpenAI** | `GPT-5.6`, `GPT-5.6 Terra`, `GPT-5.6 Luna`, `GPT-5.5`, `GPT-5.4`, `GPT-5.4 Mini`, `GPT-5.4 Nano` |
+| **Grok** | `Grok 4.5`, `Grok 4.20`, `Grok 4.3`, `Grok 4.1 Fast` |
+| **Claude** | `Claude Sonnet 5`, `Claude Opus 4.7`, `Claude Sonnet 4.6`, `Claude Haiku 4.5` |
 | **Alibaba Cloud DashScope** | `Qwen3.6 Max`, `Qwen3.6 Plus`, `Qwen3.6 Flash`, `Qwen3.6 VL Max`, `Qwen3.6 VL Plus` |
 
 ## 3. Image Generation

--- a/server/generators/claude-text-generator.ts
+++ b/server/generators/claude-text-generator.ts
@@ -16,6 +16,8 @@ export class ClaudeTextGenerator extends TextGenerator {
     try {
       const { prompt, systemPrompt, modelId, temperature = 0.7, maxTokens = 2048, refImagesBase64 } = req;
       const model = modelId || 'claude-sonnet-4-6';
+      // Sonnet 5 rejects non-default sampling parameters (400) — omit temperature entirely.
+      const supportsTemperature = !model.startsWith('claude-sonnet-5');
 
       const contentParts: Anthropic.ContentBlockParam[] = [];
 
@@ -34,7 +36,7 @@ export class ClaudeTextGenerator extends TextGenerator {
       const response = await this.client.messages.create({
         model,
         max_tokens: maxTokens,
-        temperature,
+        ...(supportsTemperature ? { temperature } : {}),
         ...(systemPrompt ? { system: systemPrompt } : {}),
         messages: [{ role: 'user', content: contentParts }],
       });

--- a/server/generators/google-ai-text-generator.ts
+++ b/server/generators/google-ai-text-generator.ts
@@ -12,7 +12,7 @@ export class GoogleAITextGenerator extends TextGenerator {
 
   async generate(req: TextGenerateRequest): Promise<TextGenerateResult> {
     const { prompt, systemPrompt, temperature = 0.7, maxTokens = 2048, refImagesBase64, modelId, apiUrl: reqApiUrl } = req;
-    const model = modelId || 'gemini-3-flash-preview';
+    const model = modelId || 'gemini-3.6-flash';
 
     let actualApiUrl: string;
     if (reqApiUrl) {

--- a/server/generators/vertex-ai-text-generator.ts
+++ b/server/generators/vertex-ai-text-generator.ts
@@ -14,7 +14,7 @@ export class VertexAITextGenerator extends TextGenerator {
 
   async generate(req: TextGenerateRequest): Promise<TextGenerateResult> {
     const { prompt, systemPrompt, temperature = 0.7, maxTokens = 2048, refImagesBase64, modelId, apiUrl: reqApiUrl } = req;
-    const model = modelId || 'gemini-3-flash-preview';
+    const model = modelId || 'gemini-3.6-flash';
 
     let actualApiUrl: string;
     if (reqApiUrl) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -270,10 +270,34 @@ export const PROVIDER_MODELS_MAP: Record<ProviderType, ModelConfig[]> = {
       },
     },
     {
+      id: 'google-gemini-3.6-flash-text',
+      name: 'Gemini 3.6 Flash',
+      generatorId: 'GoogleAI',
+      modelId: 'gemini-3.6-flash',
+      category: 'text',
+      promptLimit: { value: 1048576, unit: 'tokens' },
+      options: {
+        temperatures: [0, 0.2, 0.5, 0.7, 1.0, 1.5, 2.0],
+        maxTokenOptions: [256, 512, 1024, 2048, 4096, 8192, 16384, 32768, 65536],
+      },
+    },
+    {
       id: 'google-gemini-3.5-flash-text',
       name: 'Gemini 3.5 Flash',
       generatorId: 'GoogleAI',
       modelId: 'gemini-3.5-flash',
+      category: 'text',
+      promptLimit: { value: 1048576, unit: 'tokens' },
+      options: {
+        temperatures: [0, 0.2, 0.5, 0.7, 1.0, 1.5, 2.0],
+        maxTokenOptions: [256, 512, 1024, 2048, 4096, 8192, 16384, 32768, 65536],
+      },
+    },
+    {
+      id: 'google-gemini-3.5-flash-lite-text',
+      name: 'Gemini 3.5 Flash Lite',
+      generatorId: 'GoogleAI',
+      modelId: 'gemini-3.5-flash-lite',
       category: 'text',
       promptLimit: { value: 1048576, unit: 'tokens' },
       options: {
@@ -436,10 +460,34 @@ export const PROVIDER_MODELS_MAP: Record<ProviderType, ModelConfig[]> = {
       },
     },
     {
+      id: 'vertex-gemini-3.6-flash-text',
+      name: 'Gemini 3.6 Flash',
+      generatorId: 'VertexAI',
+      modelId: 'gemini-3.6-flash',
+      category: 'text',
+      promptLimit: { value: 1048576, unit: 'tokens' },
+      options: {
+        temperatures: [0, 0.2, 0.5, 0.7, 1.0, 1.5, 2.0],
+        maxTokenOptions: [256, 512, 1024, 2048, 4096, 8192, 16384, 32768, 65536],
+      },
+    },
+    {
       id: 'vertex-gemini-3.5-flash-text',
       name: 'Gemini 3.5 Flash',
       generatorId: 'VertexAI',
       modelId: 'gemini-3.5-flash',
+      category: 'text',
+      promptLimit: { value: 1048576, unit: 'tokens' },
+      options: {
+        temperatures: [0, 0.2, 0.5, 0.7, 1.0, 1.5, 2.0],
+        maxTokenOptions: [256, 512, 1024, 2048, 4096, 8192, 16384, 32768, 65536],
+      },
+    },
+    {
+      id: 'vertex-gemini-3.5-flash-lite-text',
+      name: 'Gemini 3.5 Flash Lite',
+      generatorId: 'VertexAI',
+      modelId: 'gemini-3.5-flash-lite',
       category: 'text',
       promptLimit: { value: 1048576, unit: 'tokens' },
       options: {
@@ -815,6 +863,42 @@ export const PROVIDER_MODELS_MAP: Record<ProviderType, ModelConfig[]> = {
       },
     },
     {
+      id: 'openai-gpt-5.6-text',
+      name: 'GPT-5.6',
+      generatorId: 'OpenAI',
+      modelId: 'gpt-5.6',
+      category: 'text',
+      promptLimit: { value: 1050000, unit: 'tokens' },
+      options: {
+        temperatures: [0, 0.2, 0.5, 0.7, 1.0, 1.5, 2.0],
+        maxTokenOptions: [256, 512, 1024, 2048, 4096, 8192, 16384, 32768, 65536, 131072],
+      },
+    },
+    {
+      id: 'openai-gpt-5.6-terra-text',
+      name: 'GPT-5.6 Terra',
+      generatorId: 'OpenAI',
+      modelId: 'gpt-5.6-terra',
+      category: 'text',
+      promptLimit: { value: 1050000, unit: 'tokens' },
+      options: {
+        temperatures: [0, 0.2, 0.5, 0.7, 1.0, 1.5, 2.0],
+        maxTokenOptions: [256, 512, 1024, 2048, 4096, 8192, 16384, 32768, 65536, 131072],
+      },
+    },
+    {
+      id: 'openai-gpt-5.6-luna-text',
+      name: 'GPT-5.6 Luna',
+      generatorId: 'OpenAI',
+      modelId: 'gpt-5.6-luna',
+      category: 'text',
+      promptLimit: { value: 1050000, unit: 'tokens' },
+      options: {
+        temperatures: [0, 0.2, 0.5, 0.7, 1.0, 1.5, 2.0],
+        maxTokenOptions: [256, 512, 1024, 2048, 4096, 8192, 16384, 32768, 65536, 131072],
+      },
+    },
+    {
       id: 'openai-gpt-5.5-text',
       name: 'GPT-5.5',
       generatorId: 'OpenAI',
@@ -911,6 +995,18 @@ export const PROVIDER_MODELS_MAP: Record<ProviderType, ModelConfig[]> = {
       },
     },
     {
+      id: 'grok-4.5-text',
+      name: 'Grok 4.5',
+      generatorId: 'Grok',
+      modelId: 'grok-4.5',
+      category: 'text',
+      promptLimit: { value: 500000, unit: 'tokens' },
+      options: {
+        temperatures: [0, 0.2, 0.5, 0.7, 1.0, 1.5, 2.0],
+        maxTokenOptions: [256, 512, 1024, 2048, 4096, 8192, 16384, 32768],
+      },
+    },
+    {
       id: 'grok-4.20-text',
       name: 'Grok 4.20',
       generatorId: 'Grok',
@@ -960,6 +1056,19 @@ export const PROVIDER_MODELS_MAP: Record<ProviderType, ModelConfig[]> = {
     },
   ],
   Claude: [
+    {
+      id: 'claude-sonnet-5-text',
+      name: 'Claude Sonnet 5',
+      generatorId: 'Claude',
+      modelId: 'claude-sonnet-5',
+      category: 'text',
+      promptLimit: { value: 1000000, unit: 'tokens' },
+      options: {
+        // Sonnet 5 rejects non-default sampling parameters; only the default temperature is allowed.
+        temperatures: [1.0],
+        maxTokenOptions: [256, 512, 1024, 2048, 4096, 8192, 16384, 32768, 65536, 131072],
+      },
+    },
     {
       // Keep the stable local config id so saved projects and custom-model aliases continue to resolve.
       id: 'claude-opus-4-6-text',


### PR DESCRIPTION
- Google AI &amp; Vertex AI: add Gemini 3.6 Flash (gemini-3.6-flash) and
  Gemini 3.5 Flash Lite (gemini-3.5-flash-lite); update the default text
  model fallback from the stale gemini-3-flash-preview to gemini-3.6-flash
- OpenAI: add GPT-5.6 (gpt-5.6, Sol alias), GPT-5.6 Terra, and GPT-5.6 Luna
- Claude: add Claude Sonnet 5 (claude-sonnet-5); omit the temperature
  parameter for Sonnet 5 in the generator since it rejects non-default
  sampling parameters
- Grok: add Grok 4.5 (grok-4.5, 500K context)
- Sync docs-site model tables and the model maintenance guide defaults

Gemini 3.5 Flash Cyber is intentionally not added: it is restricted to
governments and trusted partners via a limited-access pilot and has no
public API availability.
