### PR TITLE
fix: make pagination and library text list usable on phones

### DIFF
--- a/src/components/LibraryEditor.tsx
+++ b/src/components/LibraryEditor.tsx
@@ -3,8 +3,9 @@ import { createPortal } from 'react-dom';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { Library, LibraryItem } from '../types';
-import { Trash2, Plus, Image as ImageIcon, Edit3, Settings, Search, ArrowRight, ArrowLeft, Loader2, X, AlertCircle, Play, UploadCloud, Tag as TagIcon, CheckSquare, Square, ChevronDown, Copy, Music, Video, FileArchive, FileText, Stars, Filter, ArrowDownNarrowWide, Check } from 'lucide-react';
+import { Trash2, Plus, Image as ImageIcon, Edit3, Settings, Search, ArrowRight, Loader2, X, AlertCircle, Play, UploadCloud, Tag as TagIcon, CheckSquare, Square, ChevronDown, Copy, Music, Video, FileArchive, FileText, Stars, Filter, ArrowDownNarrowWide, Check } from 'lucide-react';
 import { ConfirmModal } from './ConfirmModal';
+import { PageNav } from './PageNav';
 import { TagModal } from './TagModal';
 import { PageHeader } from './PageHeader';
 import { saveImage, saveVideo, saveAudio, createLibraryItem, deleteLibraryItem as apiDeleteLibraryItem, updateLibraryItem, duplicateLibrary, fetchLibraryItems, imageDisplayUrl, exportMediaLibraryZip, copyLibraryItems, moveLibraryItems, fetchLibraryReferences } from '../api';
