### PR TITLE
feat(workflow): add disabled-item visibility toggle and Claude Opus 5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to Remix Studio are documented here by version number.
 
+## [Unreleased]
+
+### Added
+
+- **Claude Opus 5**: Added Claude Opus 5 to the Claude provider's text models, with a 1M-token prompt limit and 128K max output. Like Fable 5, Opus 4.8, and Sonnet 5, it accepts only the default temperature.
+- **Hide Disabled Workflow Items**: The project workflow's three-dot menu can now hide disabled items, with a count of how many are hidden. Hiding is view-only — drag-and-drop reordering still uses each item's real position.
+
 ## [1.18.0] - 2026-07-24
 
 ### Added

--- a/agent/model-maintenance-guide.md
+++ b/agent/model-maintenance-guide.md
@@ -197,7 +197,9 @@ The lister fetches all models, then filters to only those whose `id` matches a `
 | Name | Model ID | Category | Max Output |
 |---|---|---|---|
 | Claude Fable 5 | `claude-fable-5` | text | 128,000 |
+| Claude Opus 5 | `claude-opus-5` | text | 128,000 |
 | Claude Opus 4.8 | `claude-opus-4-8` | text | 128,000 |
+| Claude Sonnet 5 | `claude-sonnet-5` | text | 128,000 |
 | Claude Opus 4.7 | `claude-opus-4-7` | text | 128,000 |
 | Claude Sonnet 4.6 | `claude-sonnet-4-6` | text | 64,000 |
 | Claude Haiku 4.5 | `claude-haiku-4-5-20251001` | text | 64,000 |
@@ -216,7 +218,7 @@ The lister fetches all models, then filters to only those whose `id` matches a `
 | Google AI / Vertex AI | 2.0 | |
 | OpenAI | 2.0 | |
 | Grok (xAI) | 2.0 | |
-| Claude | 1.0 | Anthropic API hard limit |
+| Claude | 1.0 | Anthropic API hard limit. Fable 5, Opus 5, Opus 4.8 and Sonnet 5 reject any non-default value — list only `[1.0]` and skip the parameter in `claude-text-generator.ts` |
 
 ---
 

