### PR TITLE
Add page-number navigation to all paginated lists

### DIFF
--- a/src/components/PageNav.tsx
+++ b/src/components/PageNav.tsx
@@ -1,0 +1,158 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { ChevronLeft, ChevronRight, ChevronsLeft, ChevronsRight, MoreHorizontal } from 'lucide-react';
+
+const ELLIPSIS_JUMP = 5;
+
+type PageItem = number | 'left-gap' | 'right-gap';
+
+const range = (from: number, to: number): number[] =>
+  Array.from({ length: to - from + 1 }, (_, i) => from + i);
+
+/**
+ * Page numbers around the current page, with 1 / last always visible and gaps collapsed.
+ * Always emits the same number of slots so the bar keeps a stable width while paging.
+ */
+function buildPageItems(page: number, pages: number, siblings: number): PageItem[] {
+  // 1, last, current, siblings on both sides, plus a slot for each gap marker.
+  const slots = siblings * 2 + 5;
+  if (pages <= slots) return range(1, pages);
+
+  // Window of consecutive pages shown when one side is collapsed instead of two.
+  const edgeWindow = slots - 2;
+  if (page <= edgeWindow - siblings) return [...range(1, edgeWindow), 'right-gap', pages];
+  if (page > pages - edgeWindow + siblings) return [1, 'left-gap', ...range(pages - edgeWindow + 1, pages)];
+
+  return [1, 'left-gap', ...range(page - siblings, page + siblings), 'right-gap', pages];
+}
+
+interface PageNavProps {
+  page: number;
+  pages: number;
+  onPageChange: (page: number) => void;
+  /** 'lg' matches the roomier page-level layout, 'sm' the compact toolbars. */
+  size?: 'sm' | 'lg';
+  /** Page numbers shown on each side of the current page. */
+  siblings?: number;
+  className?: string;
+}
+
+export function PageNav({
+  page,
+  pages,
+  onPageChange,
+  size = 'sm',
+  siblings = 1,
+  className = '',
+}: PageNavProps) {
+  const { t } = useTranslation();
+
+  const effectivePages = Math.max(1, pages);
+  const safePage = Math.min(Math.max(1, page), effectivePages);
+  const isFirst = safePage <= 1;
+  const isLast = safePage >= effectivePages;
+
+  const goTo = (p: number) => {
+    const next = Math.min(Math.max(1, p), effectivePages);
+    if (next === safePage) return;
+    onPageChange(next);
+  };
+
+  const base =
+    size === 'lg'
+      ? 'w-11 h-11 rounded-xl text-sm'
+      : 'w-8 h-8 rounded-lg text-[11px]';
+  const idle =
+    'border border-neutral-200/50 dark:border-white/5 bg-white/40 dark:bg-neutral-900/40 text-neutral-600 dark:text-neutral-400 hover:text-neutral-900 dark:hover:text-white hover:bg-neutral-50 dark:hover:bg-neutral-800';
+  const control = `${base} ${idle} flex items-center justify-center font-black transition-all active:scale-95 disabled:opacity-20 disabled:cursor-not-allowed`;
+  const icon = size === 'lg' ? 'w-5 h-5' : 'w-4 h-4';
+
+  const items = buildPageItems(safePage, effectivePages, siblings);
+
+  return (
+    <div className={`flex items-center justify-center gap-1 ${className}`}>
+      <button
+        type="button"
+        onClick={() => goTo(1)}
+        disabled={isFirst}
+        aria-label={t('pagination.first')}
+        title={t('pagination.first')}
+        className={control}
+      >
+        <ChevronsLeft className={icon} />
+      </button>
+      <button
+        type="button"
+        onClick={() => goTo(safePage - 1)}
+        disabled={isFirst}
+        aria-label={t('pagination.prev')}
+        title={t('pagination.prev')}
+        className={control}
+      >
+        <ChevronLeft className={icon} />
+      </button>
+
+      {items.map((item) => {
+        if (item === 'left-gap' || item === 'right-gap') {
+          const target =
+            item === 'left-gap' ? safePage - ELLIPSIS_JUMP : safePage + ELLIPSIS_JUMP;
+          const label =
+            item === 'left-gap'
+              ? t('pagination.jumpBack', { n: ELLIPSIS_JUMP })
+              : t('pagination.jumpForward', { n: ELLIPSIS_JUMP });
+          return (
+            <button
+              key={item}
+              type="button"
+              onClick={() => goTo(target)}
+              aria-label={label}
+              title={label}
+              className={`${base} flex items-center justify-center text-neutral-400 dark:text-neutral-600 hover:text-neutral-900 dark:hover:text-white transition-colors`}
+            >
+              <MoreHorizontal className={icon} />
+            </button>
+          );
+        }
+
+        const isCurrent = item === safePage;
+        return (
+          <button
+            key={item}
+            type="button"
+            onClick={() => goTo(item)}
+            aria-label={t('pagination.goToPage', { page: item })}
+            aria-current={isCurrent ? 'page' : undefined}
+            className={`${base} flex items-center justify-center font-black tabular-nums transition-all active:scale-95 ${
+              isCurrent
+                ? 'border border-neutral-900 dark:border-white bg-neutral-900 dark:bg-white text-white dark:text-neutral-900'
+                : idle
+            }`}
+          >
+            {item}
+          </button>
+        );
+      })}
+
+      <button
+        type="button"
+        onClick={() => goTo(safePage + 1)}
+        disabled={isLast}
+        aria-label={t('pagination.next')}
+        title={t('pagination.next')}
+        className={control}
+      >
+        <ChevronRight className={icon} />
+      </button>
+      <button
+        type="button"
+        onClick={() => goTo(effectivePages)}
+        disabled={isLast}
+        aria-label={t('pagination.last')}
+        title={t('pagination.last')}
+        className={control}
+      >
+        <ChevronsRight className={icon} />
+      </button>
+    </div>
+  );
+}

