### PR TITLE
fix(assistant): keep Gemini function call ids through the tool loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ All notable changes to Remix Studio are documented here by version number.
 - **Signed File URLs for MCP & Assistant**: Added a `get_file_urls` tool that turns internal storage keys — from albums, libraries, and campaign post media — into temporary presigned URLs so connected agents can actually view, fetch, or download a file, with an optional `download` mode that returns a save-as link. Keys are only signed when they still belong to the authenticated user's own media; anything else is refused with a reason.
 - **Album Item Browsing over MCP**: Added a `get_album_items` tool that pages through one project's album and returns each item's prompt, format, aspect ratio, size, and storage keys, so an agent can pick a specific generated image before requesting a URL for it.
 
+### Fixed
+
+- **Gemini Batch Tool Calls in the Assistant**: Assistant turns that ran several tools at once — creating a run of campaign posts, for example — died mid-batch on Gemini 3.5 Flash Lite. Gemini issues an id with each parallel function call and, from 3.5 onwards, rejects the follow-up turn unless every function response carries the id back; the adapter was dropping them. Those ids are now kept with the tool call and echoed on both the replayed call and its response. Two calls to the same tool with identical arguments are also no longer merged into one, so a batch containing repeats still creates every item.
+- **Flash Lite Stopping Part-Way Through a Batch**: Flash Lite models default to minimal thinking, which is tuned for one-shot extraction rather than multi-step tool loops. The assistant now asks for a medium thinking level on those models whenever tools are available, so they work through a batch instead of trailing off.
+
 ## [1.18.0] - 2026-07-24
 
 ### Added

--- a/server/assistant/providers/google.ts
+++ b/server/assistant/providers/google.ts
@@ -26,6 +26,11 @@ export function resolveRealGeminiModelId(modelId: string): string {
   return modelId;
 }
 
+/** Gemini's low-latency tier — `gemini-3.5-flash-lite`, `…-flash-lite-preview`, etc. */
+function isFlashLite(modelId: string): boolean {
+  return /flash-lite/.test(modelId);
+}
+
 /**
  * Google AI (Gemini) chat adapter. Uses the official @google/genai SDK.
  */
@@ -61,14 +66,27 @@ export class GoogleAIChatProvider implements ChatProvider {
 
     if (realModelId.includes('gemma-4')) {
       config.thinkingConfig = { thinkingLevel: 'HIGH' } as any;
-    } else if (
-      includeThoughts && (
-        realModelId.includes('gemini-3') ||
-        realModelId.includes('gemini-2.5') ||
-        realModelId.includes('thinking')
-      )
-    ) {
-      config.thinkingConfig = { includeThoughts: true };
+    } else {
+      const thinkingConfig: any = {};
+      if (
+        includeThoughts && (
+          realModelId.includes('gemini-3') ||
+          realModelId.includes('gemini-2.5') ||
+          realModelId.includes('thinking')
+        )
+      ) {
+        thinkingConfig.includeThoughts = true;
+      }
+      // Flash-Lite ships with thinking at its minimal level, which is tuned for
+      // one-shot extraction and classification. Driving a tool loop on that
+      // setting makes the model stop part-way through a batch instead of
+      // continuing, so raise it whenever tools are on the table.
+      if (tools && isFlashLite(realModelId)) {
+        thinkingConfig.thinkingLevel = 'MEDIUM';
+      }
+      if (Object.keys(thinkingConfig).length > 0) {
+        config.thinkingConfig = thinkingConfig;
+      }
     }
 
     const shouldStreamThoughts = typeof req.onThought === 'function'
@@ -113,6 +131,7 @@ export class GoogleAIChatProvider implements ChatProvider {
           name: part.functionCall.name,
           arguments: part.functionCall.args ?? {},
           thoughtSignature: typeof part.thoughtSignature === 'string' ? part.thoughtSignature : undefined,
+          providerCallId: typeof part.functionCall.id === 'string' ? part.functionCall.id : undefined,
         });
       }
     }
@@ -166,17 +185,24 @@ export class GoogleAIChatProvider implements ChatProvider {
           continue;
         }
         if (part.functionCall) {
-          const key = JSON.stringify([
-            part.functionCall.name ?? '',
-            part.functionCall.args ?? {},
-            part.thoughtSignature ?? '',
-          ]);
+          // Prefer the provider's id as the dedupe key: two genuinely distinct
+          // calls in a batch can carry identical name+args (creating the same
+          // post twice, say), and collapsing them would drop work *and* leave
+          // Gemini 3.5+ with fewer responses than calls on the next turn.
+          const key = typeof part.functionCall.id === 'string' && part.functionCall.id
+            ? `id:${part.functionCall.id}`
+            : JSON.stringify([
+              part.functionCall.name ?? '',
+              part.functionCall.args ?? {},
+              part.thoughtSignature ?? '',
+            ]);
           if (!toolCallsByKey.has(key)) {
             toolCallsByKey.set(key, {
               id: `call_${crypto.randomUUID()}`,
               name: part.functionCall.name,
               arguments: part.functionCall.args ?? {},
               thoughtSignature: typeof part.thoughtSignature === 'string' ? part.thoughtSignature : undefined,
+              providerCallId: typeof part.functionCall.id === 'string' ? part.functionCall.id : undefined,
             });
           }
         }
