### PR TITLE
fix(project): leave workflow full screen after adding drafts

### DIFF
--- a/src/components/ProjectViewer.tsx
+++ b/src/components/ProjectViewer.tsx
@@ -1535,6 +1535,9 @@ export function ProjectViewer({ project, libraries, onUpdate: onUpdateProp, onDe
       setLocalProject(updatedProject);
       setLocalJobs(stripJobWorkflowSnapshots(nextJobs));
       setActiveTab('draft');
+      // Reveal the drafts we just created: mobile swaps to the jobs view, desktop
+      // leaves full screen (which keeps the jobs pane hidden).
+      setIsWorkflowExpanded(false);
       if (typeof window !== 'undefined' && window.innerWidth < 1024) {
         setMobileView('jobs');
       }


### PR DESCRIPTION
## What

When **Add to draft** succeeds, the expanded (full-screen) workflow now collapses.

## Why

`addDraftsToQueue` already did two things on success: switch to the `draft` tab, and — below `lg` — flip `mobileView` to `jobs` so the new drafts are visible.

On desktop that second step has no equivalent. While the workflow is expanded the jobs pane is `lg:hidden`, so the tab switch happens behind a hidden pane: you press the button, drafts are created, and nothing on screen changes.

Collapsing full screen is the desktop equivalent of the mobile view swap — it reveals the pane the drafts just landed in.

## Notes for reviewers

- Three lines in the success path of `addDraftsToQueue` ([ProjectViewer.tsx:1538](https://github.com/ShinChven/remix-studio/blob/fix/exit-fullscreen-on-add-drafts/src/components/ProjectViewer.tsx#L1538)).
- Only on success — a failed request leaves you in full screen with the workflow intact, rather than bouncing you out.
- Not gated behind a width check, unlike the `mobileView` line beside it. The expand control is `hidden lg:block`, so the flag is desktop-only in practice; setting it unconditionally keeps the two paths from drifting if that ever changes.
- No styling changes here — the wider question of how the panel should be laid out in full screen is still open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)