### PR TITLE
fix(assistant): show new-chat and search buttons in mobile chat drawer

### DIFF
--- a/src/pages/AssistantPage.tsx
+++ b/src/pages/AssistantPage.tsx
@@ -1612,7 +1612,7 @@ export function AssistantPage() {
 
       {/* ─── Right Panel: Conversations & Config ─── */}
       <div className={`
-        fixed inset-y-0 right-0 z-40 lg:static
+        fixed top-16 bottom-0 right-0 z-40 lg:static
         ${rightPanelOpen ? 'translate-x-0 w-[85vw] sm:w-80 lg:w-64' : 'translate-x-full lg:translate-x-0 w-[85vw] sm:w-80 lg:w-16'}
         flex-shrink-0 border-l border-neutral-200/50 dark:border-white/5
         bg-white dark:bg-neutral-950 lg:bg-white/10 lg:dark:bg-black/10 backdrop-blur-xl


### PR DESCRIPTION
## What

The conversations drawer on the chat page (`src/pages/AssistantPage.tsx`) was positioned `fixed inset-y-0 right-0 z-40`, so it started at the top of the viewport. On mobile, the app's own header is `fixed top-0 h-16 z-[100]` (`src/components/MainLayout.tsx:183`) and painted over the drawer's top 64px — the row holding the "Conversations" title plus the search (→ `/assistant/history`) and new-chat buttons.

The conversation list below that row rendered fine, which is why only those two controls looked missing.

## Change

`fixed inset-y-0 right-0 z-40 lg:static` → `fixed top-16 bottom-0 right-0 z-40 lg:static`

The drawer now starts below the app header on mobile. `lg:static` ignores the offsets, so the desktop layout is untouched.

## Notes for reviewers

- One-line CSS class change; no logic touched.
- Not verified in the running app — the local instance is behind a sign-in wall. Worth a quick manual check: mobile width, open the drawer from the header toggle, confirm the title row with search + `+` is visible and the hamburger is still reachable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)