### PR TITLE
Release v1.18.0: New models, optimized tabs, and UX improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,26 +6,26 @@ All notable changes to Remix Studio are documented here by version number.
 
 ### Added
 
-- **New Models**: Added Gemini 3.6/3.5, GPT-5.6 family, Claude Sonnet 5, and Grok 4.5 text models, plus nano banana 2 Pro, nano banana 2 Lite, Wan 2.7 Pro, Seedream V5 Pro, and Seedream 5.0 Pro image models across the RunningHub, Google AI, and Vertex AI providers.
-- **Auto Aspect Ratio**: RunningHub's nano banana 2 model now supports automatically matching the source image's aspect ratio.
-- **Workflow Image Version Selection**: Added a version picker for workflow images so you can switch between previously generated versions.
-- **Save to Library**: Added a save-to-library button for text and image workflow items.
-- **Reorderable Cover Images**: Cover images on the Sell/Export page can now be reordered by drag and drop.
-- **Text Library Import/Export**: Added lossless JSON import/export for text libraries.
+- **New Text Models**: Added Gemini 3.6 Flash and Gemini 3.5 Flash Lite (Google AI & Vertex AI), the GPT-5.6 family — GPT-5.6, GPT-5.6 Terra, and GPT-5.6 Luna (OpenAI), Claude Sonnet 5 (Claude), and Grok 4.5 (Grok). The default Gemini text model is now Gemini 3.6 Flash.
+- **New Image Models**: Added nano banana Pro, Seedream 5.0 Pro, Seedream V5 Pro, and Wan 2.7 Pro to the RunningHub provider, and nano banana 2 Lite to the Google AI and Vertex AI providers.
+- **Auto Aspect Ratio**: RunningHub's nano banana 2 now offers an "auto" aspect ratio option that lets the model pick the output ratio itself.
+- **Image Version Selection**: When picking album images in the media picker, you can now choose between the optimized version and the original file.
+- **Save to Library**: Added a save-to-library button to text and image workflow items.
+- **Cover Image Reordering**: Cover images on the sell/export page can now be reordered.
+- **Text Library JSON Import/Export**: Added a lossless JSON mode for text library import and export, so prompts containing newlines, colons, or list-like lines survive round-trips intact; the plain-text format remains available.
 
 ### Changed
 
-- **Library Editor Styling**: Refined the Library Editor's typography and toolbar styling, and added internationalized timestamp labels.
-- **Lockfile Registry**: Lockfiles now point at registry.npmjs.org instead of npmmirror.com.
+- **Project Tab Data Loading**: Reworked how the project tabs (Draft, Queue, Done, Album) load and cache their data. Album pages and completed jobs are fetched on demand per tab and cached across tab switches, deleting album items updates the album, its counts, and pagination instantly without waiting for a server refetch, and the Draft canvas keeps its own always-loaded preview of the newest album items so it appears as soon as the project opens. Confirmation dialogs now show progress and block double-submission while their action is running.
+- **Library Editor**: Updated the Library Editor's typography, refined its toolbar styling, and internationalized the timestamp labels.
+- **Package Registry**: Lockfiles now resolve packages from registry.npmjs.org instead of npmmirror.com.
 
 ### Fixed
 
-- **Wan 2.7 Prompt Length**: Prompts sent to Wan 2.7 are now truncated to the 2048-character API limit instead of failing.
-- **Async UI Consistency**: Fixed UI state falling out of sync with server-confirmed state during async operations.
-- **Workflow Image Editor Coordinates**: Fixed misaligned crop and draw coordinates in the workflow image editor.
-- **Album Lightbox Deletion**: Fixed the album lightbox not refreshing correctly after deleting an image.
-- **Album Deletion Updates**: Restored instant UI updates and draft canvas album previews after deleting album items.
-- **Mobile Message Actions**: Message copy/edit and attachment-remove buttons are now shown on mobile.
+- **Lightbox Deletion Refresh**: The album lightbox now switches to the next image immediately after deleting the current one, instead of keeping a stale image on screen.
+- **Wan 2.7 Prompt Length**: Prompts longer than Wan 2.7's 2048-character limit are now truncated before submission instead of failing the job.
+- **Image Editor Coordinates**: Drawing and cropping in the workflow image editor now land exactly under the cursor — edits are composed in the image's natural pixel space, so saved results are no longer offset or downscaled.
+- **Mobile Assistant Buttons**: Message copy/edit and attachment-remove buttons in the assistant are now visible on touch devices instead of requiring hover.
 
 ## [1.17.1] - 2026-07-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 All notable changes to Remix Studio are documented here by version number.
 
