### PR TITLE
Persist workflow disabled-items visibility preference to project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to Remix Studio are documented here by version number.
 ### Added
 
 - **Claude Opus 5**: Added Claude Opus 5 to the Claude provider's text models, with a 1M-token prompt limit and 128K max output. Like Fable 5, Opus 4.8, and Sonnet 5, it accepts only the default temperature.
-- **Hide Disabled Workflow Items**: The project workflow's three-dot menu can now hide disabled items, with a count of how many are hidden. Hiding is view-only — drag-and-drop reordering still uses each item's real position.
+- **Hide Disabled Workflow Items**: The project workflow's three-dot menu can now hide disabled items, with a count of how many are hidden. The choice is saved with the project, so it carries across reloads and devices. Hiding is view-only — drag-and-drop reordering still uses each item's real position.
 - **Signed File URLs for MCP & Assistant**: Added a `get_file_urls` tool that turns internal storage keys — from albums, libraries, and campaign post media — into temporary presigned URLs so connected agents can actually view, fetch, or download a file, with an optional `download` mode that returns a save-as link. Keys are only signed when they still belong to the authenticated user's own media; anything else is refused with a reason.
 - **Album Item Browsing over MCP**: Added a `get_album_items` tool that pages through one project's album and returns each item's prompt, format, aspect ratio, size, and storage keys, so an agent can pick a specific generated image before requesting a URL for it.
 

--- a/prisma/migrations/20260801093000_add_project_show_disabled_items/migration.sql
+++ b/prisma/migrations/20260801093000_add_project_show_disabled_items/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Project" ADD COLUMN "showDisabledItems" BOOLEAN;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -188,29 +188,31 @@ model LibraryItem {
 }
 
 model Project {
-  id             String   @id @default(uuid())
-  userId         String
-  name           String
-  description    String?  @db.Text
-  type           String   @default("image") // "image", "text", or "video"
-  status         String   @default("active") // "active" or "archived"
-  providerId     String?
-  aspectRatio    String?
-  quality        String?
-  format         String?
-  shuffle        Boolean?
-  modelConfigId  String?
-  prefix         String?
-  background     String?
-  systemPrompt   String?  @db.Text
-  temperature    Float?
-  maxTokens      Int?
+  id                String   @id @default(uuid())
+  userId            String
+  name              String
+  description       String?  @db.Text
+  type              String   @default("image") // "image", "text", or "video"
+  status            String   @default("active") // "active" or "archived"
+  providerId        String?
+  aspectRatio       String?
+  quality           String?
+  format            String?
+  shuffle           Boolean?
+  modelConfigId     String?
+  prefix            String?
+  background        String?
+  systemPrompt      String?  @db.Text
+  temperature       Float?
+  maxTokens         Int?
   // Video generation defaults
-  duration       Int? // seconds
-  resolution     String? // '720p' | '1080p' | '4k'
-  sound          String? // 'on' | 'off'
-  lastQueueCount Int?
-  createdAt      DateTime @default(now())
+  duration          Int? // seconds
+  resolution        String? // '720p' | '1080p' | '4k'
+  sound             String? // 'on' | 'off'
+  lastQueueCount    Int?
+  // Workflow view preference: null/true shows disabled items, false hides them.
+  showDisabledItems Boolean?
+  createdAt         DateTime @default(now())
 
   user          User           @relation(fields: [userId], references: [id], onDelete: Cascade)
   jobs          Job[]

--- a/server/db/project-repository.ts
+++ b/server/db/project-repository.ts
@@ -162,6 +162,7 @@ export class ProjectRepository {
       resolution: (p as any).resolution ?? undefined,
       sound: (p as any).sound ?? undefined,
       lastQueueCount: (p as any).lastQueueCount ?? undefined,
+      showDisabledItems: (p as any).showDisabledItems ?? undefined,
       jobs: [],
       workflow: [],
       album: [],
@@ -395,6 +396,7 @@ export class ProjectRepository {
         resolution: project.resolution ?? null,
         sound: project.sound ?? null,
         lastQueueCount: project.lastQueueCount ?? null,
+        showDisabledItems: project.showDisabledItems ?? null,
       } as any,
     });
 
