### PR TITLE
feat(assistant): implement automatic truncation recovery

### DIFF
--- a/server/assistant/assistant-runner.ts
+++ b/server/assistant/assistant-runner.ts
@@ -38,11 +38,16 @@ import { PROVIDER_MODELS_MAP } from '../../src/types';
  */
 
 export const ASSISTANT_LIMITS = {
-  MAX_ITERATIONS: 24,
-  MAX_TOOL_CALLS: 48,
+  MAX_ITERATIONS: 1000,
+  MAX_TOOL_CALLS: 1000,
   MAX_PARALLEL_TOOLS: 12,
+  // 8192 is the ceiling, not a preference: our Anthropic calls are
+  // non-streaming, and the SDK refuses a non-streaming request above 8192
+  // output tokens on Opus 4/4.1. Raising this requires streaming first.
+  MAX_OUTPUT_TOKENS: 8192,
+  MAX_TRUNCATION_RETRIES: 2,
   MAX_TURN_GAP_MS: 60_000,
-  PROVIDER_TIMEOUT_MS: 30_000,
+  PROVIDER_TIMEOUT_MS: 120_000,
   TOOL_TIMEOUT_MS: 15_000,
   RECENT_CALL_WINDOW: 6,
   PER_USER_CONCURRENT: 2,
@@ -51,6 +56,15 @@ export const ASSISTANT_LIMITS = {
   CONFIRMATION_TTL_MS: 10 * 60 * 1000,
   MAX_HISTORY_MESSAGES: 80,
 };
+
+const TRUNCATION_RETRY_HINT =
+  'Your previous response was cut off at the output token limit before you finished. '
+  + 'Continue from where you stopped, and split the remaining work across several smaller '
+  + 'tool calls across turns rather than emitting it all at once. Do not repeat work you already completed.';
+
+const TRUNCATED_ARGS_HINT =
+  'The arguments for this call were cut off at the output token limit, so the call was not executed. '
+  + 'Retry with roughly half as many items, then continue with further calls until every item is created.';
 
 export interface AssistantToolMetadata {
   name: string;
@@ -388,6 +402,11 @@ export class AssistantRunner {
     const recentCallHashes: string[] = [];
     let lastTurnEnd = Date.now();
     let lastFinalMessage: AssistantMessageRecord | undefined;
+    // Truncation recovery: `retryHint` is injected into the next provider call
+    // only (never persisted), so the model learns its last response was cut off
+    // without the nudge showing up in the user's transcript.
+    let truncationRetries = 0;
+    let retryHint: string | undefined;
 
     for (let iter = 0; iter < ASSISTANT_LIMITS.MAX_ITERATIONS; iter++) {
       if (abortSignal?.aborted) {
@@ -403,6 +422,10 @@ export class AssistantRunner {
       // Rebuild chat history from DB on every iteration — keeps the truncation
       // policy simple and ensures confirmation/resume paths see fresh state.
       const messages = await this.buildChatHistory(conversationId);
+      if (retryHint) {
+        messages.push({ role: 'user', content: retryHint });
+        retryHint = undefined;
+      }
 
       emit(onStatusEvent, { type: 'provider_call_started', iteration: iter });
       let response: ChatResponse;
@@ -411,6 +434,7 @@ export class AssistantRunner {
           modelId: realModelId,
           messages,
           tools: this.tools,
+          maxTokens: ASSISTANT_LIMITS.MAX_OUTPUT_TOKENS,
           abortSignal,
           onThought: (update) => {
             emit(onStatusEvent, {
@@ -441,6 +465,29 @@ export class AssistantRunner {
         outputTokens: response.usage?.outputTokens,
       });
       lastFinalMessage = assistantMessage;
+
+      // A `max_tokens` stop means the provider cut generation off mid-response —
+      // it is never a completed answer. When a tool call survived the cut its
+      // arguments are usually half-written, and the schema check below reports
+      // the truncation; with no tool call at all we would otherwise return
+      // truncated text as a successful final message.
+      if (response.stopReason === 'max_tokens') {
+        if (response.toolCalls.length === 0) {
+          if (++truncationRetries > ASSISTANT_LIMITS.MAX_TRUNCATION_RETRIES) {
+            emit(onStatusEvent, { type: 'circuit_open', reason: 'output_truncated' });
+            const partial = await this.recordCircuitStop(
+              conversationId,
+              'the model kept running past its output limit. Ask for this in smaller pieces.',
+            );
+            return { kind: 'error', error: 'Output truncated repeatedly', partialMessage: partial };
+          }
+          retryHint = TRUNCATION_RETRY_HINT;
+          lastTurnEnd = Date.now();
+          continue;
+        }
+      } else {
+        truncationRetries = 0;
+      }
 
       if (response.toolCalls.length === 0) {
         await this.repo.touchConversation(conversationId);
@@ -490,13 +537,19 @@ export class AssistantRunner {
           const parsed = safeParseToolInput(tool, call.arguments);
           if (!parsed.ok) {
             const errMsg = (parsed as { ok: false; error: string }).error;
+            // Truncated arguments fail the schema check for a reason the model
+            // can act on — say so, otherwise it retries at the same size.
+            const truncatedArgs = response.stopReason === 'max_tokens';
             await this.repo.appendMessage({
               conversationId,
               role: 'tool',
               toolCallId: call.id,
               toolName: call.name,
               toolArgsJson: call.arguments,
-              content: wrapToolResult(call.name, JSON.stringify({ error: errMsg }), { error: true }),
+              content: wrapToolResult(call.name, JSON.stringify({
+                error: errMsg,
+                ...(truncatedArgs ? { truncated: true, hint: TRUNCATED_ARGS_HINT } : {}),
+              }), { error: true }),
               status: 'error',
             });
             processedCalls.push(call);

--- a/server/assistant/providers/openai.ts
+++ b/server/assistant/providers/openai.ts
@@ -15,6 +15,17 @@ import type { ChatMessage } from './types';
  * OpenAI-compatible; the Grok adapter subclasses this one with a different
  * default base URL.
  */
+/**
+ * GPT-5 and the o-series reject `max_tokens` outright and require
+ * `max_completion_tokens`. Everything else — including OpenAI-compatible
+ * third-party endpoints reached via a custom base URL — takes `max_tokens`.
+ */
+function outputTokenParam(modelId: string, maxTokens: number): Record<string, number> {
+  const id = modelId.toLowerCase();
+  const usesCompletionTokens = /^(gpt-5|o[1-9])/.test(id);
+  return usesCompletionTokens ? { max_completion_tokens: maxTokens } : { max_tokens: maxTokens };
+}
+
 export class OpenAIChatProvider implements ChatProvider {
   protected client: OpenAI;
 
@@ -35,7 +46,7 @@ export class OpenAIChatProvider implements ChatProvider {
         model: req.modelId,
         messages,
         ...(typeof req.temperature === 'number' ? { temperature: req.temperature } : {}),
-        ...(typeof req.maxTokens === 'number' ? { max_tokens: req.maxTokens } : {}),
+        ...(typeof req.maxTokens === 'number' ? outputTokenParam(req.modelId, req.maxTokens) : {}),
         ...(tools ? { tools, tool_choice: 'auto' as const } : {}),
       },
       { signal: req.abortSignal },

--- a/server/assistant/system-prompt.ts
+++ b/server/assistant/system-prompt.ts
@@ -89,6 +89,15 @@ Use this pattern for:
 
 Only wait for another user turn when information is missing, the target is ambiguous, or the user is still deciding.
 
+### Bulk creation across several batches
+
+When the user asks for more items than one tool call should carry (for example "add 100 prompts"), treat the requested count as the finish line, not the first batch:
+- state the full target and the batch plan in your proposal ("adding 100 prompts in batches of 25")
+- after each batch succeeds, immediately continue with the next batch in the same turn — do not stop to report partial progress or ask whether to keep going
+- check the count reported back by the tool against the target before you claim the work is done
+- when the run is finished, report the final total in one sentence
+- if a call comes back saying its arguments were truncated, retry that batch at about half the size and carry on
+
 The confirmation UI is the approval step. Your assistant text should explain the proposed change, not ask the user to answer "yes" again.
 
 Proposal text must be user-facing only:

--- a/server/mcp/tool-definitions.ts
+++ b/server/mcp/tool-definitions.ts
@@ -389,14 +389,14 @@ export function createAssistantToolDefinitions(deps: ToolDependencies): Assistan
   tools.push({
     name: 'batch_create_prompts',
     title: 'Batch Create Prompts',
-    description: 'Create multiple text prompts (library items) in a library in a single batch. Each item requires content; title and tags are optional. For extensive library construction, especially when creating more than 10 items, call this tool multiple times with smaller batches instead of generating every item in one call. Multiple batches keep the generated items more comprehensive and avoid model input/output limits.',
+    description: 'Create multiple text prompts (library items) in a library in a single batch. Each item requires content; title and tags are optional. Batches of about 20-25 items work best: large enough to finish a big library quickly, small enough to stay inside the output token limit and keep each prompt well written. When the user asks for more items than one batch should carry, keep calling this tool in later turns until the full requested count exists — the result reports libraryTotal so you can check progress against the target. Never stop at the first batch and report the job done while items remain.',
     inputSchema: {
       library_id: z.string().describe('The library ID to add the prompts to'),
       items: z.array(z.object({
         content: z.string().min(1).describe('The prompt text content'),
         title: z.string().optional().describe('Optional title for the prompt'),
         tags: z.array(z.string()).optional().describe('Optional tags for categorization'),
-      })).min(1).max(100).describe('Array of prompts to create (1-100 items). Prefer batches of 10 or fewer items; for larger library builds, call this tool repeatedly until all items are created.'),
+      })).min(1).max(100).describe('Array of prompts to create (1-100 items). Prefer batches of about 20-25 items; for larger library builds, call this tool repeatedly until all items are created.'),
     },
     annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: false },
     category: 'mutate',
@@ -416,13 +416,17 @@ export function createAssistantToolDefinitions(deps: ToolDependencies): Assistan
         tags: item.tags,
       }));
       await repository.createLibraryItemsBatch(userId, library_id, libraryItems);
+      // libraryTotal lets the model compare progress against the requested
+      // count and decide whether another batch is still owed.
+      const libraryTotal = (library.items?.length ?? 0) + libraryItems.length;
       return {
         text: JSON.stringify({
           library_id,
           name: library.name,
           created: libraryItems.map((item) => ({ id: item.id, title: item.title })),
           count: libraryItems.length,
-          message: `${libraryItems.length} prompts created successfully`,
+          libraryTotal,
+          message: `${libraryItems.length} prompts created successfully. Library now holds ${libraryTotal} prompts — if the user asked for more than that, continue with another batch.`,
         }),
       };
     },


### PR DESCRIPTION
Added:
- System prompt instructions for bulk batch creation logic
- Truncation retry mechanism to resume interrupted model responses
- Context hints for models to recover from token-limit cut-offs

Changed:
- Increased MAX_ITERATIONS and MAX_TOOL_CALLS to 1000
- Updated batch_create_prompts to report total library count
- Adjusted OpenAI provider to use max_completion_tokens for o-series
- Increased PROVIDER_TIMEOUT_MS to 120s for long-running tasks

Fixed:
- Output truncation handling for both text generation and tool arguments