--- a/src/components/ProjectViewer/PaginationBar.tsx
+++ b/src/components/ProjectViewer/PaginationBar.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { ChevronLeft, ChevronRight, ChevronsLeft, ChevronsRight } from 'lucide-react';
+import { PageNav } from '../PageNav';
 
 export const PAGE_SIZE_OPTIONS: (number | 'all')[] = [25, 50, 100, 200, 500, 'all'];
 
@@ -32,15 +32,6 @@ export function PaginationBar({
   const startIndex = (safePage - 1) * pageSize + 1;
   const endIndex = Math.min(total, safePage * pageSize);
 
-  const isFirst = safePage <= 1;
-  const isLast = safePage >= effectivePages;
-
-  const goTo = (p: number) => {
-    const next = Math.min(Math.max(1, p), effectivePages);
-    if (next === safePage) return;
-    onPageChange(next);
-  };
-
   return (
     <div className="flex flex-wrap items-center justify-between gap-3 border-t border-neutral-200 dark:border-neutral-800 bg-white/40 dark:bg-neutral-950/40 px-4 py-3">
       <div className="flex items-center gap-2 text-[10px] font-black uppercase tracking-widest text-neutral-500 dark:text-neutral-500">
@@ -66,46 +57,11 @@ export function PaginationBar({
           </select>
         </label>
 
-        <div className="flex items-center gap-1">
-          <button
-            type="button"
-            onClick={() => goTo(1)}
-            disabled={isFirst}
-            aria-label={t('pagination.first')}
-            className="w-8 h-8 rounded-lg border border-neutral-300 dark:border-neutral-700 bg-white/60 dark:bg-neutral-900/60 text-neutral-600 dark:text-neutral-300 hover:bg-neutral-100 dark:hover:bg-neutral-800 disabled:opacity-40 disabled:cursor-not-allowed flex items-center justify-center transition-colors"
-          >
-            <ChevronsLeft className="w-4 h-4" />
-          </button>
-          <button
-            type="button"
-            onClick={() => goTo(safePage - 1)}
-            disabled={isFirst}
-            aria-label={t('pagination.prev')}
-            className="w-8 h-8 rounded-lg border border-neutral-300 dark:border-neutral-700 bg-white/60 dark:bg-neutral-900/60 text-neutral-600 dark:text-neutral-300 hover:bg-neutral-100 dark:hover:bg-neutral-800 disabled:opacity-40 disabled:cursor-not-allowed flex items-center justify-center transition-colors"
-          >
-            <ChevronLeft className="w-4 h-4" />
-          </button>
-          <span className="px-3 text-[10px] font-black uppercase tracking-widest text-neutral-600 dark:text-neutral-300">
+        <div className="flex items-center gap-2">
+          <span className="text-[10px] font-black uppercase tracking-widest text-neutral-600 dark:text-neutral-300">
             {t('pagination.pageOf', { page: safePage, pages: effectivePages })}
           </span>
-          <button
-            type="button"
-            onClick={() => goTo(safePage + 1)}
-            disabled={isLast}
-            aria-label={t('pagination.next')}
-            className="w-8 h-8 rounded-lg border border-neutral-300 dark:border-neutral-700 bg-white/60 dark:bg-neutral-900/60 text-neutral-600 dark:text-neutral-300 hover:bg-neutral-100 dark:hover:bg-neutral-800 disabled:opacity-40 disabled:cursor-not-allowed flex items-center justify-center transition-colors"
-          >
-            <ChevronRight className="w-4 h-4" />
-          </button>
-          <button
-            type="button"
-            onClick={() => goTo(effectivePages)}
-            disabled={isLast}
-            aria-label={t('pagination.last')}
-            className="w-8 h-8 rounded-lg border border-neutral-300 dark:border-neutral-700 bg-white/60 dark:bg-neutral-900/60 text-neutral-600 dark:text-neutral-300 hover:bg-neutral-100 dark:hover:bg-neutral-800 disabled:opacity-40 disabled:cursor-not-allowed flex items-center justify-center transition-colors"
-          >
-            <ChevronsRight className="w-4 h-4" />
-          </button>
+          <PageNav page={safePage} pages={effectivePages} onPageChange={onPageChange} />
         </div>
       </div>
     </div>

--- a/src/locales/en/app.json
+++ b/src/locales/en/app.json
@@ -7,7 +7,10 @@
     "next": "Next page",
     "last": "Last page",
     "pageOf": "Page {{page}} / {{pages}}",
-    "range": "{{start}}–{{end}} of {{total}}"
+    "range": "{{start}}–{{end}} of {{total}}",
+    "goToPage": "Go to page {{page}}",
+    "jumpBack": "Back {{n}} pages",
+    "jumpForward": "Forward {{n}} pages"
   },
   "sidebar": {
     "home": "Home",

--- a/src/locales/fr/app.json
+++ b/src/locales/fr/app.json
@@ -7,7 +7,10 @@
     "next": "Page suivante",
     "last": "Dernière page",
     "pageOf": "Page {{page}} / {{pages}}",
-    "range": "{{start}}–{{end}} sur {{total}}"
+    "range": "{{start}}–{{end}} sur {{total}}",
+    "goToPage": "Aller à la page {{page}}",
+    "jumpBack": "Reculer de {{n}} pages",
+    "jumpForward": "Avancer de {{n}} pages"
   },
   "sidebar": {
     "home": "Accueil",

--- a/src/locales/ja/app.json
+++ b/src/locales/ja/app.json
@@ -7,7 +7,10 @@
     "next": "次のページ",
     "last": "最後のページ",
     "pageOf": "{{page}} / {{pages}} ページ",
-    "range": "{{total}} 件中 {{start}}–{{end}}"
+    "range": "{{total}} 件中 {{start}}–{{end}}",
+    "goToPage": "{{page}} ページへ移動",
+    "jumpBack": "{{n}} ページ戻る",
+    "jumpForward": "{{n}} ページ進む"
   },
   "sidebar": {
     "home": "ホーム",

--- a/src/locales/ko/app.json
+++ b/src/locales/ko/app.json
@@ -7,7 +7,10 @@
     "next": "다음 페이지",
     "last": "마지막 페이지",
     "pageOf": "{{page}} / {{pages}} 페이지",
-    "range": "{{total}}개 중 {{start}}–{{end}}"
+    "range": "{{total}}개 중 {{start}}–{{end}}",
+    "goToPage": "{{page}} 페이지로 이동",
+    "jumpBack": "{{n}} 페이지 뒤로",
+    "jumpForward": "{{n}} 페이지 앞으로"
   },
   "sidebar": {
     "home": "홈",

--- a/src/locales/zh-CN/app.json
+++ b/src/locales/zh-CN/app.json
@@ -7,7 +7,10 @@
     "next": "下一页",
     "last": "末页",
     "pageOf": "第 {{page}} / {{pages}} 页",
-    "range": "{{start}}–{{end}} / 共 {{total}}"
+    "range": "{{start}}–{{end}} / 共 {{total}}",
+    "goToPage": "前往第 {{page}} 页",
+    "jumpBack": "向前 {{n}} 页",
+    "jumpForward": "向后 {{n}} 页"
   },
   "sidebar": {
     "home": "首页",

--- a/src/locales/zh-TW/app.json
+++ b/src/locales/zh-TW/app.json
@@ -7,7 +7,10 @@
     "next": "下一頁",
     "last": "末頁",
     "pageOf": "第 {{page}} / {{pages}} 頁",
-    "range": "{{start}}–{{end}} / 共 {{total}}"
+    "range": "{{start}}–{{end}} / 共 {{total}}",
+    "goToPage": "前往第 {{page}} 頁",
+    "jumpBack": "向前 {{n}} 頁",
+    "jumpForward": "向後 {{n}} 頁"
   },
   "sidebar": {
     "home": "首頁",

--- a/src/pages/AdminUsers.tsx
+++ b/src/pages/AdminUsers.tsx
@@ -1,5 +1,5 @@
 import { FormEvent, ReactNode, useEffect, useMemo, useState } from 'react';
-import { AlertCircle, CheckCircle2, ChevronLeft, ChevronRight, Clock3, Filter, HardDrive, KeyRound, Loader2, Mail, Search, Shield, UserPlus, Users, X } from 'lucide-react';
+import { AlertCircle, CheckCircle2, Clock3, Filter, HardDrive, KeyRound, Loader2, Mail, Search, Shield, UserPlus, Users, X } from 'lucide-react';
 import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { adminResetUserPassword, createUser, getUserDetail, getUsers, updateUserRole, updateUserStatus, updateUserStorageLimit } from '../api';
@@ -8,6 +8,7 @@ import { useAuth } from '../contexts/AuthContext';
 import { UserDetail, UserRole, UserStatus, UserSummary } from '../types';
 import { PageHeader } from '../components/PageHeader';
 import { toast } from 'sonner';
+import { PageNav } from '../components/PageNav';
 
 type UserFilters = {
   q: string;
@@ -409,23 +410,12 @@ export function AdminUsers() {
               <option value={50}>{t('adminUsers.pageSize', { count: 50 })}</option>
               <option value={100}>{t('adminUsers.pageSize', { count: 100 })}</option>
             </select>
-            <button
-              type="button"
-              disabled={filters.page <= 1}
-              onClick={() => setFilters((current) => ({ ...current, page: Math.max(1, current.page - 1) }))}
-              className="rounded-xl border border-neutral-200 dark:border-neutral-800 bg-neutral-50 dark:bg-neutral-950 p-2 text-neutral-700 dark:text-neutral-300 transition hover:bg-white dark:hover:bg-neutral-800 hover:shadow-sm disabled:opacity-30"
-            >
-              <ChevronLeft className="h-4 w-4" />
-            </button>
             <span className="text-sm text-neutral-600 dark:text-neutral-400">{t('adminUsers.pagination', { current: filters.page, total: pages })}</span>
-            <button
-              type="button"
-              disabled={filters.page >= pages}
-              onClick={() => setFilters((current) => ({ ...current, page: Math.min(pages, current.page + 1) }))}
-              className="rounded-xl border border-neutral-200 dark:border-neutral-800 bg-neutral-50 dark:bg-neutral-950 p-2 text-neutral-700 dark:text-neutral-300 transition hover:bg-white dark:hover:bg-neutral-800 hover:shadow-sm disabled:opacity-30"
-            >
-              <ChevronRight className="h-4 w-4" />
-            </button>
+            <PageNav
+              page={filters.page}
+              pages={pages}
+              onPageChange={(nextPage) => setFilters((current) => ({ ...current, page: nextPage }))}
+            />
           </div>
         </div>
       </div>

--- a/src/pages/CampaignBatchActions.tsx
+++ b/src/pages/CampaignBatchActions.tsx
@@ -26,6 +26,7 @@ import { BatchAiGenerateModal } from '../components/BatchAiGenerateModal';
 import { BatchScheduleModal } from '../components/BatchScheduleModal';
 import { PageHeader } from '../components/PageHeader';
 import { cn } from '../lib/utils';
+import { PageNav } from '../components/PageNav';
 
 interface BatchPost {
   id: string;
@@ -522,25 +523,14 @@ export function CampaignBatchActions() {
               Showing {totalPosts === 0 ? 0 : (page - 1) * pageSize + 1}-{Math.min(page * pageSize, totalPosts)} of {totalPosts}
             </div>
             <div className="flex items-center gap-2">
-              <button
-                type="button"
-                disabled={page <= 1}
-                className="rounded-lg border border-neutral-200 px-3 py-1.5 font-bold text-neutral-700 transition hover:bg-neutral-100 disabled:opacity-40 dark:border-white/10 dark:text-neutral-200 dark:hover:bg-white/10"
-                onClick={() => updateQuery({ page: String(page - 1) })}
-              >
-                Previous
-              </button>
               <span className="px-2 text-xs font-black uppercase tracking-widest">
                 Page {page} / {Math.max(1, totalPages)}
               </span>
-              <button
-                type="button"
-                disabled={page >= totalPages}
-                className="rounded-lg border border-neutral-200 px-3 py-1.5 font-bold text-neutral-700 transition hover:bg-neutral-100 disabled:opacity-40 dark:border-white/10 dark:text-neutral-200 dark:hover:bg-white/10"
-                onClick={() => updateQuery({ page: String(page + 1) })}
-              >
-                Next
-              </button>
+              <PageNav
+                page={page}
+                pages={Math.max(1, totalPages)}
+                onPageChange={(nextPage) => updateQuery({ page: String(nextPage) })}
+              />
             </div>
           </div>
         </section>

--- a/src/pages/CampaignDetail.tsx
+++ b/src/pages/CampaignDetail.tsx
@@ -43,6 +43,7 @@ import { PageHeader } from '../components/PageHeader';
 import { cn } from '../lib/utils';
 import { applyAvatarFallback, defaultAvatar } from '../lib/avatar';
 import { getPlatformIcon } from '../lib/platform';
+import { PageNav } from '../components/PageNav';
 
 type StatusFilter = 'all' | 'draft' | 'scheduled' | 'queued' | 'completed' | 'failed';
 type SortKey = 'scheduled_asc' | 'scheduled_desc' | 'created_desc' | 'created_asc';
@@ -979,25 +980,14 @@ export function CampaignDetail() {
                   </select>
                 </div>
                 <div className="flex items-center gap-2">
-                  <button
-                    type="button"
-                    disabled={page <= 1 || postsLoading}
-                    className="rounded-lg border border-neutral-200 px-3 py-1.5 font-bold text-neutral-700 transition hover:bg-neutral-100 disabled:opacity-40 dark:border-white/10 dark:text-neutral-200 dark:hover:bg-white/10"
-                    onClick={() => updateQuery({ page: String(page - 1) })}
-                  >
-                    Previous
-                  </button>
                   <span className="px-2 text-xs font-black uppercase tracking-widest">
                     Page {page} / {Math.max(1, totalPages)}
                   </span>
-                  <button
-                    type="button"
-                    disabled={page >= totalPages || postsLoading}
-                    className="rounded-lg border border-neutral-200 px-3 py-1.5 font-bold text-neutral-700 transition hover:bg-neutral-100 disabled:opacity-40 dark:border-white/10 dark:text-neutral-200 dark:hover:bg-white/10"
-                    onClick={() => updateQuery({ page: String(page + 1) })}
-                  >
-                    Next
-                  </button>
+                  <PageNav
+                    page={page}
+                    pages={Math.max(1, totalPages)}
+                    onPageChange={(nextPage) => updateQuery({ page: String(nextPage) })}
+                  />
                 </div>
               </div>
             </div>

--- a/src/pages/CampaignHistory.tsx
+++ b/src/pages/CampaignHistory.tsx
@@ -19,6 +19,7 @@ import { PageHeader } from '../components/PageHeader';
 import { cn } from '../lib/utils';
 import { applyAvatarFallback, defaultAvatar } from '../lib/avatar';
 import { getPlatformIcon, fallbackExternalUrl } from '../lib/platform';
+import { PageNav } from '../components/PageNav';
 
 export function CampaignHistory() {
   const navigate = useNavigate();
@@ -298,38 +299,7 @@ export function CampaignHistory() {
               <span className="text-[11px] font-medium text-neutral-500">
                 Showing {(page - 1) * pageSize + 1}-{Math.min(page * pageSize, total)} of {total}
               </span>
-              <div className="flex items-center gap-1.5">
-                <button
-                  disabled={page === 1}
-                  onClick={() => updatePage(page - 1)}
-                  className="h-7 px-2.5 rounded-lg border border-neutral-200 text-[11px] font-bold text-neutral-600 disabled:opacity-30 dark:border-white/10 dark:text-neutral-400 transition-colors"
-                >
-                  Prev
-                </button>
-                <div className="flex items-center gap-1">
-                  {Array.from({ length: totalPages }).map((_, i) => (
-                    <button
-                      key={i}
-                      onClick={() => updatePage(i + 1)}
-                      className={cn(
-                        "h-7 w-7 rounded-lg text-[11px] font-bold transition-colors",
-                        page === i + 1
-                          ? "bg-indigo-600 text-white"
-                          : "text-neutral-500 hover:bg-neutral-100 dark:hover:bg-white/5"
-                      )}
-                    >
-                      {i + 1}
-                    </button>
-                  ))}
-                </div>
-                <button
-                  disabled={page === totalPages}
-                  onClick={() => updatePage(page + 1)}
-                  className="h-7 px-2.5 rounded-lg border border-neutral-200 text-[11px] font-bold text-neutral-600 disabled:opacity-30 dark:border-white/10 dark:text-neutral-400 transition-colors"
-                >
-                  Next
-                </button>
-              </div>
+              <PageNav page={page} pages={totalPages} onPageChange={updatePage} />
             </div>
           )}
         </div>

--- a/src/pages/ChatHistoryPage.tsx
+++ b/src/pages/ChatHistoryPage.tsx
@@ -1,9 +1,10 @@
 import { useState, useEffect } from 'react';
 import { Link, useSearchParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
-import { ChevronLeft, ChevronRight, Loader2, MessageCircle, Search } from 'lucide-react';
+import { Loader2, MessageCircle, Search } from 'lucide-react';
 import { searchAssistantConversations, AssistantConversation } from '../api';
 import { PageHeader } from '../components/PageHeader';
+import { PageNav } from '../components/PageNav';
 
 const PAGE_SIZE = 20;
 
@@ -154,15 +155,8 @@ export function ChatHistoryPage() {
         )}
 
         {pages > 1 && (
-          <div className="flex items-center justify-center gap-4 pt-4">
-            <button
-              onClick={() => handlePageChange(Math.max(1, page - 1))}
-              disabled={page === 1}
-              className="p-3 bg-white/40 dark:bg-neutral-900/40 backdrop-blur-3xl border border-neutral-200/50 dark:border-white/5 rounded-xl text-neutral-600 dark:text-neutral-400 hover:text-neutral-900 dark:hover:text-white hover:bg-neutral-50 dark:hover:bg-neutral-800 disabled:opacity-20 disabled:cursor-not-allowed shadow-sm transition-all active:scale-95"
-              aria-label={t('chatHistory.previous', { defaultValue: 'Previous page' })}
-            >
-              <ChevronLeft className="w-5 h-5" />
-            </button>
+          <div className="flex flex-col items-center gap-3 pt-4">
+            <PageNav page={page} pages={pages} onPageChange={handlePageChange} size="lg" />
             <span className="text-xs font-black uppercase tracking-[0.2em] text-neutral-500 dark:text-neutral-500">
               {t('chatHistory.pagination', {
                 defaultValue: 'Page {{current}} of {{total}}',
@@ -170,14 +164,6 @@ export function ChatHistoryPage() {
                 total: pages,
               })}
             </span>
-            <button
-              onClick={() => handlePageChange(Math.min(pages, page + 1))}
-              disabled={page === pages}
-              className="p-3 bg-white/40 dark:bg-neutral-900/40 backdrop-blur-3xl border border-neutral-200/50 dark:border-white/5 rounded-xl text-neutral-600 dark:text-neutral-400 hover:text-neutral-900 dark:hover:text-white hover:bg-neutral-50 dark:hover:bg-neutral-800 disabled:opacity-20 disabled:cursor-not-allowed shadow-sm transition-all active:scale-95"
-              aria-label={t('chatHistory.next', { defaultValue: 'Next page' })}
-            >
-              <ChevronRight className="w-5 h-5" />
-            </button>
           </div>
         )}
       </div>

--- a/src/pages/Exports.tsx
+++ b/src/pages/Exports.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
-import { Download, Loader2, CheckCircle2, XCircle, Trash2, Clock, ArrowRight, List, ChevronLeft, ChevronRight, HardDrive, Link2Off, Upload, Store as StoreIcon, Tag, History as HistoryIcon } from 'lucide-react';
+import { Download, Loader2, CheckCircle2, XCircle, Trash2, Clock, ArrowRight, List, HardDrive, Link2Off, Upload, Store as StoreIcon, Tag, History as HistoryIcon } from 'lucide-react';
 import { Link, useSearchParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { ExportTask, DeliveryStatus } from '../types';
@@ -8,6 +8,7 @@ import { PageHeader } from '../components/PageHeader';
 import { useAuth } from '../contexts/AuthContext';
 import { ConfirmModal } from '../components/ConfirmModal';
 import { toast } from 'sonner';
+import { PageNav } from '../components/PageNav';
 
 const EXPORTS_PAGE_SIZE = 15;
 
@@ -587,22 +588,9 @@ export function Exports() {
              </div>
           )}
           {pages > 1 && (
-            <div className="flex items-center justify-center gap-4 pt-8 pb-4">
-              <button
-                onClick={() => handlePageChange(Math.max(1, page - 1))}
-                disabled={page === 1}
-                className="p-3 bg-white/40 dark:bg-neutral-900/40 backdrop-blur-3xl border border-neutral-200/50 dark:border-white/5 rounded-xl text-neutral-600 dark:text-neutral-400 hover:text-neutral-900 dark:hover:text-white hover:bg-neutral-50 dark:hover:bg-neutral-800 disabled:opacity-20 disabled:cursor-not-allowed shadow-sm transition-all active:scale-95"
-              >
-                <ChevronLeft className="w-5 h-5" />
-              </button>
+            <div className="flex flex-col items-center gap-3 pt-8 pb-4">
+              <PageNav page={page} pages={pages} onPageChange={handlePageChange} size="lg" />
               <span className="text-xs font-black uppercase tracking-[0.2em] text-neutral-500 dark:text-neutral-500">{t('exports.pagination', { current: page, total: pages })}</span>
-              <button
-                onClick={() => handlePageChange(Math.min(pages, page + 1))}
-                disabled={page === pages}
-                className="p-3 bg-white/40 dark:bg-neutral-900/40 backdrop-blur-3xl border border-neutral-200/50 dark:border-white/5 rounded-xl text-neutral-600 dark:text-neutral-400 hover:text-neutral-900 dark:hover:text-white hover:bg-neutral-50 dark:hover:bg-neutral-800 disabled:opacity-20 disabled:cursor-not-allowed shadow-sm transition-all active:scale-95"
-              >
-                <ChevronRight className="w-5 h-5" />
-              </button>
             </div>
           )}
         </div>

--- a/src/pages/Libraries.tsx
+++ b/src/pages/Libraries.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { Library } from '../types';
-import { Plus, Folder, LayoutGrid, ChevronRight, ChevronLeft, Loader2, Search } from 'lucide-react';
+import { Plus, Folder, LayoutGrid, Loader2, Search } from 'lucide-react';
 import { duplicateLibrary, fetchLibraries, setLibraryPinned, deleteLibrary, fetchLibraryReferences } from '../api';
 import { ConfirmModal } from '../components/ConfirmModal';
 import type { BoundContext } from '../components/Assistant/AssistantComposer';
@@ -10,6 +10,7 @@ import { DuplicateLibraryDialog } from '../components/DuplicateLibraryDialog';
 import { PageHeader } from '../components/PageHeader';
 import { LibraryCard } from '../components/EntityCards';
 import { toast } from 'sonner';
+import { PageNav } from '../components/PageNav';
 
 const MAX_PINNED_LIBRARIES = 6;
 
@@ -246,22 +247,9 @@ export function Libraries() {
               </div>
 
               {pages > 1 && (
-                <div className="flex items-center justify-center gap-4 pt-8 pb-4">
-                  <button
-                    onClick={() => handlePageChange(Math.max(1, page - 1))}
-                    disabled={page === 1}
-                    className="p-3 bg-white/40 dark:bg-neutral-900/40 backdrop-blur-3xl border border-neutral-200/50 dark:border-white/5 rounded-xl text-neutral-600 dark:text-neutral-400 hover:text-neutral-900 dark:hover:text-white hover:bg-neutral-50 dark:hover:bg-neutral-800 disabled:opacity-20 disabled:cursor-not-allowed shadow-sm transition-all active:scale-95"
-                  >
-                    <ChevronLeft className="w-5 h-5" />
-                  </button>
+                <div className="flex flex-col items-center gap-3 pt-8 pb-4">
+                  <PageNav page={page} pages={pages} onPageChange={handlePageChange} size="lg" />
                   <span className="text-xs font-black uppercase tracking-[0.2em] text-neutral-500 dark:text-neutral-500">{t('projects.pagination', { current: page, total: pages })}</span>
-                  <button
-                    onClick={() => handlePageChange(Math.min(pages, page + 1))}
-                    disabled={page === pages}
-                    className="p-3 bg-white/40 dark:bg-neutral-900/40 backdrop-blur-3xl border border-neutral-200/50 dark:border-white/5 rounded-xl text-neutral-600 dark:text-neutral-400 hover:text-neutral-900 dark:hover:text-white hover:bg-neutral-50 dark:hover:bg-neutral-800 disabled:opacity-20 disabled:cursor-not-allowed shadow-sm transition-all active:scale-95"
-                  >
-                    <ChevronRight className="w-5 h-5" />
-                  </button>
                 </div>
               )}
             </>

--- a/src/pages/Projects.tsx
+++ b/src/pages/Projects.tsx
@@ -3,9 +3,10 @@ import { Link, useNavigate, useSearchParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
 import { Project } from '../types';
-import { Activity, Plus, Play, Clock, ChevronLeft, ChevronRight, Loader2, Search } from 'lucide-react';
+import { Activity, Plus, Play, Clock, Loader2, Search } from 'lucide-react';
 import { fetchProjects, updateProject, deleteProject } from '../api';
 import { PageHeader } from '../components/PageHeader';
+import { PageNav } from '../components/PageNav';
 import type { BoundContext } from '../components/Assistant/AssistantComposer';
 import { ProjectCard } from '../components/EntityCards';
 import { ConfirmDialog } from '../components/ConfirmDialog';
@@ -263,22 +264,9 @@ export function Projects() {
               </div>
               
               {pages > 1 && (
-                <div className="flex items-center justify-center gap-4 pt-8 pb-4">
-                  <button
-                    onClick={() => handlePageChange(Math.max(1, page - 1))}
-                    disabled={page === 1}
-                    className="p-3 bg-white/40 dark:bg-neutral-900/40 backdrop-blur-3xl border border-neutral-200/50 dark:border-white/5 rounded-xl text-neutral-600 dark:text-neutral-400 hover:text-neutral-900 dark:hover:text-white hover:bg-neutral-50 dark:hover:bg-neutral-800 disabled:opacity-20 disabled:cursor-not-allowed shadow-sm transition-all active:scale-95"
-                  >
-                    <ChevronLeft className="w-5 h-5" />
-                  </button>
+                <div className="flex flex-col items-center gap-3 pt-8 pb-4">
+                  <PageNav page={page} pages={pages} onPageChange={handlePageChange} size="lg" />
                   <span className="text-xs font-black uppercase tracking-[0.2em] text-neutral-500 dark:text-neutral-500">{t('projects.pagination', { current: page, total: pages })}</span>
-                  <button
-                    onClick={() => handlePageChange(Math.min(pages, page + 1))}
-                    disabled={page === pages}
-                    className="p-3 bg-white/40 dark:bg-neutral-900/40 backdrop-blur-3xl border border-neutral-200/50 dark:border-white/5 rounded-xl text-neutral-600 dark:text-neutral-400 hover:text-neutral-900 dark:hover:text-white hover:bg-neutral-50 dark:hover:bg-neutral-800 disabled:opacity-20 disabled:cursor-not-allowed shadow-sm transition-all active:scale-95"
-                  >
-                    <ChevronRight className="w-5 h-5" />
-                  </button>
                 </div>
               )}
             </>

--- a/src/pages/ScheduledPosts.tsx
+++ b/src/pages/ScheduledPosts.tsx
@@ -24,6 +24,7 @@ import { toast } from 'sonner';
 import { fetchScheduledPosts, fetchScheduledPostCounts } from '../api';
 import { PageHeader } from '../components/PageHeader';
 import { cn } from '../lib/utils';
+import { PageNav } from '../components/PageNav';
 
 type ViewMode = 'list' | 'calendar';
 
@@ -328,22 +329,7 @@ export function ScheduledPosts() {
               {totalPages > 1 && (
                 <div className="px-6 py-4 border-t border-neutral-100 dark:border-white/5 bg-neutral-50/30 flex items-center justify-between">
                   <span className="text-xs text-neutral-500">Page {page} of {totalPages}</span>
-                  <div className="flex items-center gap-2">
-                    <button
-                      disabled={page === 1}
-                      onClick={() => updatePage(page - 1)}
-                      className="h-8 px-4 rounded-lg border border-neutral-200 text-xs font-bold disabled:opacity-30 dark:border-white/10"
-                    >
-                      Prev
-                    </button>
-                    <button
-                      disabled={page === totalPages}
-                      onClick={() => updatePage(page + 1)}
-                      className="h-8 px-4 rounded-lg border border-neutral-200 text-xs font-bold disabled:opacity-30 dark:border-white/10"
-                    >
-                      Next
-                    </button>
-                  </div>
+                  <PageNav page={page} pages={totalPages} onPageChange={updatePage} />
                 </div>
               )}
             </div>

--- a/src/pages/StoreUploadHistory.tsx
+++ b/src/pages/StoreUploadHistory.tsx
@@ -1,10 +1,11 @@
 import { useEffect, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
-import { CheckCircle2, ChevronLeft, ChevronRight, Clock, ExternalLink, History as HistoryIcon, List, Loader2, Store as StoreIcon, XCircle } from 'lucide-react';
+import { CheckCircle2, Clock, ExternalLink, History as HistoryIcon, List, Loader2, Store as StoreIcon, XCircle } from 'lucide-react';
 import { toast } from 'sonner';
 import { fetchStoreUploads, StoreUploadHistoryItem } from '../api';
 import { PageHeader } from '../components/PageHeader';
+import { PageNav } from '../components/PageNav';
 
 const PAGE_SIZE = 20;
 
@@ -176,24 +177,11 @@ export function StoreUploadHistory() {
           })}
 
           {pages > 1 && (
-            <div className="flex items-center justify-center gap-4 pt-8 pb-4">
-              <button
-                onClick={() => handlePageChange(Math.max(1, page - 1))}
-                disabled={page === 1}
-                className="p-3 bg-white/40 dark:bg-neutral-900/40 backdrop-blur-3xl border border-neutral-200/50 dark:border-white/5 rounded-xl text-neutral-600 dark:text-neutral-400 hover:text-neutral-900 dark:hover:text-white hover:bg-neutral-50 dark:hover:bg-neutral-800 disabled:opacity-20 disabled:cursor-not-allowed shadow-sm transition-all active:scale-95"
-              >
-                <ChevronLeft className="w-5 h-5" />
-              </button>
+            <div className="flex flex-col items-center gap-3 pt-8 pb-4">
+              <PageNav page={page} pages={pages} onPageChange={handlePageChange} size="lg" />
               <span className="text-xs font-black uppercase tracking-[0.2em] text-neutral-500 dark:text-neutral-500">
                 {t('exports.pagination', { current: page, total: pages })}
               </span>
-              <button
-                onClick={() => handlePageChange(Math.min(pages, page + 1))}
-                disabled={page === pages}
-                className="p-3 bg-white/40 dark:bg-neutral-900/40 backdrop-blur-3xl border border-neutral-200/50 dark:border-white/5 rounded-xl text-neutral-600 dark:text-neutral-400 hover:text-neutral-900 dark:hover:text-white hover:bg-neutral-50 dark:hover:bg-neutral-800 disabled:opacity-20 disabled:cursor-not-allowed shadow-sm transition-all active:scale-95"
-              >
-                <ChevronRight className="w-5 h-5" />
-              </button>
             </div>
           )}
         </div>


### PR DESCRIPTION
## What

Adds a shared `PageNav` component and uses it for every paginated list in the app. Lists that previously offered only prev/next arrows now show clickable page numbers.

`PageNav` renders: first / prev, a window of page numbers, next / last. Long ranges collapse to an ellipsis button that jumps 5 pages per click. The current page is highlighted and marked with `aria-current="page"`; every control has an `aria-label`.

## Why

Jumping to a specific page meant clicking the arrow repeatedly — on a list with 40 pages, reaching the end took 39 clicks.

Two smaller issues fixed along the way:

- **Campaign history** did render page numbers, but rendered *all* of them (`Array.from({ length: totalPages })`). With a few hundred pages that overflows the row.
- The page window is **constant width**. A naive window alternates between 4 and 7 buttons as you page, which makes the bar visibly shift under the cursor.

## Where

| File | Before |
|---|---|
| `src/pages/Projects.tsx` | prev/next arrows |
| `src/pages/Libraries.tsx` | prev/next arrows |
| `src/pages/Exports.tsx` | prev/next arrows |
| `src/pages/StoreUploadHistory.tsx` | prev/next arrows |
| `src/pages/ChatHistoryPage.tsx` | prev/next arrows |
| `src/pages/AdminUsers.tsx` | prev/next arrows |
| `src/pages/CampaignDetail.tsx` | Previous / Next text buttons |
| `src/pages/CampaignBatchActions.tsx` | Previous / Next text buttons |
| `src/pages/ScheduledPosts.tsx` | Prev / Next text buttons |
| `src/pages/CampaignHistory.tsx` | all page numbers, unbounded |
| `src/components/ProjectViewer/PaginationBar.tsx` | first/prev/next/last arrows |

Deliberately left alone — these use chevrons but are not pagination: the back arrow in `LibraryImportExport`, item reordering in `SellExport`, month navigation in the `ScheduledPosts` calendar, and image stepping in `ImageLightbox`.

## Notes for review

- `size="lg"` is used on full-page lists, the default `sm` inside toolbars and bars, to match the surrounding controls.
- New i18n keys `pagination.goToPage` / `jumpBack` / `jumpForward` added for all six locales. They interpolate `{{n}}` rather than `{{count}}` on purpose — `count` triggers i18next's plural resolution, which would need `_one` / `_other` variants per locale.
- The page-window function was checked exhaustively over 1/2/5/7/8/9/20/100 pages x every page: the current page is always present, first and last are always visible, numbers are strictly increasing, and the slot count is constant.
- `npx tsc --noEmit`, `npm run i18n:check`, and `npx vite build` all pass. Not verified against a running server — the dev server needs a database and I did not touch that setup, so a quick visual pass on one list would be worth it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)