@@ -424,6 +426,7 @@ export class ProjectRepository {
     if (updates.resolution !== undefined) data.resolution = updates.resolution ?? null;
     if (updates.sound !== undefined) data.sound = updates.sound ?? null;
     if (updates.lastQueueCount !== undefined) data.lastQueueCount = updates.lastQueueCount ?? null;
+    if (updates.showDisabledItems !== undefined) data.showDisabledItems = updates.showDisabledItems ?? null;
 
     if (Object.keys(data).length > 0) {
       await this.prisma.project.updateMany({ where: { id: projectId, userId }, data: data as any });

--- a/server/routes/projects.ts
+++ b/server/routes/projects.ts
@@ -528,6 +528,7 @@ export function createProjectRouter(repository: IRepository, userRepository: Use
         resolution: typeof body.resolution === 'string' ? body.resolution : undefined,
         sound: body.sound === 'on' || body.sound === 'off' ? body.sound : undefined,
         lastQueueCount: typeof body.lastQueueCount === 'number' ? body.lastQueueCount : undefined,
+        showDisabledItems: typeof body.showDisabledItems === 'boolean' ? body.showDisabledItems : undefined,
       };
 
       await repository.createProject(user.userId, project);
@@ -594,6 +595,7 @@ export function createProjectRouter(repository: IRepository, userRepository: Use
       if (typeof body?.resolution === 'string') updates.resolution = body.resolution;
       if (body?.sound === 'on' || body?.sound === 'off') updates.sound = body.sound;
       if (typeof body?.lastQueueCount === 'number') updates.lastQueueCount = body.lastQueueCount;
+      if (typeof body?.showDisabledItems === 'boolean') updates.showDisabledItems = body.showDisabledItems;
       
       // Storage check for new jobs (Drafts)
       if (updates.jobs) {

--- a/src/components/ProjectViewer.tsx
+++ b/src/components/ProjectViewer.tsx
@@ -2079,6 +2079,28 @@ export function ProjectViewer({ project, libraries, onUpdate: onUpdateProp, onDe
     }
   };
 
+  // Whether disabled workflow items are shown is a per-project preference stored on
+  // the project, so hiding them on one device carries over to the next. Missing means
+  // "show" — that was the behaviour before the preference was persisted.
+  const showDisabledItems = localProject.showDisabledItems ?? true;
+
+  const handleToggleShowDisabledItems = async () => {
+    const previous = showDisabledItems;
+    const next = !previous;
+    // Applied optimistically: it only filters the list, so waiting on the write
+    // would make the menu feel unresponsive.
+    setLocalProject((prev) => ({ ...prev, showDisabledItems: next }));
+    try {
+      // Written on its own rather than through onUpdate, which re-sends the whole
+      // workflow — far too much traffic for flipping a view filter.
+      await apiUpdateProject(localProject.id, { showDisabledItems: next });
+    } catch (e) {
+      console.error('Failed to save disabled-item visibility:', e);
+      setLocalProject((prev) => ({ ...prev, showDisabledItems: previous }));
+      toast.error(t('projectViewer.toasts.disabledVisibilityFailed'));
+    }
+  };
+
   const handleToggleItemDisable = (id: string) => {
     const updated = {
       ...localProject,
@@ -2189,6 +2211,8 @@ export function ProjectViewer({ project, libraries, onUpdate: onUpdateProp, onDe
         setIsModelSelectorOpen={setIsModelSelectorOpen}
         onAddDraftsToQueue={addDraftsToQueue}
         onToggleDisable={handleToggleItemDisable}
+        showDisabledItems={showDisabledItems}
+        onToggleShowDisabledItems={handleToggleShowDisabledItems}
         onFilesDrop={handleFilesDrop}
       />
 

--- a/src/components/ProjectViewer/WorkflowPanel.tsx
+++ b/src/components/ProjectViewer/WorkflowPanel.tsx
@@ -59,6 +59,8 @@ interface WorkflowPanelProps {
   setIsModelSelectorOpen: (open: boolean) => void;
   onAddDraftsToQueue: () => void;
   onToggleDisable?: (id: string) => void;
+  showDisabledItems: boolean;
+  onToggleShowDisabledItems: () => void;
   onFilesDrop?: (files: File[]) => void;
 }
 
@@ -115,13 +117,14 @@ export function WorkflowPanel({
   setIsModelSelectorOpen,
   onAddDraftsToQueue,
   onToggleDisable,
+  showDisabledItems,
+  onToggleShowDisabledItems,
   onFilesDrop,
 }: WorkflowPanelProps) {
   const { t } = useTranslation();
   const [isActionMenuOpen, setIsActionMenuOpen] = useState(false);
   const [isProjectInfoOpen, setIsProjectInfoOpen] = useState(false);
   const [isDragOverFiles, setIsDragOverFiles] = useState(false);
-  const [showDisabledItems, setShowDisabledItems] = useState(true);
   const actionMenuRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
@@ -281,7 +284,7 @@ export function WorkflowPanel({
               {isActionMenuOpen && (
                 <div className="absolute right-0 top-full mt-2 w-52 p-2 rounded-xl border border-neutral-200/60 dark:border-white/10 bg-white/90 dark:bg-neutral-900/95 backdrop-blur-xl shadow-xl z-30">
                   <button
-                    onClick={() => closeMenuAndRun(() => setShowDisabledItems((show) => !show))}
+                    onClick={() => closeMenuAndRun(onToggleShowDisabledItems)}
                     disabled={disabledItemsCount === 0}
                     className={`${menuButtonBaseClass} justify-between text-neutral-600 dark:text-neutral-300 hover:text-neutral-900 dark:hover:text-white hover:bg-neutral-100/80 dark:hover:bg-neutral-800/80 disabled:opacity-40 disabled:hover:bg-transparent disabled:hover:text-neutral-600 dark:disabled:hover:text-neutral-300`}
                   >

--- a/src/locales/en/project-viewer.json
+++ b/src/locales/en/project-viewer.json
@@ -47,6 +47,7 @@
       "archived": "Archived \"{{name}}\"",
       "unarchived": "Restored \"{{name}}\"",
       "archiveFailed": "Failed to change archive status. Please try again.",
+      "disabledVisibilityFailed": "Failed to save the disabled-item view setting. Please try again.",
       "savedToLibrary": "Saved to library",
       "saveToLibraryFailed": "Failed to save to library",
       "startJobsFailed": "Failed to start jobs. Please try again.",

--- a/src/locales/fr/project-viewer.json
+++ b/src/locales/fr/project-viewer.json
@@ -47,6 +47,7 @@
       "archived": "« {{name}} » archivé",
       "unarchived": "« {{name}} » restauré",
       "archiveFailed": "Échec du changement de statut d'archive. Veuillez réessayer.",
+      "disabledVisibilityFailed": "Échec de l'enregistrement du réglage d'affichage des éléments désactivés. Veuillez réessayer.",
       "savedToLibrary": "Enregistré dans la bibliothèque",
       "saveToLibraryFailed": "Échec de l'enregistrement dans la bibliothèque",
       "startJobsFailed": "Impossible de démarrer les tâches. Réessayez.",

--- a/src/locales/ja/project-viewer.json
+++ b/src/locales/ja/project-viewer.json
@@ -47,6 +47,7 @@
       "archived": "「{{name}}」をアーカイブしました",
       "unarchived": "「{{name}}」を復元しました",
       "archiveFailed": "アーカイブ状態の変更に失敗しました。もう一度お試しください。",
+      "disabledVisibilityFailed": "無効アイテムの表示設定を保存できませんでした。もう一度お試しください。",
       "savedToLibrary": "ライブラリに保存しました",
       "saveToLibraryFailed": "ライブラリへの保存に失敗しました",
       "startJobsFailed": "ジョブを開始できませんでした。もう一度お試しください。",

--- a/src/locales/ko/project-viewer.json
+++ b/src/locales/ko/project-viewer.json
@@ -47,6 +47,7 @@
       "archived": "\"{{name}}\" 보관됨",
       "unarchived": "\"{{name}}\" 복원됨",
       "archiveFailed": "보관 상태를 변경하지 못했습니다. 다시 시도하세요.",
+      "disabledVisibilityFailed": "비활성 항목 표시 설정을 저장하지 못했습니다. 다시 시도해 주세요.",
       "savedToLibrary": "라이브러리에 저장했습니다",
       "saveToLibraryFailed": "라이브러리에 저장하지 못했습니다",
       "startJobsFailed": "작업을 시작하지 못했습니다. 다시 시도해 주세요.",

--- a/src/locales/zh-CN/project-viewer.json
+++ b/src/locales/zh-CN/project-viewer.json
@@ -47,6 +47,7 @@
       "archived": "已归档 “{{name}}”",
       "unarchived": "已恢复 “{{name}}”",
       "archiveFailed": "更改归档状态失败，请重试。",
+      "disabledVisibilityFailed": "无法保存已禁用项目的显示设置，请重试。",
       "savedToLibrary": "已保存到资料库",
       "saveToLibraryFailed": "保存到资料库失败",
       "startJobsFailed": "启动任务失败，请重试。",

--- a/src/locales/zh-TW/project-viewer.json
+++ b/src/locales/zh-TW/project-viewer.json
@@ -47,6 +47,7 @@
       "archived": "已封存「{{name}}」",
       "unarchived": "已還原「{{name}}」",
       "archiveFailed": "變更封存狀態失敗，請再試一次。",
+      "disabledVisibilityFailed": "無法儲存已停用項目的顯示設定，請再試一次。",
       "savedToLibrary": "已儲存到資料庫",
       "saveToLibraryFailed": "儲存到資料庫失敗",
       "startJobsFailed": "啟動任務失敗，請重試。",

--- a/src/types.ts
+++ b/src/types.ts
@@ -1609,6 +1609,8 @@ export interface Project {
   steps?: number;
   guidance?: number;
   lastQueueCount?: number;
+  // Workflow view preference: undefined/true shows disabled items, false hides them.
+  showDisabledItems?: boolean;
 }
 
 export type ProviderType = 'GoogleAI' | 'VertexAI' | 'RunningHub' | 'KlingAI' | 'OpenAI' | 'Grok' | 'Claude' | 'BytePlus' | 'Replicate' | 'BlackForestLabs' | 'Alibabacloud';


### PR DESCRIPTION
## Summary
This change persists the &#34;show/hide disabled workflow items&#34; preference to the project, so the user&#39;s choice carries across page reloads and devices, rather than resetting to the default on each session.

## Key Changes

- **Database Schema**: Added `showDisabledItems` boolean field to the `Project` model in Prisma schema and created migration
- **Backend**: Updated project repository and routes to handle the new field in create/update operations with proper type validation
- **Frontend State Management**: Moved `showDisabledItems` state from local component state in `WorkflowPanel` to the project object, making it persistent
- **API Integration**: Added optimized API call (`apiUpdateProject`) that updates only the visibility preference without re-sending the entire workflow
- **Error Handling**: Implemented rollback on save failure with user-facing toast notification
- **Localization**: Added error message translations for the visibility save failure across all supported languages (EN, FR, JA, KO, ZH-CN, ZH-TW)
- **Type Definitions**: Updated `Project` interface to include the new optional field with documentation

## Implementation Details

- The preference defaults to `true` (show disabled items) when undefined, maintaining backward compatibility
- Uses optimistic UI updates for responsiveness—the filter is applied immediately while the save happens in the background
- The visibility preference is saved independently from the workflow to minimize network traffic
- Disabled items remain in their actual positions for drag-and-drop operations; the filtering is view-only
