### PR TITLE
Add MCP tools for signed file URLs and album browsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to Remix Studio are documented here by version number.
 
 - **Claude Opus 5**: Added Claude Opus 5 to the Claude provider's text models, with a 1M-token prompt limit and 128K max output. Like Fable 5, Opus 4.8, and Sonnet 5, it accepts only the default temperature.
 - **Hide Disabled Workflow Items**: The project workflow's three-dot menu can now hide disabled items, with a count of how many are hidden. Hiding is view-only — drag-and-drop reordering still uses each item's real position.
+- **Signed File URLs for MCP & Assistant**: Added a `get_file_urls` tool that turns internal storage keys — from albums, libraries, and campaign post media — into temporary presigned URLs so connected agents can actually view, fetch, or download a file, with an optional `download` mode that returns a save-as link. Keys are only signed when they still belong to the authenticated user's own media; anything else is refused with a reason.
+- **Album Item Browsing over MCP**: Added a `get_album_items` tool that pages through one project's album and returns each item's prompt, format, aspect ratio, size, and storage keys, so an agent can pick a specific generated image before requesting a URL for it.
 
 ## [1.18.0] - 2026-07-24
 

--- a/agent/mcp-oauth-implementation.md
+++ b/agent/mcp-oauth-implementation.md
@@ -111,6 +111,20 @@ Remix Studio currently exposes several high-level tools to MCP clients. Each too
 - **Description:** Lists project albums with their respective sizes and item counts.
 - **Use Case:** Gives the AI visibility into the user's media projects, allowing it to reference them in conversation.
 
+### 3.7 `get_album_items`
+- **Description:** Browses the generated items inside one project's album, paginated and optionally filtered by aspect ratio.
+- **Inputs:** `project_id` (string), `sort` (`newest`/`oldest`), `aspect_ratios` (optional array), `page`, `limit`.
+- **Returns:** Per item: `id`, `jobId`, truncated `prompt`, `storageKey`, `thumbnailKey`, `optimizedKey`, `format`, `aspectRatio`, `size`, `createdAt`.
+- **Use Case:** Lets the AI reference a specific generated image before signing a URL for it.
+
+### 3.8 `get_file_urls`
+- **Description:** Mints temporary presigned HTTPS URLs for internal storage keys so files can actually be fetched, viewed, or downloaded.
+- **Inputs:** `keys` (array of internal storage keys, max 50), `expires_in` (seconds, 60–86400, default 3600), `download` (boolean — when true the URL carries `Content-Disposition: attachment`).
+- **Returns:** `urls` (`key`, `url`, `filename`), `denied` (`key`, `reason`), plus `expiresIn` / `expiresAt`.
+- **Authorization:** Each key is re-checked against the caller's own `LibraryItem`, `AlbumItem`, `Job`, and `PostMedia` rows. Keys that no record of the authenticated user references are refused, as are values that are already absolute URLs (`http(s)://`, `data:`).
+- **Note:** When the deployment sets `S3_PUBLIC_CUSTOM_DOMAIN`, the storage layer returns a direct public URL instead of a SigV4-signed one.
+- **Use Case:** "Show me / download the last image from that campaign post" — the AI resolves keys via `get_album_items` / `get_library_items` / `get_post`, then signs them here.
+
 ---
 
 ## 4. Database Schema Details

--- a/docs-site/integrations/mcp.md
+++ b/docs-site/integrations/mcp.md
@@ -13,9 +13,19 @@ Available MCP capabilities include:
 - **Update** a single text prompt's content, title, or tags with `update_prompt`.
 - **Delete** a single text prompt from a text library with `delete_prompt`.
 - **Inspect** storage usage, albums, libraries, library items, and usable model/provider pairings.
+- **Browse** the items inside a project album with `get_album_items`, including each item's prompt, format, aspect ratio, size, and storage keys.
+- **Download** stored files with `get_file_urls`, which converts internal storage keys into temporary presigned URLs (optionally as save-as download links).
 - **Create and update** workflow-backed projects.
 
 Write and destructive tools are **confirmation-gated**. Prompt deletion is scoped to one item in a text library and requires an explicit confirmed tool call.
