### PR TITLE
Update latest AI provider model catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,11 +145,11 @@ These are the model profiles currently bundled with the app.
 
 | Provider | Text Models | Image Models | Video Models | Audio Models |
 | :--- | :--- | :--- | :--- | :--- |
-| **Google AI** | `Gemini 3 Flash`, `Gemini 3.1 Pro`, `Gemini 3.1 Flash Lite`, `Gemma 4` | `nano banana 2` | `Veo 3.1`, `Veo 3.1 Lite` | `Gemini 3.1 Flash TTS`, `Gemini 2.5 Flash TTS`, `Gemini 2.5 Pro TTS`, `Lyria 3 Clip`, `Lyria 3 Pro` |
-| **Vertex AI** | `Gemini 3 Flash`, `Gemini 3.1 Pro`, `Gemini 3.1 Flash Lite` | `nano banana 2` | - | `Gemini 3.1 Flash TTS`, `Gemini 2.5 Flash TTS`, `Gemini 2.5 Pro TTS`, `Lyria 3 Clip`, `Lyria 3 Pro` |
-| **OpenAI** | `GPT-5.4`, `GPT-5.4 Mini`, `GPT-5.4 Nano` | `GPT Image 2`, `GPT Image 1.5`, `GPT Image 1 Mini` | `Sora 2`, `Sora 2 Pro` | - |
+| **Google AI** | `Gemini 3.6 Flash`, `Gemini 3.5 Flash`, `Gemini 3.5 Flash Lite`, `Gemini 3.1 Pro`, `Gemini 3.1 Flash Lite`, `Gemma 4` | `nano banana Pro`, `nano banana 2`, `nano banana 2 Lite` | `Veo 3.1`, `Veo 3.1 Lite` | `Gemini 3.1 Flash TTS`, `Gemini 2.5 Flash TTS`, `Gemini 2.5 Pro TTS`, `Lyria 3 Clip`, `Lyria 3 Pro` |
+| **Vertex AI** | `Gemini 3.6 Flash`, `Gemini 3.5 Flash`, `Gemini 3.5 Flash Lite`, `Gemini 3.1 Pro`, `Gemini 3.1 Flash Lite` | `nano banana Pro`, `nano banana 2`, `nano banana 2 Lite` | - | `Gemini 3.1 Flash TTS`, `Gemini 2.5 Flash TTS`, `Gemini 2.5 Pro TTS`, `Lyria 3 Clip`, `Lyria 3 Pro` |
+| **OpenAI** | `GPT-5.6`, `GPT-5.6 Terra`, `GPT-5.6 Luna`, `GPT-5.5`, `GPT-5.4`, `GPT-5.4 Mini`, `GPT-5.4 Nano` | `GPT Image 2`, `GPT Image 1.5`, `GPT Image 1 Mini` | `Sora 2`, `Sora 2 Pro` | - |
 | **Grok** | `Grok 4.20`, `Grok 4.1 Fast` | `Grok Imagine`, `Grok Imagine Pro` | `Grok Imagine Video` | - |
-| **Claude** | `Claude Opus 4.7`, `Claude Sonnet 4.6`, `Claude Haiku 4.5` | - | - | - |
+| **Claude** | `Claude Fable 5`, `Claude Opus 4.8`, `Claude Sonnet 5`, `Claude Opus 4.7`, `Claude Sonnet 4.6`, `Claude Haiku 4.5` | - | - | - |
 | **Alibaba Cloud DashScope** | `Qwen3.6 Max`, `Qwen3.6 Plus`, `Qwen3.6 Flash`, `Qwen3.6 VL Max`, `Qwen3.6 VL Plus` | - | - | - |
 | **RunningHub** | - | `nano banana 2`, `Qwen Image 2 Pro` | `Seedance 2.0 Global`, `Seedance 2.0 Global Multimodal Reference` | - |
 | **BytePlus** | - | `Seedream 5.0 Lite`, `Seedream 4.5`, `Seedream 4.0`, `Seedream 3.0 T2I`, `Seededit 3.0 I2I` | `Seedance 1.5 Pro`, `Seedance 1.0 Pro`, `Seedance 1.0 Pro Fast` | - |

--- a/agent/model-maintenance-guide.md
+++ b/agent/model-maintenance-guide.md
@@ -19,7 +19,7 @@ server/generators/                    -- One generator class per provider per ca
     +-- build-video-generator.ts      -- Factory: provider type -> video generator
     +-- build-audio-generator.ts      -- Factory: provider type -> audio generator
     +-- claude-text-generator.ts      -- Default model: claude-sonnet-4-6
