### PR TITLE
Add keyboard shortcut (H) to toggle disabled workflow items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to Remix Studio are documented here by version number.
 ### Added
 
 - **Claude Opus 5**: Added Claude Opus 5 to the Claude provider's text models, with a 1M-token prompt limit and 128K max output. Like Fable 5, Opus 4.8, and Sonnet 5, it accepts only the default temperature.
-- **Hide Disabled Workflow Items**: The project workflow's three-dot menu can now hide disabled items, with a count of how many are hidden. The choice is saved with the project, so it carries across reloads and devices. Hiding is view-only — drag-and-drop reordering still uses each item's real position.
+- **Hide Disabled Workflow Items**: The project workflow's three-dot menu can now hide disabled items, with a count of how many are hidden, and the `H` key toggles them from anywhere in the project view (the menu entry shows the shortcut). The choice is saved with the project, so it carries across reloads and devices. Hiding is view-only — drag-and-drop reordering still uses each item's real position.
 - **Signed File URLs for MCP & Assistant**: Added a `get_file_urls` tool that turns internal storage keys — from albums, libraries, and campaign post media — into temporary presigned URLs so connected agents can actually view, fetch, or download a file, with an optional `download` mode that returns a save-as link. Keys are only signed when they still belong to the authenticated user's own media; anything else is refused with a reason.
 - **Album Item Browsing over MCP**: Added a `get_album_items` tool that pages through one project's album and returns each item's prompt, format, aspect ratio, size, and storage keys, so an agent can pick a specific generated image before requesting a URL for it.
 

--- a/src/components/ProjectViewer.tsx
+++ b/src/components/ProjectViewer.tsx
@@ -2084,7 +2084,7 @@ export function ProjectViewer({ project, libraries, onUpdate: onUpdateProp, onDe
   // "show" — that was the behaviour before the preference was persisted.
   const showDisabledItems = localProject.showDisabledItems ?? true;
 
-  const handleToggleShowDisabledItems = async () => {
+  const handleToggleShowDisabledItems = useCallback(async () => {
     const previous = showDisabledItems;
     const next = !previous;
     // Applied optimistically: it only filters the list, so waiting on the write
@@ -2099,7 +2099,37 @@ export function ProjectViewer({ project, libraries, onUpdate: onUpdateProp, onDe
       setLocalProject((prev) => ({ ...prev, showDisabledItems: previous }));
       toast.error(t('projectViewer.toasts.disabledVisibilityFailed'));
     }
-  };
+  }, [showDisabledItems, localProject.id, t]);
+
+  // Pressing H toggles the disabled-item filter, mirroring the workflow menu entry.
+  // Ignored while typing, while a modifier is held (so browser and OS shortcuts still
+  // work), and while a modal, lightbox, or drawer is open — those cover the workflow
+  // list and some carry single-letter shortcuts of their own.
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key !== 'h' && e.key !== 'H') return;
+      if (e.metaKey || e.ctrlKey || e.altKey || e.isComposing) return;
+
+      const active = (e.target as HTMLElement | null) ?? (document.activeElement as HTMLElement | null);
+      if (active) {
+        const tagName = active.tagName.toLowerCase();
+        if (tagName === 'input' || tagName === 'textarea' || tagName === 'select' || active.isContentEditable) return;
+      }
+
+      // Overlays in this app are all full-screen `fixed inset-0` layers, so their
+      // presence is the cheapest reliable signal that something sits on top.
+      if (document.querySelector('.fixed.inset-0')) return;
+
+      // No-op with nothing to hide, matching the menu entry being disabled then.
+      if (!(localProject.workflow || []).some((item) => item.disabled)) return;
+
+      e.preventDefault();
+      void handleToggleShowDisabledItems();
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [localProject.workflow, handleToggleShowDisabledItems]);
 
   const handleToggleItemDisable = (id: string) => {
     const updated = {

--- a/src/components/ProjectViewer/WorkflowPanel.tsx
+++ b/src/components/ProjectViewer/WorkflowPanel.tsx
@@ -294,9 +294,14 @@ export function WorkflowPanel({
                         {t(showDisabledItems ? 'projectViewer.main.hideDisabledItems' : 'projectViewer.main.showDisabledItems')}
                       </span>
                     </span>
-                    {disabledItemsCount > 0 && (
-                      <span className="shrink-0 text-[9px] font-black text-neutral-500 dark:text-neutral-500">{disabledItemsCount}</span>
-                    )}
+                    <span className="shrink-0 flex items-center gap-1.5">
+                      {disabledItemsCount > 0 && (
+                        <span className="text-[9px] font-black text-neutral-500 dark:text-neutral-500">{disabledItemsCount}</span>
+                      )}
+                      <kbd className="hidden lg:inline-flex items-center rounded border border-neutral-200 dark:border-white/10 bg-neutral-100 dark:bg-neutral-800 px-1.5 font-mono text-[10px] font-medium text-neutral-500 dark:text-neutral-400">
+                        H
+                      </kbd>
+                    </span>
                   </button>
 
                   <div className="my-1 h-px bg-neutral-200/60 dark:bg-white/10" />


### PR DESCRIPTION
## Summary
Added keyboard shortcut support to toggle the visibility of disabled workflow items in the project view. Users can now press `H` to quickly toggle the disabled items filter without accessing the menu.

## Key Changes
- **Memoized toggle handler**: Wrapped `handleToggleShowDisabledItems` with `useCallback` to optimize performance and enable safe use in event listeners
- **Keyboard event listener**: Added a `useEffect` hook that listens for the `H` key and triggers the toggle with appropriate guards:
  - Ignores input when typing in form fields (input, textarea, select, contentEditable)
  - Respects modifier keys (Ctrl, Cmd, Alt) to avoid interfering with browser/OS shortcuts
  - Skips activation when modals, lightboxes, or drawers are open (detected via `.fixed.inset-0` selector)
  - Only activates when there are actually disabled items to toggle
- **UI enhancement**: Updated the workflow menu button to display the `H` keyboard shortcut hint next to the disabled items count (visible on lg screens and above)
- **Documentation**: Updated CHANGELOG to reflect the new keyboard shortcut feature

## Implementation Details
- The keyboard handler uses event delegation and checks the active element to prevent conflicts with text input
- Full-screen overlay detection prevents the shortcut from firing when UI overlays are present
- The shortcut is disabled when there are no disabled items, matching the menu entry&#39;s disabled state
- Proper cleanup of event listeners on component unmount