@@ -788,7 +789,7 @@ export function LibraryEditor({ library, onUpdate, onDelete }: Props) {
                     </div>
                   ) : (
                     <div
-                      className="h-11 px-3 md:px-4 flex items-center gap-3 cursor-pointer"
+                      className="px-3 py-2.5 md:px-4 sm:h-11 sm:py-0 flex items-start sm:items-center gap-3 cursor-pointer"
                       onClick={(e) => {
                         if (e.metaKey || e.ctrlKey || e.shiftKey) toggleItemSelection(item.id, index, e);
                         else setViewingItemId(item.id);
@@ -796,7 +797,7 @@ export function LibraryEditor({ library, onUpdate, onDelete }: Props) {
                     >
                         <div
                           onClick={(e) => toggleItemSelection(item.id, index, e)}
-                          className="p-1 -m-1 hover:bg-neutral-200/60 dark:hover:bg-neutral-800 transition-colors cursor-pointer shrink-0"
+                          className="p-1 -m-1 mt-0.5 sm:mt-0 hover:bg-neutral-200/60 dark:hover:bg-neutral-800 transition-colors cursor-pointer shrink-0"
                         >
                           {isSelected ? (
                             <CheckSquare className="w-4 h-4 text-blue-500" />
@@ -804,28 +805,31 @@ export function LibraryEditor({ library, onUpdate, onDelete }: Props) {
                             <Square className="w-4 h-4 text-neutral-400 dark:text-neutral-600" />
                           )}
                         </div>
-                        {item.title && (
-                          <span className="text-sm font-medium text-neutral-900 dark:text-white truncate shrink-0 max-w-[30%]">
-                            {item.title}
+                        {/* Phones stack title over a two-line preview; from sm up this is the original single-line row. */}
+                        <div className="flex flex-col sm:flex-row sm:items-center gap-1 sm:gap-3 flex-1 min-w-0">
+                          {item.title && (
+                            <span className="text-sm font-medium text-neutral-900 dark:text-white truncate sm:shrink-0 sm:max-w-[30%]">
+                              {item.title}
+                            </span>
+                          )}
+                          <span className="text-sm text-neutral-600 dark:text-neutral-400 line-clamp-2 sm:line-clamp-none sm:truncate sm:flex-1 sm:min-w-0">
+                            {item.content}
                           </span>
-                        )}
-                        <span className="text-sm text-neutral-600 dark:text-neutral-400 truncate flex-1 min-w-0">
-                          {item.content}
-                        </span>
-                        {(item.tags && item.tags.length > 0) && (
-                          <span className="hidden sm:flex items-center gap-1.5 shrink-0">
-                            <span className="px-1.5 py-0.5 bg-neutral-100 dark:bg-neutral-800 text-neutral-600 dark:text-neutral-400 text-[11px] truncate max-w-[100px]">{item.tags[0]}</span>
-                            {item.tags.length > 1 && (
-                              <span className="text-[11px] text-neutral-500 dark:text-neutral-600">+{item.tags.length - 1}</span>
-                            )}
-                          </span>
-                        )}
-                        {updatedAtLabel && (
-                          <span className="hidden md:block text-[11px] text-neutral-500 dark:text-neutral-600 tabular-nums whitespace-nowrap shrink-0">
-                            {updatedAtLabel}
-                          </span>
-                        )}
-                        <div className="flex items-center gap-0.5 shrink-0 opacity-0 group-hover/item:opacity-100 transition-opacity">
+                          {(item.tags && item.tags.length > 0) && (
+                            <span className="hidden sm:flex items-center gap-1.5 shrink-0">
+                              <span className="px-1.5 py-0.5 bg-neutral-100 dark:bg-neutral-800 text-neutral-600 dark:text-neutral-400 text-[11px] truncate max-w-[100px]">{item.tags[0]}</span>
+                              {item.tags.length > 1 && (
+                                <span className="text-[11px] text-neutral-500 dark:text-neutral-600">+{item.tags.length - 1}</span>
+                              )}
+                            </span>
+                          )}
+                          {updatedAtLabel && (
+                            <span className="hidden md:block text-[11px] text-neutral-500 dark:text-neutral-600 tabular-nums whitespace-nowrap shrink-0">
+                              {updatedAtLabel}
+                            </span>
+                          )}
+                          {/* Touch devices never hover, so the actions stay visible on phones. */}
+                          <div className="flex items-center gap-0.5 shrink-0 self-end -mr-1 sm:self-auto sm:mr-0 sm:opacity-0 sm:group-hover/item:opacity-100 transition-opacity">
                           <button
                             onClick={(e) => {
                               e.stopPropagation();
@@ -858,6 +862,7 @@ export function LibraryEditor({ library, onUpdate, onDelete }: Props) {
                           >
                             <Trash2 className="w-4 h-4" />
                           </button>
+                          </div>
                         </div>
                     </div>
                   )}
@@ -883,36 +888,11 @@ export function LibraryEditor({ library, onUpdate, onDelete }: Props) {
 
         {/* Pagination */}
         {totalPages > 1 && (
-          <div className="flex items-center justify-center gap-6 pt-12">
-            <button
-              onClick={() => setCurrentPage(prev => Math.max(1, prev - 1))}
-              disabled={currentPage === 1}
-              className="p-3 bg-white dark:bg-neutral-900 border border-neutral-200 dark:border-neutral-800 text-neutral-500 dark:text-neutral-500 hover:text-neutral-900 dark:hover:text-white hover:border-neutral-400 dark:hover:border-neutral-700 transition-colors disabled:opacity-30 disabled:cursor-not-allowed active:scale-95"
-            >
-              <ArrowLeft className="w-5 h-5" />
-            </button>
-            <div className="flex items-center gap-3">
-              {[...Array(totalPages)].map((_, i) => (
-                <button
-                  key={i}
-                  onClick={() => setCurrentPage(i + 1)}
-                  className={`w-10 h-10 text-xs font-medium transition-colors active:scale-95 border ${
-                    currentPage === i + 1
-                      ? 'bg-blue-600 text-white border-blue-700'
-                      : 'bg-white dark:bg-neutral-900 border-neutral-200 dark:border-neutral-800 text-neutral-500 dark:text-neutral-500 hover:text-neutral-900 dark:hover:text-white hover:border-neutral-400 dark:hover:border-neutral-700'
-                  }`}
-                >
-                  {i + 1}
-                </button>
-              ))}
-            </div>
-            <button
-              onClick={() => setCurrentPage(prev => Math.min(totalPages, prev + 1))}
-              disabled={currentPage === totalPages}
-              className="p-3 bg-white dark:bg-neutral-900 border border-neutral-200 dark:border-neutral-800 text-neutral-500 dark:text-neutral-500 hover:text-neutral-900 dark:hover:text-white hover:border-neutral-400 dark:hover:border-neutral-700 transition-colors disabled:opacity-30 disabled:cursor-not-allowed active:scale-95"
-            >
-              <ArrowRight className="w-5 h-5" />
-            </button>
+          <div className="flex flex-col items-center gap-3 pt-8 md:pt-12">
+            <PageNav page={currentPage} pages={totalPages} onPageChange={setCurrentPage} size="lg" />
+            <span className="text-xs font-black uppercase tracking-[0.2em] text-neutral-500 dark:text-neutral-500 tabular-nums">
+              {t('pagination.pageOf', { page: currentPage, pages: totalPages })}
+            </span>
           </div>
         )}
       </div>

--- a/src/components/PageNav.tsx
+++ b/src/components/PageNav.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { ChevronLeft, ChevronRight, ChevronsLeft, ChevronsRight, MoreHorizontal } from 'lucide-react';
+import { useIsCompactViewport } from '../hooks/useMediaQuery';
 
 const ELLIPSIS_JUMP = 5;
 
@@ -46,6 +47,9 @@ export function PageNav({
   className = '',
 }: PageNavProps) {
   const { t } = useTranslation();
+  // Phones cannot fit the full window: drop the siblings and the first/last jumps,
+  // which the always-visible "1" and last-page buttons already cover.
+  const isCompact = useIsCompactViewport();
 
   const effectivePages = Math.max(1, pages);
   const safePage = Math.min(Math.max(1, page), effectivePages);
@@ -58,29 +62,33 @@ export function PageNav({
     onPageChange(next);
   };
 
+  // Touch targets stay at least 36px wide on phones, where the desktop 'sm' size is too small to tap.
+  // min-w keeps the squares square for 1-3 digits and lets large page numbers grow instead of clipping.
   const base =
     size === 'lg'
-      ? 'w-11 h-11 rounded-xl text-sm'
-      : 'w-8 h-8 rounded-lg text-[11px]';
+      ? 'min-w-10 h-10 sm:min-w-11 sm:h-11 px-1 rounded-xl text-sm'
+      : 'min-w-9 h-9 sm:min-w-8 sm:h-8 px-1 rounded-lg text-xs sm:text-[11px]';
   const idle =
     'border border-neutral-200/50 dark:border-white/5 bg-white/40 dark:bg-neutral-900/40 text-neutral-600 dark:text-neutral-400 hover:text-neutral-900 dark:hover:text-white hover:bg-neutral-50 dark:hover:bg-neutral-800';
-  const control = `${base} ${idle} flex items-center justify-center font-black transition-all active:scale-95 disabled:opacity-20 disabled:cursor-not-allowed`;
+  const control = `${base} ${idle} shrink-0 touch-manipulation select-none flex items-center justify-center font-black transition-all active:scale-95 disabled:opacity-20 disabled:cursor-not-allowed`;
   const icon = size === 'lg' ? 'w-5 h-5' : 'w-4 h-4';
 
-  const items = buildPageItems(safePage, effectivePages, siblings);
+  const items = buildPageItems(safePage, effectivePages, isCompact ? 0 : siblings);
 
   return (
     <div className={`flex items-center justify-center gap-1 ${className}`}>
-      <button
-        type="button"
-        onClick={() => goTo(1)}
-        disabled={isFirst}
-        aria-label={t('pagination.first')}
-        title={t('pagination.first')}
-        className={control}
-      >
-        <ChevronsLeft className={icon} />
-      </button>
+      {!isCompact && (
+        <button
+          type="button"
+          onClick={() => goTo(1)}
+          disabled={isFirst}
+          aria-label={t('pagination.first')}
+          title={t('pagination.first')}
+          className={control}
+        >
+          <ChevronsLeft className={icon} />
+        </button>
+      )}
       <button
         type="button"
         onClick={() => goTo(safePage - 1)}
@@ -107,7 +115,7 @@ export function PageNav({
               onClick={() => goTo(target)}
               aria-label={label}
               title={label}
-              className={`${base} flex items-center justify-center text-neutral-400 dark:text-neutral-600 hover:text-neutral-900 dark:hover:text-white transition-colors`}
+              className={`${base} shrink-0 touch-manipulation select-none flex items-center justify-center text-neutral-400 dark:text-neutral-600 hover:text-neutral-900 dark:hover:text-white transition-colors`}
             >
               <MoreHorizontal className={icon} />
             </button>
@@ -122,7 +130,7 @@ export function PageNav({
             onClick={() => goTo(item)}
             aria-label={t('pagination.goToPage', { page: item })}
             aria-current={isCurrent ? 'page' : undefined}
-            className={`${base} flex items-center justify-center font-black tabular-nums transition-all active:scale-95 ${
+            className={`${base} shrink-0 touch-manipulation select-none flex items-center justify-center font-black tabular-nums transition-all active:scale-95 ${
               isCurrent
                 ? 'border border-neutral-900 dark:border-white bg-neutral-900 dark:bg-white text-white dark:text-neutral-900'
                 : idle
@@ -143,16 +151,18 @@ export function PageNav({
       >
         <ChevronRight className={icon} />
       </button>
-      <button
-        type="button"
-        onClick={() => goTo(effectivePages)}
-        disabled={isLast}
-        aria-label={t('pagination.last')}
-        title={t('pagination.last')}
-        className={control}
-      >
-        <ChevronsRight className={icon} />
-      </button>
+      {!isCompact && (
+        <button
+          type="button"
+          onClick={() => goTo(effectivePages)}
+          disabled={isLast}
+          aria-label={t('pagination.last')}
+          title={t('pagination.last')}
+          className={control}
+        >
+          <ChevronsRight className={icon} />
+        </button>
+      )}
     </div>
   );
 }

--- a/src/components/ProjectViewer/PaginationBar.tsx
+++ b/src/components/ProjectViewer/PaginationBar.tsx
@@ -33,12 +33,12 @@ export function PaginationBar({
   const endIndex = Math.min(total, safePage * pageSize);
 
   return (
-    <div className="flex flex-wrap items-center justify-between gap-3 border-t border-neutral-200 dark:border-neutral-800 bg-white/40 dark:bg-neutral-950/40 px-4 py-3">
+    <div className="flex flex-col items-center gap-3 border-t border-neutral-200 dark:border-neutral-800 bg-white/40 dark:bg-neutral-950/40 px-3 py-3 sm:flex-row sm:flex-wrap sm:items-center sm:justify-between sm:px-4">
       <div className="flex items-center gap-2 text-[10px] font-black uppercase tracking-widest text-neutral-500 dark:text-neutral-500">
         <span>{t('pagination.range', { start: startIndex, end: endIndex, total })}</span>
       </div>
 
-      <div className="flex items-center gap-3">
+      <div className="flex flex-wrap items-center justify-center gap-x-3 gap-y-2">
         <label className="flex items-center gap-2 text-[10px] font-black uppercase tracking-widest text-neutral-500 dark:text-neutral-500">
           <span>{t('pagination.pageSize')}</span>
           <select
@@ -47,7 +47,7 @@ export function PaginationBar({
               const v = e.target.value;
               onPageSizeChange(v === 'all' ? 'all' : Number(v));
             }}
-            className="rounded-lg border border-neutral-300 dark:border-neutral-700 bg-white/60 dark:bg-neutral-900/60 px-2 py-1 text-[10px] font-black text-neutral-700 dark:text-neutral-200 focus:outline-none focus:border-blue-500"
+            className="rounded-lg border border-neutral-300 dark:border-neutral-700 bg-white/60 dark:bg-neutral-900/60 px-2 py-1.5 sm:py-1 text-[10px] font-black text-neutral-700 dark:text-neutral-200 focus:outline-none focus:border-blue-500"
           >
             {PAGE_SIZE_OPTIONS.map((opt) => (
               <option key={String(opt)} value={String(opt)}>
@@ -57,7 +57,7 @@ export function PaginationBar({
           </select>
         </label>
 
-        <div className="flex items-center gap-2">
+        <div className="flex flex-wrap items-center justify-center gap-2">
           <span className="text-[10px] font-black uppercase tracking-widest text-neutral-600 dark:text-neutral-300">
             {t('pagination.pageOf', { page: safePage, pages: effectivePages })}
           </span>

--- a/src/hooks/useMediaQuery.ts
+++ b/src/hooks/useMediaQuery.ts
@@ -1,0 +1,26 @@
+import { useEffect, useState } from 'react';
+
+/** Tracks a CSS media query and re-renders when it flips. */
+export function useMediaQuery(query: string): boolean {
+  const [matches, setMatches] = useState(() =>
+    typeof window !== 'undefined' && typeof window.matchMedia === 'function'
+      ? window.matchMedia(query).matches
+      : false
+  );
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return;
+    const mql = window.matchMedia(query);
+    const onChange = (e: MediaQueryListEvent) => setMatches(e.matches);
+    setMatches(mql.matches);
+    mql.addEventListener('change', onChange);
+    return () => mql.removeEventListener('change', onChange);
+  }, [query]);
+
+  return matches;
+}
+
+/** True below Tailwind's `sm` breakpoint — phone-sized viewports. */
+export function useIsCompactViewport(): boolean {
+  return useMediaQuery('(max-width: 639px)');
+}

--- a/src/pages/AdminUsers.tsx
+++ b/src/pages/AdminUsers.tsx
@@ -400,7 +400,7 @@ export function AdminUsers() {
           <div className="text-sm text-neutral-600 dark:text-neutral-400">
             {total > 0 ? t('adminUsers.showingUsers', { count: users.length, total }) : t('adminUsers.noUsersToShow')}
           </div>
-          <div className="flex items-center gap-3">
+          <div className="flex flex-wrap items-center justify-center gap-3 md:justify-end">
             <select
               value={filters.pageSize}
               onChange={(e) => setFilters((current) => ({ ...current, pageSize: Number(e.target.value), page: 1 }))}

--- a/src/pages/CampaignBatchActions.tsx
+++ b/src/pages/CampaignBatchActions.tsx
@@ -522,7 +522,7 @@ export function CampaignBatchActions() {
             <div>
               Showing {totalPosts === 0 ? 0 : (page - 1) * pageSize + 1}-{Math.min(page * pageSize, totalPosts)} of {totalPosts}
             </div>
-            <div className="flex items-center gap-2">
+            <div className="flex flex-wrap items-center justify-center gap-2 sm:justify-end">
               <span className="px-2 text-xs font-black uppercase tracking-widest">
                 Page {page} / {Math.max(1, totalPages)}
               </span>

--- a/src/pages/CampaignDetail.tsx
+++ b/src/pages/CampaignDetail.tsx
@@ -979,7 +979,7 @@ export function CampaignDetail() {
                     ))}
                   </select>
                 </div>
-                <div className="flex items-center gap-2">
+                <div className="flex flex-wrap items-center justify-center gap-2 sm:justify-end">
                   <span className="px-2 text-xs font-black uppercase tracking-widest">
                     Page {page} / {Math.max(1, totalPages)}
                   </span>

--- a/src/pages/CampaignHistory.tsx
+++ b/src/pages/CampaignHistory.tsx
@@ -295,7 +295,7 @@ export function CampaignHistory() {
 
           {/* Pagination */}
           {!isLoading && totalPages > 1 && (
-            <div className="px-6 py-4 border-t border-neutral-100 dark:border-white/5 bg-neutral-50/30 dark:bg-white/2 flex items-center justify-between">
+            <div className="px-4 sm:px-6 py-4 border-t border-neutral-100 dark:border-white/5 bg-neutral-50/30 dark:bg-white/2 flex flex-col items-center gap-3 sm:flex-row sm:items-center sm:justify-between">
               <span className="text-[11px] font-medium text-neutral-500">
                 Showing {(page - 1) * pageSize + 1}-{Math.min(page * pageSize, total)} of {total}
               </span>

--- a/src/pages/ScheduledPosts.tsx
+++ b/src/pages/ScheduledPosts.tsx
@@ -327,7 +327,7 @@ export function ScheduledPosts() {
               )}
 
               {totalPages > 1 && (
-                <div className="px-6 py-4 border-t border-neutral-100 dark:border-white/5 bg-neutral-50/30 flex items-center justify-between">
+                <div className="px-4 sm:px-6 py-4 border-t border-neutral-100 dark:border-white/5 bg-neutral-50/30 flex flex-col items-center gap-3 sm:flex-row sm:items-center sm:justify-between">
                   <span className="text-xs text-neutral-500">Page {page} of {totalPages}</span>
                   <PageNav page={page} pages={totalPages} onPageChange={updatePage} />
                 </div>


### PR DESCRIPTION
The shared PageNav rendered up to 11 buttons in a row, which overflowed
phone viewports. Below the sm breakpoint it now drops the sibling pages
and the first/last jumps (the always-visible "1" and last-page buttons
already cover those), leaving 7 slots that fit at 360px, and grows the
touch targets that were only sized for a mouse.

The library editor still had the pre-PageNav pagination that rendered
every page number at once, so a 235-item text library spilled a row of
10+ buttons off-screen. It now uses PageNav like the other lists.

Library text rows were a single desktop line: title and content were
both truncated to a few words on a phone, and the row actions were
hover-only, so they were unreachable on touch. Rows now stack the title
over a two-line preview and keep the actions visible below the sm
breakpoint.

Also let the surrounding pagination rows wrap or stack instead of
squeezing the nav against the range/page labels.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>