+
+### File access
+
+Read tools return **storage keys**, not links. To fetch, view, or download a file, pass those keys to `get_file_urls`:
+
+- Accepts up to 50 keys per call, with `expires_in` between 60 and 86400 seconds (default 1 hour) and `download: true` for an attachment (save-as) URL.
+- Signs a key only when it is still referenced by media the authenticated user owns — library items, album items, job outputs, or campaign post media. Everything else is returned under `denied` with a reason, and values that are already absolute URLs are rejected as needing no signing.
+- Returned URLs are temporary; request new ones rather than reusing expired links. When the deployment sets `S3_PUBLIC_CUSTOM_DOMAIN`, storage returns a direct public URL instead of a signed one.
 
 ## Authentication
 

--- a/server.ts
+++ b/server.ts
@@ -241,7 +241,7 @@ async function startServer() {
   app.route('/', createSocialRouter(prisma));
   app.route('/', createStoreRouter(prisma));
   app.route('/', createProductsRouter(prisma, deliveryManager));
-  app.route('/', createMcpRouter(prisma, repository, userRepository, providerRepository));
+  app.route('/', createMcpRouter(prisma, repository, userRepository, providerRepository, storage));
 
   // === Assistant chat runtime ===
   const assistantRepo = new AssistantRepository(prisma);
@@ -250,6 +250,7 @@ async function startServer() {
     userRepository,
     prisma,
     providerRepository,
+    storage,
   });
   app.route('/', createAssistantRouter(assistantRepo, assistantRunner, providerRepository));
 

--- a/server/assistant/system-prompt.ts
+++ b/server/assistant/system-prompt.ts
@@ -58,7 +58,8 @@ You do NOT:
 
 ## Tool use
 