-    +-- openai-text-generator.ts      -- Default model: gpt-5.4
+    +-- openai-text-generator.ts      -- Default model: gpt-5.6
     +-- grok-text-generator.ts        -- Default model: grok-4.20-0309-non-reasoning
     +-- google-ai-text-generator.ts   -- Default model: gemini-3.6-flash
     +-- vertex-ai-text-generator.ts   -- Default model: gemini-3.6-flash
@@ -156,12 +156,14 @@ The lister fetches all models, then filters to only those whose `id` matches a `
 
 ---
 
-## Current Model Inventory (April 2026)
+## Current Model Inventory (July 2026)
 
 ### Google AI / Vertex AI
 | Name | Model ID | Category | Max Output |
 |---|---|---|---|
+| nano banana Pro | `gemini-3-pro-image` | image | 32,768 |
 | nano banana 2 | `gemini-3.1-flash-image-preview` | image | 32,768 |
+| nano banana 2 Lite | `gemini-3.1-flash-lite-image` | image | 32,768 |
 | Gemini 3 Flash | `gemini-3-flash-preview` | text | 65,536 |
 | Gemini 3.1 Pro | `gemini-3.1-pro-preview` | text | 65,536 |
 | Gemini 3.1 Flash Lite | `gemini-3.1-flash-lite-preview` | text | 65,536 |
@@ -175,7 +177,11 @@ The lister fetches all models, then filters to only those whose `id` matches a `
 | GPT Image 2 | `gpt-image-2` | image | - |
 | GPT Image 1.5 | `gpt-image-1.5` | image | - |
 | GPT Image 1 Mini | `gpt-image-1-mini` | image | - |
-| GPT-5.4 | `gpt-5.4` | text | 128,000 |
+| GPT-5.6 | `gpt-5.6` | text | 131,072 |
+| GPT-5.6 Terra | `gpt-5.6-terra` | text | 131,072 |
+| GPT-5.6 Luna | `gpt-5.6-luna` | text | 131,072 |
+| GPT-5.5 | `gpt-5.5` | text | 131,072 |
+| GPT-5.4 | `gpt-5.4` | text | 131,072 |
 | GPT-5.4 Mini | `gpt-5.4-mini` | text | 128,000 |
 | GPT-5.4 Nano | `gpt-5.4-nano` | text | 128,000 |
 