--- a/server/generators/claude-text-generator.ts
+++ b/server/generators/claude-text-generator.ts
@@ -19,6 +19,7 @@ export class ClaudeTextGenerator extends TextGenerator {
       // Claude's latest adaptive-thinking models reject non-default sampling parameters (400) — omit temperature entirely.
       const supportsTemperature = !(
         model.startsWith('claude-fable-5') ||
+        model.startsWith('claude-opus-5') ||
         model.startsWith('claude-opus-4-8') ||
         model.startsWith('claude-sonnet-5')
       );

--- a/src/components/ProjectViewer/WorkflowPanel.tsx
+++ b/src/components/ProjectViewer/WorkflowPanel.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
-import { Archive, ArchiveRestore, Copy, Eraser, HardDrive, Hash, ImageIcon, Library as LibraryIcon, Loader2, Maximize2, Minimize2, MoreVertical, Settings, Stars, Trash2, Type, Video as VideoIcon, Volume2, X } from 'lucide-react';
+import { Archive, ArchiveRestore, Copy, Eraser, Eye, EyeOff, HardDrive, Hash, ImageIcon, Library as LibraryIcon, Loader2, Maximize2, Minimize2, MoreVertical, Settings, Stars, Trash2, Type, Video as VideoIcon, Volume2, X } from 'lucide-react';
 import { Library, Project, Provider, WorkflowItem as WorkflowItemType, ProviderType, PROVIDER_MODELS_MAP, resolveCustomModels } from '../../types';
 import { WorkflowItem } from './WorkflowItem';
 import { SettingsPanel } from './SettingsPanel';
@@ -121,6 +121,7 @@ export function WorkflowPanel({
   const [isActionMenuOpen, setIsActionMenuOpen] = useState(false);
   const [isProjectInfoOpen, setIsProjectInfoOpen] = useState(false);
   const [isDragOverFiles, setIsDragOverFiles] = useState(false);
+  const [showDisabledItems, setShowDisabledItems] = useState(true);
   const actionMenuRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
@@ -156,6 +157,13 @@ export function WorkflowPanel({
   const selectedAllModels = [...selectedBaseModels, ...resolveCustomModels(selectedProviderType, selectedCustomAliases)];
   const selectedModel = selectedAllModels.find((m) => m.id === selectedModelId);
   const supportsImageInput = localProject.type !== 'audio' || selectedModel?.options.supportsReferenceImages === true;
+  const workflowItems = localProject.workflow || [];
+  const disabledItemsCount = workflowItems.filter((item) => item.disabled).length;
+  // Keep each item's position in the unfiltered workflow: drag and drop reorders by
+  // index, so hiding items must not shift the indices handed to the drag handlers.
+  const visibleWorkflowItems = workflowItems
+    .map((item, index) => ({ item, index }))
+    .filter(({ item }) => showDisabledItems || !item.disabled);
   const sumStoredSize = (item: { size?: number; optimizedSize?: number; thumbnailSize?: number }) => {
     return Number(item.size || 0) + Number(item.optimizedSize || 0) + Number(item.thumbnailSize || 0);
   };
@@ -272,6 +280,24 @@ export function WorkflowPanel({
 
               {isActionMenuOpen && (
                 <div className="absolute right-0 top-full mt-2 w-52 p-2 rounded-xl border border-neutral-200/60 dark:border-white/10 bg-white/90 dark:bg-neutral-900/95 backdrop-blur-xl shadow-xl z-30">
+                  <button
+                    onClick={() => closeMenuAndRun(() => setShowDisabledItems((show) => !show))}
+                    disabled={disabledItemsCount === 0}
+                    className={`${menuButtonBaseClass} justify-between text-neutral-600 dark:text-neutral-300 hover:text-neutral-900 dark:hover:text-white hover:bg-neutral-100/80 dark:hover:bg-neutral-800/80 disabled:opacity-40 disabled:hover:bg-transparent disabled:hover:text-neutral-600 dark:disabled:hover:text-neutral-300`}
+                  >
+                    <span className="flex items-center gap-2 min-w-0">
+                      {showDisabledItems ? <EyeOff className="w-3.5 h-3.5 shrink-0" /> : <Eye className="w-3.5 h-3.5 shrink-0" />}
+                      <span className="truncate">
+                        {t(showDisabledItems ? 'projectViewer.main.hideDisabledItems' : 'projectViewer.main.showDisabledItems')}
+                      </span>
+                    </span>
+                    {disabledItemsCount > 0 && (
+                      <span className="shrink-0 text-[9px] font-black text-neutral-500 dark:text-neutral-500">{disabledItemsCount}</span>
+                    )}
+                  </button>
+
+                  <div className="my-1 h-px bg-neutral-200/60 dark:bg-white/10" />
+
                   <button
                     onClick={() => closeMenuAndRun(onNavigateToEdit)}
                     className={`${menuButtonBaseClass} text-neutral-600 dark:text-neutral-300 hover:text-neutral-900 dark:hover:text-white hover:bg-neutral-100/80 dark:hover:bg-neutral-800/80`}
@@ -441,7 +467,7 @@ export function WorkflowPanel({
             </div>
           </div>
         )}
-        {!isLoading && (localProject.workflow || []).map((item, index) => (
+        {!isLoading && visibleWorkflowItems.map(({ item, index }) => (
           <WorkflowItem
             key={item.id}
             item={item}
@@ -470,8 +496,12 @@ export function WorkflowPanel({
             gridView={isExpanded}
           />
         ))}
-        {!isLoading && (localProject.workflow || []).length === 0 && (
-          <div className="col-span-full text-center text-neutral-500 dark:text-neutral-500 text-[10px] font-bold uppercase tracking-[0.2em] py-12 border-2 border-dashed border-neutral-200 dark:border-neutral-800 rounded-xl bg-white/20 dark:bg-neutral-900/20 shadow-inner backdrop-blur-sm">{t('projectViewer.main.buildWorkflow')}</div>
+        {!isLoading && visibleWorkflowItems.length === 0 && (
+          <div className="col-span-full text-center text-neutral-500 dark:text-neutral-500 text-[10px] font-bold uppercase tracking-[0.2em] py-12 border-2 border-dashed border-neutral-200 dark:border-neutral-800 rounded-xl bg-white/20 dark:bg-neutral-900/20 shadow-inner backdrop-blur-sm">
+            {workflowItems.length === 0
+              ? t('projectViewer.main.buildWorkflow')
+              : t('projectViewer.workflow.allItemsHidden')}
+          </div>
         )}
       </div>
 

--- a/src/locales/en/project-viewer.json
+++ b/src/locales/en/project-viewer.json
@@ -70,7 +70,9 @@
       "archiveProject": "Archive",
       "unarchiveProject": "Restore",
       "archivedBadge": "Archived",
-      "buildWorkflow": "Build your workflow"
+      "buildWorkflow": "Build your workflow",
+      "hideDisabledItems": "Hide Disabled",
+      "showDisabledItems": "Show Disabled"
     },
     "drafts": {
       "emptyCanvas": "Empty Canvas",
@@ -163,7 +165,8 @@
       "unknownLibrary": "Unknown Library",
       "itemsCount": "{{count}} items",
       "filteredTags": "Filtered: {{count}} tags",
-      "wait": "Wait"
+      "wait": "Wait",
+      "allItemsHidden": "All items are hidden"
     },
     "modelSelector": {
       "title": "Select Model",

--- a/src/locales/fr/project-viewer.json
+++ b/src/locales/fr/project-viewer.json
@@ -70,7 +70,9 @@
       "archiveProject": "Archiver",
       "unarchiveProject": "Restaurer",
       "archivedBadge": "Archivé",
-      "buildWorkflow": "Construisez votre flux"
+      "buildWorkflow": "Construisez votre flux",
+      "hideDisabledItems": "Masquer désactivés",
+      "showDisabledItems": "Afficher désactivés"
     },
     "drafts": {
       "emptyCanvas": "Toile vide",
@@ -163,7 +165,8 @@
       "unknownLibrary": "Bibliothèque inconnue",
       "itemsCount": "{{count}} éléments",
       "filteredTags": "Filtré : {{count}} tags",
-      "wait": "Attendre"
+      "wait": "Attendre",
+      "allItemsHidden": "Tous les éléments sont masqués"
     },
     "modelSelector": {
       "title": "Sélectionner un modèle",

--- a/src/locales/ja/project-viewer.json
+++ b/src/locales/ja/project-viewer.json
@@ -70,7 +70,9 @@
       "archiveProject": "アーカイブ",
       "unarchiveProject": "復元",
       "archivedBadge": "アーカイブ済み",
-      "buildWorkflow": "ワークフローを作成"
+      "buildWorkflow": "ワークフローを作成",
+      "hideDisabledItems": "無効を非表示",
+      "showDisabledItems": "無効を表示"
     },
     "drafts": {
       "emptyCanvas": "空のキャンバス",
@@ -163,7 +165,8 @@
       "unknownLibrary": "不明なライブラリ",
       "itemsCount": "{{count}} 件",
       "filteredTags": "フィルター済み: {{count}} タグ",
-      "wait": "待機"
+      "wait": "待機",
+      "allItemsHidden": "すべての項目が非表示です"
     },
     "modelSelector": {
       "title": "モデルを選択",

--- a/src/locales/ko/project-viewer.json
+++ b/src/locales/ko/project-viewer.json
@@ -70,7 +70,9 @@
       "archiveProject": "보관",
       "unarchiveProject": "복원",
       "archivedBadge": "보관됨",
-      "buildWorkflow": "워크플로 구축"
+      "buildWorkflow": "워크플로 구축",
+      "hideDisabledItems": "비활성 숨기기",
+      "showDisabledItems": "비활성 표시"
     },
     "drafts": {
       "emptyCanvas": "빈 캔버스",
@@ -163,7 +165,8 @@
       "unknownLibrary": "알 수 없는 라이브러리",
       "itemsCount": "{{count}}개 항목",
       "filteredTags": "필터됨: {{count}}개 태그",
-      "wait": "대기"
+      "wait": "대기",
+      "allItemsHidden": "모든 항목이 숨겨져 있습니다"
     },
     "modelSelector": {
       "title": "모델 선택",

--- a/src/locales/zh-CN/project-viewer.json
+++ b/src/locales/zh-CN/project-viewer.json
@@ -70,7 +70,9 @@
       "archiveProject": "归档",
       "unarchiveProject": "恢复",
       "archivedBadge": "已归档",
-      "buildWorkflow": "构建您的工作流"
+      "buildWorkflow": "构建您的工作流",
+      "hideDisabledItems": "隐藏已禁用",
+      "showDisabledItems": "显示已禁用"
     },
     "drafts": {
       "emptyCanvas": "空白画布",
@@ -163,7 +165,8 @@
       "unknownLibrary": "未知资料库",
       "itemsCount": "{{count}} 项",
       "filteredTags": "已筛选：{{count}} 个标签",
-      "wait": "等待"
+      "wait": "等待",
+      "allItemsHidden": "所有项目已隐藏"
     },
     "modelSelector": {
       "title": "选择模型",

--- a/src/locales/zh-TW/project-viewer.json
+++ b/src/locales/zh-TW/project-viewer.json
@@ -70,7 +70,9 @@
       "archiveProject": "封存",
       "unarchiveProject": "還原",
       "archivedBadge": "已封存",
-      "buildWorkflow": "構建您的工作流"
+      "buildWorkflow": "構建您的工作流",
+      "hideDisabledItems": "隱藏已停用",
+      "showDisabledItems": "顯示已停用"
     },
     "drafts": {
       "emptyCanvas": "空白畫布",
@@ -163,7 +165,8 @@
       "unknownLibrary": "未知資料庫",
       "itemsCount": "{{count}} 項",
       "filteredTags": "已篩選：{{count}} 個標籤",
-      "wait": "等待"
+      "wait": "等待",
+      "allItemsHidden": "所有項目已隱藏"
     },
     "modelSelector": {
       "title": "選擇模型",

--- a/src/types.ts
+++ b/src/types.ts
@@ -1094,6 +1094,19 @@ export const PROVIDER_MODELS_MAP: Record<ProviderType, ModelConfig[]> = {
       },
     },
     {
+      id: 'claude-opus-5-text',
+      name: 'Claude Opus 5',
+      generatorId: 'Claude',
+      modelId: 'claude-opus-5',
+      category: 'text',
+      promptLimit: { value: 1000000, unit: 'tokens' },
+      options: {
+        // Opus 5 rejects non-default sampling parameters; only the default temperature is allowed.
+        temperatures: [1.0],
+        maxTokenOptions: [256, 512, 1024, 2048, 4096, 8192, 16384, 32768, 65536, 131072],
+      },
+    },
+    {
       id: 'claude-opus-4-8-text',
       name: 'Claude Opus 4.8',
       generatorId: 'Claude',


### PR DESCRIPTION
## What

Two independent additions plus doc updates:

1. A **hide/show disabled items** toggle in the project workflow's three-dot menu.
2. **Claude Opus 5** registered as a Claude text model.

## Why

**Disabled items.** Disabling an item leaves it on screen at reduced opacity. On a long workflow those accumulate and crowd the list without contributing anything to generation. The new menu entry hides them, with a count of how many are hidden so nothing disappears silently. It's disabled when there's nothing to hide.

**Opus 5.** Adds `claude-opus-5` to `PROVIDER_MODELS_MAP.Claude` — 1M prompt limit, 128K max output.

## Notes for reviewers

- **The index pairing in [WorkflowPanel.tsx](https://github.com/ShinChven/remix-studio/blob/feat/hide-disabled-items-and-opus-5/src/components/ProjectViewer/WorkflowPanel.tsx#L166) is load-bearing.** Drag-and-drop reorders by array index, so filtering the list naively would hand the drag handlers shifted indices and reorder the wrong items. Items are paired with their position in the *unfiltered* workflow before filtering, so each visible card keeps its true index. Worth a look if you change how the list is built.
- Hiding is view-only — it's local component state, nothing is persisted, and disabled items are still disabled for generation exactly as before.
- The empty state now distinguishes an empty workflow from one whose items are all hidden.
- **Opus 5 needed a generator change, not just a model entry**: like Fable 5, Opus 4.8, and Sonnet 5, it rejects any non-default `temperature` with a 400, so `claude-text-generator.ts` omits the parameter for it and the model lists only `[1.0]`.
- Three new i18n keys across all six locales; `npm run i18n:check` is clean.
- Docs: the model maintenance guide gains Opus 5 and **Sonnet 5** — the latter was already shipped but missing from that inventory table — plus a note in the temperature table about which models reject non-default values.

## Out of scope

`server/assistant/providers/anthropic.ts` forwards `temperature` with no model gate, so the assistant chat path can still 400 on these models. That's pre-existing — it already affects Fable 5, Opus 4.8, and Sonnet 5 — so I left it for a separate change rather than widening this one.

## Related

[#31](https://github.com/ShinChven/remix-studio/pull/31) is open separately against `main`. This branch is cut from `main`, not from that one, so the two are independent and can merge in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)