-- Prefer reading before writing. Discover via \`list_libraries\` / \`search_library_items\` / \`get_library_items\` / \`list_albums\` / \`list_available_models\` / \`get_storage_usage\` before proposing changes.
+- Prefer reading before writing. Discover via \`list_libraries\` / \`search_library_items\` / \`get_library_items\` / \`list_albums\` / \`get_album_items\` / \`list_available_models\` / \`get_storage_usage\` before proposing changes.
+- Storage keys returned by read tools (\`storageKey\`, \`thumbnailKey\`, \`optimizedKey\`, post media \`sourceUrl\`) are internal references, not links. To view, fetch, or hand the user a downloadable file, call \`get_file_urls\` with those keys — it returns short-lived presigned URLs (pass \`download: true\` for a save-as link). Never invent a media URL, and mint a fresh one instead of reusing an expired URL.
 - Paginated read tools return \`hasMore\` and \`nextPage\`. Only page further when the user's question genuinely needs more results — don't preemptively fetch everything.
 - When searching by keyword or title, use \`search_library_items\` (cross-library keyword match) or \`get_library_items\` with a \`query\` (single library, substring match).
 - When the user asks what's available before a mutation (e.g. "show me my image libraries"), read and summarize first; do not mutate.

--- a/server/mcp/mcp-server.ts
+++ b/server/mcp/mcp-server.ts
@@ -6,6 +6,7 @@ import crypto from 'crypto';
 import type { IRepository } from '../db/repository';
 import type { UserRepository } from '../auth/user-repository';
 import type { ProviderRepository } from '../db/provider-repository';
+import type { IStorage } from '../storage/storage';
 import { createAssistantToolDefinitions, AssistantToolDefinition } from './tool-definitions';
 import { getTransportInputSchema, resolveExternalToolCall } from './tool-confirmation';
 
@@ -93,6 +94,7 @@ function createMcpServerInstance(
   userRepository: UserRepository,
   prisma: PrismaClient,
   providerRepository: ProviderRepository,
+  storage: IStorage,
   userId: string,
 ) {
   const server = new McpServer({
@@ -100,7 +102,7 @@ function createMcpServerInstance(
     version: '1.0.0',
   });
 
-  const tools = createAssistantToolDefinitions({ repository, userRepository, prisma, providerRepository });
+  const tools = createAssistantToolDefinitions({ repository, userRepository, prisma, providerRepository, storage });
   for (const tool of tools) {
     registerToolOnServer(server, tool, userId);
   }
@@ -113,6 +115,7 @@ export function createMcpRouter(
   repository: IRepository,
   userRepository: UserRepository,
   providerRepository: ProviderRepository,
+  storage: IStorage,
 ) {
   const router = new Hono<{ Variables: Variables }>();
 
@@ -132,7 +135,7 @@ export function createMcpRouter(
 
   router.all('/mcp', async (c) => {
     const userId = c.get('mcpUserId');
-    const server = createMcpServerInstance(repository, userRepository, prisma, providerRepository, userId);
+    const server = createMcpServerInstance(repository, userRepository, prisma, providerRepository, storage, userId);
 
     const transport = new WebStandardStreamableHTTPServerTransport();
 

--- a/server/mcp/tool-definitions.ts
+++ b/server/mcp/tool-definitions.ts
@@ -4,6 +4,7 @@ import { PrismaClient } from '@prisma/client';
 import type { IRepository } from '../db/repository';
 import type { UserRepository } from '../auth/user-repository';
 import type { ProviderRepository } from '../db/provider-repository';
+import type { IStorage } from '../storage/storage';
 import { PROVIDER_MODELS_MAP } from '../../src/types';
 
 const MODEL_CATEGORY_VALUES = ['text', 'image', 'audio', 'video'] as const;
@@ -85,9 +86,14 @@ export interface ToolDependencies {
   userRepository: UserRepository;
   prisma: PrismaClient;
   providerRepository: ProviderRepository;
+  /** Media bucket, used to mint presigned download URLs for owned storage keys. */
+  storage: IStorage;
 }
 
 const MAX_CONTENT_PREVIEW_CHARS = 4096;
+const MAX_SIGNED_KEYS_PER_CALL = 50;
+const DEFAULT_SIGNED_URL_TTL_SECONDS = 3600;
+const MAX_SIGNED_URL_TTL_SECONDS = 86400;
 
 function formatSize(bytes: number): string {
   if (bytes < 1024) return `${bytes} B`;
@@ -261,6 +267,87 @@ async function assertPostMediaSourceAllowed(
   return source;
 }
 
+/**
+ * Batch ownership check for raw storage keys. A key is signable only when it is
+ * still referenced by a record the authenticated user owns — library items,
+ * album items, job outputs, or campaign post media. Returns the subset of
+ * `keys` that passed, so callers can report the rest as denied.
+ */
+async function resolveOwnedStorageKeys(
+  prisma: PrismaClient,
+  userId: string,
+  keys: string[],
+): Promise<Set<string>> {
+  const candidates = [...new Set(keys.map((key) => key.trim()).filter((key) => key && isInternalStorageValue(key)))];
+  if (candidates.length === 0) return new Set();
+
+  const inList = { in: candidates };
+  const [libraryItems, albumItems, jobs, postMedia] = await Promise.all([
+    prisma.libraryItem.findMany({
+      where: {
+        library: { userId },
+        OR: [{ content: inList }, { thumbnailUrl: inList }, { optimizedUrl: inList }],
+      },
+      select: { content: true, thumbnailUrl: true, optimizedUrl: true },
+    }),
+    prisma.albumItem.findMany({
+      where: {
+        userId,
+        OR: [{ imageUrl: inList }, { thumbnailUrl: inList }, { optimizedUrl: inList }],
+      },
+      select: { imageUrl: true, thumbnailUrl: true, optimizedUrl: true },
+    }),
+    prisma.job.findMany({
+      where: {
+        userId,
+        OR: [{ imageUrl: inList }, { thumbnailUrl: inList }, { optimizedUrl: inList }],
+      },
+      select: { imageUrl: true, thumbnailUrl: true, optimizedUrl: true },
+    }),
+    prisma.postMedia.findMany({
+      where: {
+        post: { userId },
+        OR: [{ sourceUrl: inList }, { processedUrl: inList }, { thumbnailUrl: inList }],
+      },
+      select: { sourceUrl: true, processedUrl: true, thumbnailUrl: true },
+    }),
+  ]);
+
+  // A row can match on one column while its other columns hold keys the caller
+  // never asked for, so every value is re-checked against the requested set.
+  const requested = new Set(candidates);
+  const owned = new Set<string>();
+  const allow = (value?: string | null) => {
+    if (value && requested.has(value)) owned.add(value);
+  };
+  for (const item of libraryItems) {
+    allow(item.content);
+    allow(item.thumbnailUrl);
+    allow(item.optimizedUrl);
+  }
+  for (const item of albumItems) {
+    allow(item.imageUrl);
+    allow(item.thumbnailUrl);
+    allow(item.optimizedUrl);
+  }
+  for (const job of jobs) {
+    allow(job.imageUrl);
+    allow(job.thumbnailUrl);
+    allow(job.optimizedUrl);
+  }
+  for (const media of postMedia) {
+    allow(media.sourceUrl);
+    allow(media.processedUrl);
+    allow(media.thumbnailUrl);
+  }
+  return owned;
+}
+
+function basenameForKey(key: string): string {
+  const name = key.split('/').pop() || 'download';
+  return name.replace(/["\\]/g, '');
+}
+
 function toToolWorkflowItem(item: {
   id?: string;
   type: string;
@@ -284,7 +371,7 @@ function toToolWorkflowItem(item: {
 }
 
 export function createAssistantToolDefinitions(deps: ToolDependencies): AssistantToolDefinition[] {
-  const { repository, userRepository, prisma, providerRepository } = deps;
+  const { repository, userRepository, prisma, providerRepository, storage } = deps;
 
   const tools: AssistantToolDefinition[] = [];
 
@@ -677,6 +764,170 @@ export function createAssistantToolDefinitions(deps: ToolDependencies): Assistan
           pages: projectsResult.pages,
           ...paginationHints(projectsResult.page, projectsResult.pages),
         }, null, 2),
+      };
+    },
+  });
+
+  // ─── get_album_items ───
+  tools.push({
+    name: 'get_album_items',
+    title: 'Get Album Items',
+    description: `Browse the generated items saved in one project's album. Returns each item's id, prompt, format, size, aspect ratio, and its storage keys (storageKey for the full-size file, plus thumbnail/optimized variants when present).
+
+Storage keys are internal references, not fetchable URLs — pass them to get_file_urls to obtain a temporary download URL.`,
+    inputSchema: {
+      project_id: z.string().min(1).describe('The project ID whose album to browse (from list_albums)'),
+      sort: z.enum(['newest', 'oldest']).default('newest').describe('Sort order by creation time (default "newest")'),
+      aspect_ratios: z.array(z.string()).optional().describe('Optional: only return items matching these aspect ratios (e.g. ["1:1", "16:9"])'),
+      page: z.number().int().min(1).default(1).describe('Page number (default 1)'),
+      limit: z.number().int().min(1).max(100).default(25).describe('Items per page (default 25)'),
+    },
+    annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
+    category: 'read',
+    handler: async (userId, input) => {
+      const { project_id, sort, aspect_ratios, page, limit } = input as {
+        project_id: string;
+        sort: 'newest' | 'oldest';
+        aspect_ratios?: string[];
+        page: number;
+        limit: number;
+      };
+
+      const project = await repository.getProject(userId, project_id);
+      if (!project) {
+        return {
+          text: JSON.stringify({ error: `Project "${project_id}" not found.` }),
+          isError: true,
+        };
+      }
+
+      const album = await repository.getProjectAlbum(userId, project_id, {
+        page,
+        limit,
+        sort,
+        aspectRatios: aspect_ratios,
+      });
+
+      const items = album.items.map((item) => {
+        const preview = truncateContent(item.prompt ?? '');
+        return {
+          id: item.id,
+          jobId: item.jobId ?? null,
+          prompt: preview.text,
+          promptTruncated: preview.truncated,
+          storageKey: item.imageUrl || null,
+          thumbnailKey: item.thumbnailUrl ?? null,
+          optimizedKey: item.optimizedUrl ?? null,
+          format: item.format ?? null,
+          aspectRatio: item.aspectRatio ?? null,
+          size: item.size ?? null,
+          sizeFormatted: item.size ? formatSize(item.size) : null,
+          createdAt: item.createdAt,
+        };
+      });
+
+      const response = {
+        projectId: project.id,
+        projectName: project.name,
+        projectType: project.type,
+        items,
+        total: album.total,
+        page: album.page,
+        pages: album.pages,
+        totalSize: album.totalSize,
+        totalSizeFormatted: formatSize(album.totalSize),
+        aspectRatioCounts: album.aspectRatioCounts,
+        ...paginationHints(album.page, album.pages),
+        hint: 'Pass storageKey / thumbnailKey / optimizedKey to get_file_urls to download or view a file.',
+      };
+
+      return {
+        text: JSON.stringify(response, null, 2),
+        structuredContent: response,
+      };
+    },
+  });
+
+  // ─── get_file_urls ───
+  tools.push({
+    name: 'get_file_urls',
+    title: 'Get File URLs',
+    description: `Mint temporary, presigned HTTPS URLs for stored files so they can be fetched, viewed, or downloaded. Input is one or more internal storage keys — the values returned as storageKey/thumbnailKey/optimizedKey by get_album_items and get_library_items, or sourceUrl/processedUrl/thumbnailUrl on campaign post media from get_post.
+
+Only keys still referenced by the authenticated user's own library items, album items, job outputs, or campaign post media can be signed; anything else comes back under "denied" instead of "urls". Full public URLs (http://, https://, data:) are rejected — they need no signing.
+
+Set download=true to get a URL that saves as a file (Content-Disposition: attachment) instead of rendering inline. URLs expire after expires_in seconds (default 1 hour, max 24 hours); mint fresh ones rather than storing them. When the deployment serves media from a public custom domain, the returned URL is a direct public URL rather than a signed one.`,
+    inputSchema: {
+      keys: z
+        .array(z.string().min(1))
+        .min(1)
+        .max(MAX_SIGNED_KEYS_PER_CALL)
+        .describe(`Internal storage keys to sign (max ${MAX_SIGNED_KEYS_PER_CALL} per call)`),
+      expires_in: z
+        .number()
+        .int()
+        .min(60)
+        .max(MAX_SIGNED_URL_TTL_SECONDS)
+        .default(DEFAULT_SIGNED_URL_TTL_SECONDS)
+        .describe(`URL lifetime in seconds (default ${DEFAULT_SIGNED_URL_TTL_SECONDS}, max ${MAX_SIGNED_URL_TTL_SECONDS})`),
+      download: z
+        .boolean()
+        .default(false)
+        .describe('When true, the URL forces a file download (attachment) instead of inline display'),
+    },
+    annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: false, openWorldHint: false },
+    category: 'read',
+    handler: async (userId, input) => {
+      const { keys, expires_in, download } = input as {
+        keys: string[];
+        expires_in: number;
+        download: boolean;
+      };
+
+      const requested = [...new Set(keys.map((key) => key.trim()).filter(Boolean))];
+      const external = requested.filter((key) => !isInternalStorageValue(key));
+      const internal = requested.filter((key) => isInternalStorageValue(key));
+      const owned = await resolveOwnedStorageKeys(prisma, userId, internal);
+
+      const denied = [
+        ...external.map((key) => ({
+          key,
+          reason: 'Not an internal storage key — already a fetchable URL, no signing needed.',
+        })),
+        ...internal
+          .filter((key) => !owned.has(key))
+          .map((key) => ({
+            key,
+            reason: 'Not found among media owned by the authenticated user (library items, album items, job outputs, or campaign post media).',
+          })),
+      ];
+
+      const signable = internal.filter((key) => owned.has(key));
+      const expiresAt = new Date(Date.now() + expires_in * 1000).toISOString();
+      const urls = await Promise.all(
+        signable.map(async (key) => ({
+          key,
+          url: await storage.getPresignedUrl(
+            key,
+            expires_in,
+            download ? { responseContentDisposition: `attachment; filename="${basenameForKey(key)}"` } : undefined,
+          ),
+          filename: basenameForKey(key),
+        })),
+      );
+
+      const response = {
+        urls,
+        denied,
+        expiresIn: expires_in,
+        expiresAt,
+        download,
+        hint: 'These URLs are temporary. Fetch or hand them to the user promptly, and re-call get_file_urls instead of reusing an expired URL.',
+      };
+
+      return {
+        text: JSON.stringify(response, null, 2),
+        structuredContent: response,
       };
     },
   });

--- a/server/storage/storage.ts
+++ b/server/storage/storage.ts
@@ -7,6 +7,10 @@ export interface IStorage {
   listObjectsWithMetadata(prefix: string): Promise<{ key: string; size: number | undefined }[]>;
   getSize(key: string): Promise<number | undefined>;
   rename(oldPrefix: string, newPrefix: string): Promise<void>;
-  getPresignedUrl(key: string, expiresIn?: number): Promise<string>;
+  getPresignedUrl(
+    key: string,
+    expiresIn?: number,
+    opts?: { responseContentDisposition?: string; responseContentType?: string },
+  ): Promise<string>;
   getReadStream(key: string): Promise<any>;
 }


### PR DESCRIPTION
Read tools only ever returned internal storage keys, so an MCP client or the
in-app assistant had no way to actually fetch, view, or download a file from an
album, library, or campaign post.

- get_file_urls: signs up to 50 storage keys into temporary presigned URLs
  (60s-24h, default 1h), with an optional download mode that returns an
  attachment URL. Each key is re-checked against the caller's own library
  items, album items, job outputs, and post media; unowned keys and absolute
  URLs come back under "denied" with a reason instead of being signed.
- get_album_items: pages through a project's album and returns each item's
  prompt, format, aspect ratio, size, and storage keys, so a specific
  generated image can be picked before requesting a URL.

Storage is now a tool dependency, threaded through the MCP router and the
assistant runner, and IStorage.getPresignedUrl exposes the response-header
options S3Storage already supported.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>