@@ -190,6 +196,8 @@ The lister fetches all models, then filters to only those whose `id` matches a `
 ### Claude (Anthropic)
 | Name | Model ID | Category | Max Output |
 |---|---|---|---|
+| Claude Fable 5 | `claude-fable-5` | text | 128,000 |
+| Claude Opus 4.8 | `claude-opus-4-8` | text | 128,000 |
 | Claude Opus 4.7 | `claude-opus-4-7` | text | 128,000 |
 | Claude Sonnet 4.6 | `claude-sonnet-4-6` | text | 64,000 |
 | Claude Haiku 4.5 | `claude-haiku-4-5-20251001` | text | 64,000 |

--- a/server/generators/claude-text-generator.ts
+++ b/server/generators/claude-text-generator.ts
@@ -16,8 +16,12 @@ export class ClaudeTextGenerator extends TextGenerator {
     try {
       const { prompt, systemPrompt, modelId, temperature = 0.7, maxTokens = 2048, refImagesBase64 } = req;
       const model = modelId || 'claude-sonnet-4-6';
-      // Sonnet 5 rejects non-default sampling parameters (400) — omit temperature entirely.
-      const supportsTemperature = !model.startsWith('claude-sonnet-5');
+      // Claude's latest adaptive-thinking models reject non-default sampling parameters (400) — omit temperature entirely.
+      const supportsTemperature = !(
+        model.startsWith('claude-fable-5') ||
+        model.startsWith('claude-opus-4-8') ||
+        model.startsWith('claude-sonnet-5')
+      );
 
       const contentParts: Anthropic.ContentBlockParam[] = [];
 

--- a/server/generators/openai-text-generator.ts
+++ b/server/generators/openai-text-generator.ts
@@ -21,7 +21,7 @@ export class OpenAITextGenerator extends TextGenerator {
   async generate(req: TextGenerateRequest): Promise<TextGenerateResult> {
     try {
       const { prompt, systemPrompt, modelId, temperature = 0.7, maxTokens = 2048, refImagesBase64 } = req;
-      const model = modelId || 'gpt-5.4';
+      const model = modelId || 'gpt-5.6';
 
       const messages: OpenAI.Chat.ChatCompletionMessageParam[] = [];
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -258,6 +258,18 @@ export const PROVIDER_MODELS_MAP: Record<ProviderType, ModelConfig[]> = {
       },
     },
     {
+      id: 'google-nano-banana-pro',
+      name: 'nano banana Pro',
+      generatorId: 'GoogleAI',
+      modelId: 'gemini-3-pro-image',
+      category: 'image',
+      promptLimit: { value: 65536, unit: 'tokens' },
+      options: {
+        aspectRatios: ['1:1', '4:3', '3:4', '16:9', '9:16', '2:3', '3:2', '1:4', '4:1', '4:5', '5:4', '21:9'],
+        qualities: ['1K', '2K', '4K'],
+      },
+    },
+    {
       id: 'google-nano-banana-2-lite',
       name: 'nano banana 2 Lite',
       generatorId: 'GoogleAI',
@@ -444,6 +456,18 @@ export const PROVIDER_MODELS_MAP: Record<ProviderType, ModelConfig[]> = {
       promptLimit: { value: 131072, unit: 'tokens' },
       options: {
         aspectRatios: ['1:1', '4:3', '3:4', '16:9', '9:16', '2:3', '3:2', '1:4', '4:1', '1:8', '8:1', '4:5', '5:4', '21:9', '9:21'],
+        qualities: ['1K', '2K', '4K'],
+      },
+    },
+    {
+      id: 'vertex-nano-banana-pro',
+      name: 'nano banana Pro',
+      generatorId: 'VertexAI',
+      modelId: 'gemini-3-pro-image',
+      category: 'image',
+      promptLimit: { value: 65536, unit: 'tokens' },
+      options: {
+        aspectRatios: ['1:1', '4:3', '3:4', '16:9', '9:16', '2:3', '3:2', '1:4', '4:1', '4:5', '5:4', '21:9'],
         qualities: ['1K', '2K', '4K'],
       },
     },
@@ -1056,6 +1080,32 @@ export const PROVIDER_MODELS_MAP: Record<ProviderType, ModelConfig[]> = {
     },
   ],
   Claude: [
+    {
+      id: 'claude-fable-5-text',
+      name: 'Claude Fable 5',
+      generatorId: 'Claude',
+      modelId: 'claude-fable-5',
+      category: 'text',
+      promptLimit: { value: 1000000, unit: 'tokens' },
+      options: {
+        // Fable 5 uses always-on adaptive thinking and rejects disabled/manual thinking controls.
+        temperatures: [1.0],
+        maxTokenOptions: [256, 512, 1024, 2048, 4096, 8192, 16384, 32768, 65536, 131072],
+      },
+    },
+    {
+      id: 'claude-opus-4-8-text',
+      name: 'Claude Opus 4.8',
+      generatorId: 'Claude',
+      modelId: 'claude-opus-4-8',
+      category: 'text',
+      promptLimit: { value: 1000000, unit: 'tokens' },
+      options: {
+        // Opus 4.8 rejects non-default sampling parameters; only the default temperature is allowed.
+        temperatures: [1.0],
+        maxTokenOptions: [256, 512, 1024, 2048, 4096, 8192, 16384, 32768, 65536, 131072],
+      },
+    },
     {
       id: 'claude-sonnet-5-text',
       name: 'Claude Sonnet 5',


### PR DESCRIPTION
### Motivation
- Bring the local provider/model registry and docs up to date with recent provider releases for Google (Gemini/nano banana), Claude, and OpenAI/GPT and ensure generators behave correctly with new model semantics.
- Ensure the default generator fallbacks and sampling behavior reflect provider constraints for new adaptive-thinking Claude models and new GPT defaults.

### Description
- Added `nano banana Pro` (`gemini-3-pro-image`) entries to `GoogleAI` and `VertexAI` in `src/types.ts` and included corresponding image options.
- Added `Claude Fable 5` (`claude-fable-5`) and `Claude Opus 4.8` (`claude-opus-4-8`) model entries to `src/types.ts` and adjusted Claude sampling/temperature handling in `server/generators/claude-text-generator.ts` to omit `temperature` for adaptive-thinking models.
- Updated OpenAI text generator fallback default from `gpt-5.4` to `gpt-5.6` in `server/generators/openai-text-generator.ts`.
- Updated documentation and inventories in `README.md` and `agent/model-maintenance-guide.md` to reflect the new Google, Claude, and GPT model rows and bumped the inventory date to July 2026.

### Testing
- Ran `git diff --check` which reported no whitespace or diff-check errors and passed.
- Ran `npm run lint` (`tsc --noEmit`) which surfaced unrelated TypeScript errors stemming from the local/generated Prisma client/types (missing `PrismaClient`/`Prisma` exports); no new model-catalog-specific TypeScript issues were identified prior to those environment/type-generation failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6023f91d5c832db08f07e01f6cfa31)