@@ -201,7 +227,11 @@ export class GoogleAIChatProvider implements ChatProvider {
         ...(thoughtText ? [{ text: thoughtText, thought: true }] : []),
         ...(visibleText ? [{ text: visibleText }] : []),
         ...Array.from(toolCallsByKey.values()).map((call) => ({
-          functionCall: { name: call.name, args: call.arguments ?? {} },
+          functionCall: {
+            ...(call.providerCallId ? { id: call.providerCallId } : {}),
+            name: call.name,
+            args: call.arguments ?? {},
+          },
           ...(call.thoughtSignature ? { thoughtSignature: call.thoughtSignature } : {}),
         })),
       ],
@@ -345,6 +375,9 @@ function mapMessages(messages: ChatMessage[]): {
   const systemParts: string[] = [];
   const contents: any[] = [];
   const toolCallNameById = new Map<string, string>();
+  // Internal tool-call id → the id Gemini issued for that call, so the matching
+  // functionResponse can carry it back (required from Gemini 3.5 onwards).
+  const providerCallIdByToolCallId = new Map<string, string>();
   let pendingToolResponses: any[] = [];
 
   const flushPendingToolResponses = () => {
@@ -384,7 +417,12 @@ function mapMessages(messages: ChatMessage[]): {
       if (m.toolCalls) {
         for (const tc of m.toolCalls) {
           toolCallNameById.set(tc.id, tc.name);
-          const part: any = { functionCall: { name: tc.name, args: tc.arguments ?? {} } };
+          const call: any = { name: tc.name, args: tc.arguments ?? {} };
+          if (typeof tc.providerCallId === 'string' && tc.providerCallId.length > 0) {
+            call.id = tc.providerCallId;
+            providerCallIdByToolCallId.set(tc.id, tc.providerCallId);
+          }
+          const part: any = { functionCall: call };
           if (typeof tc.thoughtSignature === 'string' && tc.thoughtSignature.length > 0) {
             part.thoughtSignature = tc.thoughtSignature;
           }
@@ -402,7 +440,14 @@ function mapMessages(messages: ChatMessage[]): {
       } else {
         try { parsed = JSON.parse(m.content); } catch { parsed = { result: m.content }; }
       }
-      pendingToolResponses.push({ functionResponse: { name: m.name, response: parsed } });
+      const providerCallId = providerCallIdByToolCallId.get(m.toolCallId);
+      pendingToolResponses.push({
+        functionResponse: {
+          ...(providerCallId ? { id: providerCallId } : {}),
+          name: m.name,
+          response: parsed,
+        },
+      });
     }
   }
 

--- a/server/assistant/providers/types.ts
+++ b/server/assistant/providers/types.ts
@@ -23,6 +23,13 @@ export interface ToolCall {
   name: string;
   arguments: unknown;
   thoughtSignature?: string;
+  /**
+   * The provider's own identifier for this call, when it issues one. Gemini
+   * 3.5+ hands out an id on every parallel function call and rejects the next
+   * turn with 400 INVALID_ARGUMENT unless the matching functionResponse echoes
+   * it back, so the adapter has to keep it alongside our internal `id`.
+   */
+  providerCallId?: string;
 }
 
 export interface ChatRequest {


### PR DESCRIPTION
Batch work in the assistant — creating a run of campaign posts, say —
failed on Gemini 3.5 Flash Lite while the same prompt went through on the
3.1 Flash Lite entry.

Gemini attaches an id to each parallel function call and, from 3.5
onwards, rejects the next turn with 400 INVALID_ARGUMENT unless every
functionResponse echoes the id of the call it answers. The adapter
generated its own internal ids and dropped Gemini&#39;s, so the second
provider call of any multi-tool turn was rejected. The 3.1 Flash Lite
entry never hit this because resolveRealGeminiModelId rewrites it to
gemini-3-flash-preview, which does not enforce the rule.

Carry the provider&#39;s id on ToolCall, echo it on both the replayed
functionCall and its functionResponse, and dedupe streamed calls by that
id so two identical calls in one batch stay two calls — matching the
&#34;one response per call&#34; rule as well.

Also set a medium thinking level for Flash Lite models when tools are
present; their minimal default is tuned for one-shot extraction and makes
them stop part-way through a tool loop.