+## [1.18.0] - 2026-07-21
+
+### Added
+
+- **New Models**: Added Gemini 3.6/3.5, GPT-5.6 family, Claude Sonnet 5, and Grok 4.5 text models, plus nano banana 2 Pro, nano banana 2 Lite, Wan 2.7 Pro, Seedream V5 Pro, and Seedream 5.0 Pro image models across the RunningHub, Google AI, and Vertex AI providers.
+- **Auto Aspect Ratio**: RunningHub's nano banana 2 model now supports automatically matching the source image's aspect ratio.
+- **Workflow Image Version Selection**: Added a version picker for workflow images so you can switch between previously generated versions.
+- **Save to Library**: Added a save-to-library button for text and image workflow items.
+- **Reorderable Cover Images**: Cover images on the Sell/Export page can now be reordered by drag and drop.
+- **Text Library Import/Export**: Added lossless JSON import/export for text libraries.
+
+### Changed
+
+- **Library Editor Styling**: Refined the Library Editor's typography and toolbar styling, and added internationalized timestamp labels.
+- **Lockfile Registry**: Lockfiles now point at registry.npmjs.org instead of npmmirror.com.
+
+### Fixed
+
+- **Wan 2.7 Prompt Length**: Prompts sent to Wan 2.7 are now truncated to the 2048-character API limit instead of failing.
+- **Async UI Consistency**: Fixed UI state falling out of sync with server-confirmed state during async operations.
+- **Workflow Image Editor Coordinates**: Fixed misaligned crop and draw coordinates in the workflow image editor.
+- **Album Lightbox Deletion**: Fixed the album lightbox not refreshing correctly after deleting an image.
+- **Album Deletion Updates**: Restored instant UI updates and draft canvas album previews after deleting album items.
+- **Mobile Message Actions**: Message copy/edit and attachment-remove buttons are now shown on mobile.
+
 ## [1.17.1] - 2026-07-10
 
 ### Changed

--- a/docs-site/concepts/models.md
+++ b/docs-site/concepts/models.md
@@ -37,11 +37,11 @@ This matrix reflects the profiles shipped with the current release. Model availa
 
 | Provider | Supported Models |
 | :--- | :--- |
-| **Google AI** | `nano banana 2` |
-| **Vertex AI** | `nano banana 2` |
+| **Google AI** | `nano banana 2`, `nano banana 2 Lite` |
+| **Vertex AI** | `nano banana 2`, `nano banana 2 Lite` |
 | **OpenAI** | `GPT Image 2`, `GPT Image 1.5`, `GPT Image 1 Mini` |
 | **Grok** | `Grok Imagine`, `Grok Imagine Pro` |
-| **RunningHub** | `nano banana 2`, `GPT Image 2`, `Qwen Image 2 Pro`, `Grok Imagine Pro` |
+| **RunningHub** | `nano banana 2`, `nano banana Pro`, `GPT Image 2`, `Qwen Image 2 Pro`, `Grok Imagine Pro`, `Seedream 5.0 Pro`, `Seedream V5 Pro`, `Wan 2.7 Pro` |
 | **BytePlus** | `Seedream 5.0 Lite`, `Seedream 4.5`, `Seedream 4.0`, `Seedream 3.0 T2I`, `Seededit 3.0 I2I` |
 | **Kling AI** | `Kling Image O1`, `Kling V3 Omni`, `Kling V3 Standard`, `Kling V2.1 Standard`, `Kling V2 Standard`, `Kling V1.5 Standard`, `Kling V1 Standard` |
 | **Black Forest Labs** | `Flux 2 Max`, `Flux 2 Pro (Preview)`, `Flux 2 Pro`, `Flux 2 Flex`, `Flux 2 Klein 9B (Preview)`, `Flux 2 Klein 9B`, `Flux 2 Klein 4B` |

--- a/docs-site/whats-new.md
+++ b/docs-site/whats-new.md
@@ -8,6 +8,33 @@ Please open a ticket on [GitHub Issues](https://github.com/ShinChven/remix-studi
 
 ---
 
+## 1.18.0 — A wave of new models & snappier project tabs
+
+*New text and image models across five providers, project tabs that load on demand and update instantly, and quality-of-life upgrades throughout the workspace.*
+
+**Added**
+
+- **New text models** — Gemini 3.6 Flash and Gemini 3.5 Flash Lite (Google AI & Vertex AI), the GPT-5.6 family (GPT-5.6, Terra, and Luna), Claude Sonnet 5, and Grok 4.5. The default Gemini text model is now Gemini 3.6 Flash.
+- **New image models** — nano banana Pro, Seedream 5.0 Pro, Seedream V5 Pro, and Wan 2.7 Pro on RunningHub, plus nano banana 2 Lite on Google AI and Vertex AI.
+- **Auto aspect ratio** — nano banana 2 on RunningHub gains an "auto" option that lets the model pick the output ratio itself.
+- **Optimized or original** — When picking album images in the media picker, choose whether you want the optimized version or the original file.
+- **Save to library** — Send a workflow item's text or image straight to a library with one click.
+- **Reorder cover images** — Arrange product cover images in the order you want on the sell page.
+- **Lossless library transfer** — Export and import text libraries as JSON, so prompts with newlines, colons, or list-like lines survive round-trips byte-for-byte. The simple plain-text format is still there.
+
+**Improved**
+
+- **Snappier project tabs** — The Draft, Queue, Done, and Album tabs now fetch their data on demand and cache what you've already seen. Deleting album items updates the album, its counts, and pagination instantly — no more waiting on a server refetch — and the draft canvas shows your newest images the moment the project opens.
+- **Safer confirmations** — Confirmation dialogs show progress and prevent double-submission while their action is running.
+- **Library editor polish** — Cleaner typography, a refined toolbar, and localized timestamps.
+
+**Fixed**
+
+- Deleting the current image in the album lightbox now shows the next image immediately instead of leaving a stale one on screen.
+- Wan 2.7 prompts longer than the API's 2048-character limit are truncated instead of failing the job.
+- Drawing and cropping in the image editor now land exactly where you point, and saved edits keep the image's full resolution.
+- Assistant message and attachment buttons are now reachable on phones and tablets.
+
 ## 1.17.1 — Light mode polish
 
 *A cleanup pass for light mode, plus tidier fullscreen workflow cards and smarter pagination.*

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "remix-studio",
-  "version": "1.17.1",
+  "version": "1.18.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "remix-studio",
-      "version": "1.17.1",
+      "version": "1.18.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.87.0",
         "@aws-sdk/client-s3": "^3.1024.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "remix-studio",
   "private": true,
-  "version": "1.17.1",
+  "version": "1.18.0",
   "type": "module",
   "scripts": {
     "dev": "tsx watch --exclude \"agent/**\" --exclude \"data/**\" --exclude \"dist/**\" --exclude \"dist-server/**\" --exclude \"docs/**\" --exclude \"docs-site/**\" server.ts",


### PR DESCRIPTION
## Summary
This release introduces version 1.18.0 with expanded model support across multiple providers, performance improvements to project tabs, and various quality-of-life enhancements throughout the workspace.

## Key Changes

**New Models &amp; Providers**
- Added 8 new text models: Gemini 3.6 Flash, Gemini 3.5 Flash Lite, GPT-5.6 family (GPT-5.6, Terra, Luna), Claude Sonnet 5, and Grok 4.5
- Added 8 new image models: nano banana Pro, Seedream 5.0 Pro, Seedream V5 Pro, Wan 2.7 Pro (RunningHub), and nano banana 2 Lite (Google AI &amp; Vertex AI)
- Updated model documentation in `docs-site/concepts/models.md` to reflect new provider/model combinations
- Set Gemini 3.6 Flash as the new default Gemini text model

**Project Tab Performance**
- Reworked project tabs (Draft, Queue, Done, Album) to load data on-demand and cache results across tab switches
- Album deletion now updates counts and pagination instantly without server refetch
- Draft canvas displays newest images immediately on project open

**User Experience Improvements**
- Added image version selection (optimized vs. original) in media picker
- Implemented save-to-library functionality for workflow items
- Added cover image reordering on sell/export page
- Introduced lossless JSON import/export for text libraries (preserves newlines, colons, list formatting)
- Added auto aspect ratio option for nano banana 2 on RunningHub
- Enhanced confirmation dialogs with progress indication and double-submission prevention
- Polished library editor typography, toolbar, and localized timestamps

**Bug Fixes**
- Album lightbox now shows next image immediately after deletion instead of stale image
- Wan 2.7 prompts exceeding 2048 characters are truncated instead of failing
- Image editor drawing/cropping now aligns precisely with cursor position and preserves full resolution
- Assistant message and attachment buttons now accessible on mobile/tablet devices
- Updated package registry from npmmirror.com to registry.npmjs.org

## Version Bump
Updated `package.json` version from 1.17.1 to 1.18.0
