### PR TITLE
Expand and audit product documentation

### DIFF
--- a/docs-site/concepts/assistant.md
+++ b/docs-site/concepts/assistant.md
@@ -1,36 +1,89 @@
 # The Assistant
 
-Remix Studio ships with a built-in **assistant** that can plan and operate workflows in chat. It is the "assistant-first" half of the product: you describe what you want, and it inspects your workspace and prepares changes for you.
+Remix Studio includes a persistent, tool-using assistant for planning and operating the workspace in chat. It uses the same account-scoped tool definitions as the [MCP server](/integrations/mcp), while providing an in-app confirmation UI and conversation history.
 
-## What It Can Do
+## Requirements and Model Selection
 
-The assistant uses the same **shared tool layer** as the [MCP integration](/integrations/mcp), so it can:
+The assistant does not use a hidden global model credential. Create a provider in Remix Studio, then choose an assistant-capable text model in the composer or **Assistant Settings**.
 
-- Inspect [libraries](/concepts/libraries), album summaries, [model availability](/concepts/models), and [storage](/concepts/storage) status.
-- Create libraries and prompts, including batch creation.
-- Assemble and update [workflow-backed projects](/concepts/projects).
-- Prepare project mutations behind **explicit confirmation** — write and destructive actions are confirmation-gated.
+The chat runtime currently supports provider records of these types:
 
-## Confirmation Model
+- **Google AI**
+- **OpenAI**
+- **Claude (Anthropic)**
+- **Alibaba Cloud**
 
-The assistant does not silently mutate your workspace. Write and destructive tool calls surface a confirmation step (an approved-tools flow), so you stay in control of what actually changes.
+Other provider families may generate project assets without being available as the assistant's chat model. A saved provider must belong to the user and contain a decryptable API key. API URL overrides are honored after the same URL-safety validation used elsewhere in the server.
 
-## Model Providers
+The selected provider and model are stored on the conversation. The most recent selection is also remembered locally as the default for a new chat.
 
-The assistant is powered by Gemini models by default, and the assistant runner supports multiple backends — Google, Anthropic, OpenAI, Grok, and Alibaba Cloud — selectable in assistant settings.
+## Workspace Context
 
-## Chat History & Settings
+The assistant can read account-scoped workspace data through tools rather than relying on a stale copy in the prompt. Read capabilities include:
 
-- **Chat History** keeps your previous assistant conversations.
-- **Assistant Settings** controls the model, behavior, and approved tools. Navigation preserves return paths so backing out lands you where you started.
+- Libraries and paginated/searchable library items.
+- Storage totals and category breakdowns.
+- Project workflows and album summaries.
+- Usable provider/model pairings.
+- Social accounts, campaigns, posts, post text, and post media metadata.
+
+The composer can bind workspace context and attach supported images. With a Google AI provider selected, the microphone control records audio in the browser and transcribes it through the configured Google provider before sending the resulting text.
+
+## Skills
+
+Assistant skills are prompt templates stored in a dedicated text library. Manage them under **Assistant Settings → Skills**, then type `/` in the composer to search and insert one.
+
+Skills help standardize recurring instructions; they do not add server permissions or bypass tool confirmation. Editing or deleting a skill is the same kind of library-item operation as editing other reusable text.
+
+## Tools and What They Can Change
+
+The assistant can:
+
+- Create and describe libraries.
+- Create prompts individually or in batches.
+- Update prompt text, titles, and tags, including batch metadata updates.
+- Create projects with complete workflows and update existing projects.
+- Create and update campaigns and posts, attach owned media, and schedule posts.
+
+The tool catalog is visible under **Assistant Settings → Tools**, including each tool's input schema, category, and whether approval is required.
+
+## Confirmation and Approval Modes
+
+Tools are categorized as read, write, or destructive.
+
+- **Read tools** run without a mutation confirmation.
+- **Write tools** pause and show a human-readable summary plus the exact arguments.
+- **Destructive tools** also require explicit confirmation and cannot be placed on the auto-approved write list.
+
+For a write tool, you can approve only the pending call or approve that tool for future calls in the current conversation. Conversation approvals are stored per chat and can be changed from the tool-approvals dialog. They do not become a global permission for other conversations.
+
+Pending confirmations expire. Cancelling one records the cancellation and lets the conversation continue without applying the change.
+
+::: warning
+Approving a tool means later calls to that named write tool in the same conversation can execute without another prompt. Review the approved-tools list when a conversation's purpose changes.
+:::
+
+## Conversation History
+
+Messages, tool calls, structured arguments/results, token counts, errors, and pending confirmations are persisted separately from project generation jobs. This keeps chat history independent of the generation queue.
+
+The history screen can reopen previous conversations and archive chats you no longer need in the active list. Deleting a conversation removes its messages and confirmation records; it does not undo workspace changes the conversation already performed.
 
 ## Assistant vs. MCP
 
-| | In-App Assistant | [MCP Clients](/integrations/mcp) |
+| | In-app assistant | External MCP client |
 | :--- | :--- | :--- |
-| Where it runs | Inside Remix Studio | External clients (Claude, Codex, …) |
-| Tool layer | Shared registry | Shared registry |
-| Auth | Your logged-in session | OAuth 2.0 / personal access token |
-| Confirmation | Approved-tools flow | Confirmation-gated write/destructive tools |
+| Interface | Remix Studio chat UI | Claude, Codex, or another MCP client |
+| Authentication | Logged-in Remix Studio session | OAuth 2.0 or personal access token |
+| Tool definitions | Shared registry | Shared registry |
+| Read tools | Execute directly | Execute directly |
+| Write confirmation | In-app confirmation; eligible write tools can be approved per conversation | Two-call preview and hash-confirmation protocol |
+| Conversation storage | Stored by Remix Studio | Managed by the external client |
 
-Because both use the same registry, chat orchestration and external automation stay aligned.
+Both paths enforce user ownership in each handler. IDs supplied by a model do not grant access to another user's records.
+
+## Related
+
+- [MCP Support](/integrations/mcp) — authentication and the external confirmation protocol.
+- [Libraries & Prompts](/concepts/libraries) — reusable data and assistant skills.
+- [Campaigns](/concepts/campaigns) — campaign/post tools available to the assistant.

--- a/docs-site/concepts/campaigns.md
+++ b/docs-site/concepts/campaigns.md
@@ -1,46 +1,120 @@
 # Campaigns
 
-The **campaign workspace** turns generated copy and media into scheduled social posts. It connects generation output, reusable media, scheduling, post history, and social channel delivery in the same app.
+Campaigns organize social posts, target channels, media preparation, schedules, and per-channel publishing results. They are separate from generation projects: project/library media can be reused in posts, but a campaign has its own records and lifecycle.
 
-## What a Campaign Contains
+## Campaign Lifecycle
 
-- **Posts** with copy and attached media.
-- A **scheduling timeline** for when posts publish.
-- **Connected channels** to publish through.
-- **History** of published and failed posts.
+A campaign stores a name, description, status, posts, and a set of connected social accounts.
 
-## Batch Post Creation
+- **Active** campaigns can schedule and publish posts.
+- Pausing/archiving a campaign prevents the scheduler from publishing its posts until the campaign becomes active again.
+- Deleting a campaign removes its posts, media records, and execution history, including campaign-owned uploaded objects.
 
-Just like workflows expand inputs into drafts, campaigns can generate **post copy in batches** and attach reusable media. Campaign media creation runs as **asynchronous batch processing with status polling**, and batch actions show **thumbnail previews** of attached media.
+Assigning a channel targets that social account for posts in the campaign. Disconnecting the account removes its stored tokens and stops campaigns from targeting it; it does not delete posts already published on the social platform.
 
-## Channels
+## Posts
 
-Connect social accounts under **Campaigns → Channels**. Supported channels:
+A post contains optional text, ordered media, a status, an optional schedule, and one execution record per target social account.
 
-- **X (Twitter)** — see [X Setup](/integrations/x-platform).
-- **Threads (Meta)** — see [Threads Setup](/integrations/threads-platform).
+The editor:
 
-Connection status is surfaced through UI toasts, and channel-specific API errors are parsed and reported clearly. Disconnecting a channel deletes the stored social account and its tokens.
+- Requires at least text or media.
+- Accepts image and video uploads.
+- Lets you remove and drag to reorder media.
+- Supports up to four media items in the current post editor.
+- Saves without a time as a draft.
+- Rejects a scheduled time less than about five minutes in the future in the UI.
 
-## Scheduling & Publishing
+Post media moves through `pending`, `processing`, `ready`, or `failed`. Images are processed into platform-ready assets; current video/GIF processing preserves the uploaded source while marking it ready. A post cannot be scheduled or published while attached media is unready.
 
-- Posts are scheduled on a timeline and published through connected channels at their scheduled time.
-- The scheduler proactively refreshes long-lived OAuth tokens before they expire, so scheduled posts keep working without you reconnecting.
-- **Scheduled Posts** and **Campaign History** views let you track upcoming and past posts.
+## Post and Execution States
 
-## Media Requirements
+Post status summarizes the whole post:
 
-Social platforms fetch media from a **public URL** that the platform requests server-side. Remix Studio supplies time-limited presigned URLs from your configured [S3-compatible storage](/concepts/storage).
+| Status | Meaning |
+| :--- | :--- |
+| `draft` | Editable and not scheduled |
+| `scheduled` | Waiting for its due time |
+| `queued` | Fan-out to channel execution records has begun |
+| `completed` | At least one channel execution posted successfully and all executions settled |
+| `failed` | Publishing could not produce a successful result |
+
+Each target channel has a separate execution with `pending`, `publishing`, `posted`, or `failed` status, attempt count, retry time, error, and remote URL/ID. The post detail screen shows these per-channel results.
+
+## Scheduling and Send Now
+
+When a scheduled post becomes due, the scheduler:
+
+1. Verifies the campaign is active.
+2. Verifies it has at least one active connected account.
+3. Verifies all media is ready.
+4. Creates or resets one execution per target account.
+5. Queues executions for publishing.
+
+Executions use retry/backoff metadata for transient failures and rate limits. Authentication failures trigger one reactive token refresh when the platform supports it. Final post status is calculated only after all executions settle.
+
+**Send Now** uses the same target-account fan-out without waiting for the schedule. Sending a completed post again creates another publishing attempt and may create another live social post.
+
+## Batch Actions
+
+The campaign Batch Actions view supports searchable, paginated post selection and:
+
+- Batch schedule with a time assigned to each post.
+- Batch unschedule, which returns scheduled posts to draft.
+- Batch Send Now for an active campaign.
+- Batch AI text generation.
+- Creating one new draft post per selected/uploaded media item.
+
+Batch operations report skipped items individually—for example, already completed posts, invalid dates, or media that is still processing.
+
+### Batch Media Post Creation
+
+The media batch screen queues uploads or owned media from libraries/albums and creates **one post per media item**. Local files are encoded and sent once; the server processes the batch asynchronously while the browser polls progress.
+
+Optional per-user watermark settings are applied to image media during processing. Thumbnail previews show the queued source and the resulting draft posts remain editable.
+
+### Batch AI Text Generation
+
+Select posts, then choose an assistant-capable provider/model and a reusable prompt from a text library or enter instructions directly. The task can optionally include each post's images as model context.
+
+The server processes the selected post IDs asynchronously and reports per-post success/failure. Generated text replaces the targeted post's text; it does not automatically schedule or send the post.
+
+## Connected Channels
+
+The current channel adapters are:
+
+- **X (Twitter)** — OAuth 2.0, media upload, and post creation. See [X Setup](/integrations/x-platform).
+- **Threads (Meta)** — long-lived token flow, public media fetching, and container publishing. See [Threads Setup](/integrations/threads-platform).
+
+Access and refresh tokens are encrypted at rest. The scheduler proactively refreshes eligible tokens before expiry, and the publisher can retry after an authentication failure.
+
+Platform rules still apply. For example, character limits, media combinations, account access tier, and rate limits can cause one channel execution to fail while another succeeds.
+
+## Public Media URLs
+
+Threads and other server-fetch platforms require an internet-reachable, time-limited URL. Remix Studio signs objects from the main storage bucket.
 
 ::: warning
-Your storage's public endpoint (`S3_PUBLIC_ENDPOINT` / custom domain) must be reachable from the public internet, or the platform cannot fetch the media and publishing will fail.
+`S3_PUBLIC_ENDPOINT` must resolve publicly to the same stored objects. An internal endpoint such as `http://minio:9000` is valid for the Remix Studio container but cannot be fetched by a social platform.
 :::
 
-## Watermarking
+X uploads media bytes through its API and therefore has different delivery mechanics, but its size/format rules still apply.
 
-Campaign and album exports support **watermarking**, configured through a dedicated panel, with automated image processing in the delivery queue. Per-product watermark settings also apply to listing covers when [selling exports](/concepts/selling-exports).
+## Watermark Settings
+
+Campaign media watermarks are per-user settings shared with the image-export watermark screen. They include text, position, padding, font size, opacity, and color.
+
+Watermarking creates a processed post asset; it does not overwrite the original library/album source. Video watermarking is not part of the current image watermark utility.
+
+## Tracking Activity
+
+- **Scheduled Posts** lists and searches upcoming posts across campaigns.
+- **Campaign History** shows completed/failed posts and channel errors.
+- **Post Detail** shows media, schedule controls, generated text actions, and every channel execution.
+- Campaign cards summarize total, completed, and scheduled ranges.
 
 ## Related
 
-- [Projects & Albums](/concepts/projects) — the source of campaign media.
-- [Exports & Delivery](/concepts/exports) — package and deliver finished media.
+- [Projects & Albums](/concepts/projects) — sources for reusable generated media.
+- [Libraries & Prompts](/concepts/libraries) — media and AI instruction reuse.
+- [MCP Support](/integrations/mcp) — create/update campaigns and posts programmatically.

--- a/docs-site/concepts/exports.md
+++ b/docs-site/concepts/exports.md
@@ -1,35 +1,87 @@
 # Exports & Delivery
 
-Remix Studio packages generated album media into downloadable **ZIP archives**, and can deliver completed packages to external destinations.
+Exports package project album results into named ZIP archives. Archive creation and external delivery use persistent database task rows and separate background workers, so they continue independently of the browser and the generation queue.
 
-## Creating Exports
+## Creating an Archive
 
-- Exports are created from project [album](/concepts/projects) items.
-- Export tasks run in the **background** and move through `pending`, `processing`, `completed`, or `failed` states.
-- Completed archives are stored in a **separate export bucket** (`S3_EXPORT_BUCKET`).
-- Export creation performs a runtime [storage](/concepts/storage) quota check before uploading the ZIP archive.
+From a project's final-results tab:
 
-## The Archive Page
+1. Select specific items, or leave the selection empty to target the full album.
+2. Enter a package name.
+3. Choose the **raw** or **optimized** asset version where the modality supports both.
+4. For an image project, optionally open the watermark screen.
+5. Queue the export and follow it on **Exports**.
 
-The **Archive / Exports** page shows export status across projects and lets you:
+The server verifies project ownership and resolves the selected album records. Before creating a task it estimates the ZIP size from the chosen asset versions and checks the user's storage quota.
 
-- Download completed ZIPs.
-- Delete export records.
-- Track failed exports.
+Watermarking is currently restricted to image projects. When enabled with non-empty text, each selected image is processed and stored in the ZIP as JPEG.
 
-## Watermarking
+## Export Task Lifecycle
 
-Album exports support **watermarking** via a configuration panel, with a backend watermark utility applied during processing. The same watermark capability extends to product listing covers when [selling exports](/concepts/selling-exports).
+| State | Meaning |
+| :--- | :--- |
+| `pending` | Waiting for an export worker |
+| `processing` | Files are being read, processed, and appended to the archive |
+| `completed` | ZIP uploaded to the export bucket |
+| `failed` | Task stopped with an error |
 
-## External Delivery
+Workers claim tasks in the database, heartbeat while processing, and can reclaim abandoned work after a stale claim. Progress records the number of album items appended.
 
-Completed export packages can be delivered to external destinations such as **Google Drive**, handled by a background delivery queue. The delivery queue also performs the automated image processing used for watermarking covers.
+The final archive is stored in `S3_EXPORT_BUCKET`, separate from project/library objects in `S3_BUCKET`. Its size counts toward the user's archive quota category.
 
-## Selling Exports
+## Raw and Optimized Versions
 
-Beyond downloads and delivery, a finished export can be published as a paid product to a connected store. See [Selling Exports](/concepts/selling-exports).
+When **optimized** is selected, the worker prefers the item's optimized object and falls back to the original if no optimized version exists. **Raw** uses the original output object.
+
+Thumbnails are previews and are not the source of a normal archive. Filename metadata is sanitized for the ZIP, and duplicate entry names are disambiguated.
+
+## The Exports Page
+
+The global page lists exports across projects and shows:
+
+- Queue/archiving progress.
+- Completed size and a download action.
+- Failure messages.
+- Active Google Drive or store-delivery progress.
+- Delete, Drive upload, and sell actions when eligible.
+
+Download URLs are presigned when the task is read and expire after 24 hours. Reload the page to obtain a new URL; the archive itself is not deleted merely because a link expires.
+
+Deleting an export removes both its database task and its export-bucket object. It does not delete the source album items.
+
+## Image Watermark Settings
+
+The watermark screen previews the first selected image and configures text, position, padding, font size, opacity, and color. Settings are stored per user and are saved when the export starts.
+
+The selected scope and raw/optimized choice are carried into the watermark screen. Watermarking creates processed bytes for the archive; it does not overwrite the album originals.
+
+## Google Drive Delivery
+
+Connect Google Drive from the Exports/Account flow. A completed export can then be submitted to the delivery queue.
+
+The delivery worker:
+
+1. Loads the completed ZIP from the export bucket.
+2. Refreshes Google credentials when needed.
+3. Uses a resumable upload and records transferred/total bytes.
+4. Stores the returned external ID/URL on completion.
+
+Disconnecting Drive clears the stored refresh token. It does not remove files already uploaded to Drive.
+
+## Store Delivery
+
+When a supported store is connected, a completed archive can become a digital product. Product publishing uses the same delivery-task infrastructure but adds product metadata, cover processing, file upload, and publish phases.
+
+See [Selling Exports](/concepts/selling-exports).
+
+## Failure and Recovery
+
+Export and delivery tasks store attempts, claim/heartbeat state, and error text. Worker loops can reclaim stale tasks after a process interruption. A failed task remains visible for diagnosis; create a new export or delivery after correcting the underlying storage, credential, or remote-service problem.
+
+Source album files must remain available until export processing completes. Deleting source objects while a task is running can cause the archive to fail.
 
 ## Related
 
-- [Storage](/concepts/storage) — where archives are stored and how they count toward quota.
-- [Queue & Concurrency](/concepts/queue) — exports and deliveries run as background tasks.
+- [Storage](/concepts/storage) — two buckets, quota accounting, and endpoints.
+- [Projects & Albums](/concepts/projects) — selecting source results.
+- [Selling Exports](/concepts/selling-exports) — Gumroad product publishing.

--- a/docs-site/concepts/libraries.md
+++ b/docs-site/concepts/libraries.md
@@ -1,41 +1,111 @@
 # Libraries & Prompts
 
-**Libraries** are reusable collections that keep common prompt fragments and media references out of individual projects. Build them once, reuse them across every [workflow](/concepts/workflows).
+**Libraries** are reusable, typed collections of text or media. A workflow can point at a library instead of embedding a particular item, allowing one project step to expand into every matching item in that collection.
+
+Libraries belong to the signed-in user and can be reused across projects, campaign posts, the in-app assistant, and MCP automation.
 
 ## Library Types
 
-Remix Studio supports reusable libraries for each modality:
+| Type | What an item stores | Typical uses |
+| :--- | :--- | :--- |
+| **Text** | Prompt text, with an optional title and tags | Subjects, styles, instructions, templates, campaign ideas |
+| **Image** | An uploaded image storage key and derived preview data | Reference images, moodboards, products, characters |
+| **Video** | An uploaded video storage key and preview metadata | Motion references and source clips |
+| **Audio** | An uploaded audio storage key and metadata | Voice, music, and other supported audio references |
 
-- **Text libraries** — reusable prompt fragments, style blocks, subject ideas, and prompt-building templates.
-- **Image libraries** — reference images, moodboards, style references, and reusable visual inputs.
-- **Video and audio libraries** — reusable video and audio inputs.
+The library type matters when a workflow is expanded: text items are joined into the generated prompt, while media items become image, video, or audio context arrays.
 
-## Items, Titles & Tags
+## Browsing and Organizing
 
-- Each library contains **ordered items**.
-- Items can include **titles** and **tags** for easier filtering and reuse.
-- The [workflow engine](/concepts/workflows) can filter library items by tags using an **AND/OR tag match mode**.
+The library list supports search, pagination, and pinning. Up to the UI's pin limit can be kept at the top for quick access.
 
-## Editing & Reuse
+Inside a library you can:
 
-- Libraries are edited **independently from projects**, so you can improve a shared collection once and have the change reflected across multiple workflows.
-- Libraries can be created, updated, deleted, and duplicated.
-- A **Library Cleanup** view helps remove unused or orphaned items.
-- A refreshed **Library Preview** modal gives a responsive view of library contents.
+- Search items and filter them by tags.
+- Sort by newest/oldest or by name in ascending/descending order.
+- Edit an item's title and tags; text items can also be edited in the Prompt Editor.
+- Select several items for batch tagging, copying, moving, or deletion.
+- Copy or move items only to a library of the same media type.
+- Duplicate a whole library, including its items.
+- Export media libraries as ZIP archives.
 
-## Import & Export
+Items do **not** have a manually maintained sequence. Their display order comes from the selected sort mode.
 
-Text libraries support **import and export as Markdown-style lists**, so you can bulk-edit prompt collections outside the app and paste them back in.
+## Titles, Tags, and Generated Filenames
 
-## Prompt Editor
+Titles make long prompts and opaque media keys easier to recognize. Tags serve two separate purposes:
 
-Individual text prompts open in a dedicated **Prompt Editor** with rendered Markdown content, so longer prompt templates stay readable.
+1. The library editor can filter the items you see.
+2. A workflow library step can select tags to restrict which items participate in generation.
 
-## Building Libraries Programmatically
+Workflow tag matching can use:
 
-Both the in-app [assistant](/concepts/assistant) and external [MCP clients](/integrations/mcp) can create libraries and prompts (including batch prompt creation), search items across libraries, and update or delete individual text prompts — all through the same shared tool layer used by the UI.
+- **OR** — an item is eligible when it has any selected tag.
+- **AND** — an item is eligible only when it has every selected tag.
+
+Matching is case-insensitive. Items without any selected tag are excluded. When a library item becomes a draft, its title and tags are also used as candidate filename parts; the project prefix and a short random suffix complete the filename.
+
+## Adding and Reusing Items
+
+Text items can be created in the library editor, imported in batches, or created through the assistant/MCP tool layer. Media files can be uploaded directly.
+
+From a project you can also:
+
+- Save a direct workflow input into a compatible library.
+- Copy selected album results—or the whole album—into a new or existing compatible library.
+- Choose the raw or optimized asset version when copying generated media.
+
+Changing a library later changes the choices available to workflows that reference it. Drafts already created keep their resolved prompt, contexts, provider/model settings, and workflow snapshot; they are not silently regenerated.
+
+## Import & Export for Text Libraries
+
+The **Import / Export** screen is available for text libraries and supports plain list text and JSON.
+
+List format:
+
+```text
+- A prompt with no title
+- Portrait lighting: soft window light | tags: portrait, soft
+```
+
+- Every non-empty list line must begin with `- `.
+- Text before the first colon becomes the optional title.
+- `| tags:` adds comma-separated tags.
+- Shared tags entered in the screen are merged into every imported item.
+- The preview reports malformed lines before anything is created.
+
+JSON format is an array of objects:
+
+```json
+[
+  {
+    "title": "Portrait lighting",
+    "content": "soft window light",
+    "tags": ["portrait", "soft"]
+  }
+]
+```
+
+Export can include titles and tags or produce a simpler plain list. Import appends items; it does not replace the existing library.
+
+## Deleting a Referenced Library
+
+A library can be referenced by workflow items in more than one project. If it is still referenced, deletion opens **Library Cleanup**.
+
+Cleanup lists the projects that use the library and lets you remove those workflow references one project at a time, or remove all references and then delete the library. It does **not** scan for or delete “orphaned” items inside the library.
+
+::: warning
+Removing a reference changes the affected project's workflow. Deleting the library and its stored media is permanent; library items do not go to the project recycle bin.
+:::
+
+## Assistant and MCP Access
+
+The shared tool layer can list and search libraries, browse their items, create and update libraries, create prompts individually or in batches, and update item metadata. Text prompts can also be deleted through the explicitly confirmed destructive tool.
+
+See [The Assistant](/concepts/assistant) for the in-app approval flow and [MCP Support](/integrations/mcp) for external clients.
 
 ## Related
 
-- [Workflows & Combinations](/concepts/workflows) — how library inputs get expanded.
-- [Browser Extension](/integrations/chrome-extension) — send images and text from any web page straight into a library.
+- [Workflows & Combinations](/concepts/workflows) — how library choices become drafts.
+- [Projects & Albums](/concepts/projects) — copy results back into libraries.
+- [Browser Extension](/integrations/chrome-extension) — import page content into a library.

--- a/docs-site/concepts/models.md
+++ b/docs-site/concepts/models.md
@@ -30,15 +30,15 @@ This matrix reflects the profiles shipped with the current release. Model availa
 | **Vertex AI** | `Gemini 3.6 Flash`, `Gemini 3.5 Flash`, `Gemini 3.5 Flash Lite`, `Gemini 3.1 Pro`, `Gemini 3.1 Flash Lite` |
 | **OpenAI** | `GPT-5.6`, `GPT-5.6 Terra`, `GPT-5.6 Luna`, `GPT-5.5`, `GPT-5.4`, `GPT-5.4 Mini`, `GPT-5.4 Nano` |
 | **Grok** | `Grok 4.5`, `Grok 4.20`, `Grok 4.3`, `Grok 4.1 Fast` |
-| **Claude** | `Claude Sonnet 5`, `Claude Opus 4.7`, `Claude Sonnet 4.6`, `Claude Haiku 4.5` |
+| **Claude** | `Claude Fable 5`, `Claude Opus 5`, `Claude Opus 4.8`, `Claude Sonnet 5`, `Claude Opus 4.7`, `Claude Sonnet 4.6`, `Claude Haiku 4.5` |
 | **Alibaba Cloud DashScope** | `Qwen3.6 Max`, `Qwen3.6 Plus`, `Qwen3.6 Flash`, `Qwen3.6 VL Max`, `Qwen3.6 VL Plus` |
 
 ## 3. Image Generation
 
 | Provider | Supported Models |
 | :--- | :--- |
-| **Google AI** | `nano banana 2`, `nano banana 2 Lite` |
-| **Vertex AI** | `nano banana 2`, `nano banana 2 Lite` |
+| **Google AI** | `nano banana 2`, `nano banana Pro`, `nano banana 2 Lite` |
+| **Vertex AI** | `nano banana 2`, `nano banana Pro`, `nano banana 2 Lite` |
 | **OpenAI** | `GPT Image 2`, `GPT Image 1.5`, `GPT Image 1 Mini` |
 | **Grok** | `Grok Imagine`, `Grok Imagine Pro` |
 | **RunningHub** | `nano banana 2`, `nano banana Pro`, `GPT Image 2`, `Qwen Image 2 Pro`, `Grok Imagine Pro`, `Seedream 5.0 Pro`, `Seedream V5 Pro`, `Wan 2.7 Pro` |
@@ -70,17 +70,21 @@ This matrix reflects the profiles shipped with the current release. Model availa
 
 ## 6. Chat Assistant Models
 
-The built-in Remix Studio [Assistant](/concepts/assistant) acts as your agent within the app. By default, it is powered by **Gemini** models (such as `Gemini 3.1 Pro`), but the assistant runner supports multiple backends. You can select your preferred assistant model from the assistant settings, including capable reasoning models from:
-- **Google AI / Vertex AI** (e.g., Gemini)
+The in-app [Assistant](/concepts/assistant) can use text profiles belonging to provider records of these types:
+
+- **Google AI**
 - **Anthropic (Claude)**
 - **OpenAI**
-- **Grok**
 - **Alibaba Cloud**
 
-These models are optimized for tool-calling and understanding the internal state of your library and storage.
+Vertex AI and Grok profiles can be used by generation projects where supported, but their provider types are not accepted by the current assistant chat adapter.
+
+The assistant receives the shared tool catalog independently of the model profile. Successful orchestration still depends on the upstream model handling tool calls reliably; a profile being categorized as text does not guarantee equal agent performance.
 
 ## Choosing Models
 
 - Models are selected per provider as saved **model profiles**, so jobs reference a profile instead of repeating raw model settings.
-- A project sets a default provider; individual jobs can override the provider (and therefore the model). See [Providers & Models](/concepts/providers).
+- A project sets a default provider/model; the resolved choice is copied into each draft/job. See [Providers & Models](/concepts/providers).
 - The assistant and MCP clients can list usable model/provider pairings via `list_available_models`.
+- Profile options drive the project UI: prompt limits, context support, aspect ratio, quality, background, duration, resolution, sound, and audio-format controls are shown only when declared.
+- A custom alias adds a model to an existing provider adapter; it does not add a new transport or generator family.

--- a/docs-site/concepts/projects.md
+++ b/docs-site/concepts/projects.md
@@ -1,69 +1,104 @@
 # Projects & Albums
 
-A **project** is the workspace where you compose a [workflow](/concepts/workflows), run it, and collect the results. Each project holds an **album** of generated and uploaded media.
+A **project** owns a generation workflow, output settings, draft and execution records, and a durable result collection. Project data is user-scoped and stored in PostgreSQL; media is stored under the user's project prefix in the configured object store.
+
+## Project Types
+
+Choose the type according to the output you want:
+
+| Project type | Output | Common settings |
+| :--- | :--- | :--- |
+| **Text** | Generated text | System prompt, temperature, maximum tokens |
+| **Image** | Generated images | Aspect ratio, quality, format, background |
+| **Video** | Generated video | Duration, resolution, sound, format |
+| **Audio** | Speech or music, depending on model | Voice/speaker or music mode, output format |
+
+Available controls come from the selected model profile. A project also stores a default provider/model, description, filename prefix, shuffle setting, and workflow.
 
 ## Project Management
 
-- Create, read, update, and delete projects.
-- Project types: **Image, Text, Video, Audio**.
-- Project states: **active** and **archived**.
-- Rename project folders.
-- Duplicate or copy workflows from existing projects.
+The Projects screen supports search, pagination, and active/archived/all filters. You can:
 
-## The Album
+- Create, edit, and permanently delete projects.
+- Archive a project to remove it from the default active view, then restore it later.
+- Duplicate a project by starting a new project with an existing workflow as the source.
+- Rename project folders from the project list.
 
-The album is where a project's media lives:
+Archiving is organizational; it does not delete jobs, media, exports, or storage. Deleting a project removes its workflow records, jobs, album records, project objects, and associated export tasks/files. Move individual album items to the recycle bin when you need a recoverable deletion.
 
-- Upload images, videos, and audio directly to a project.
-- Generated outputs land in the album when workflows run.
-- Rename album items.
-- Browse with a page-size selector and shareable views — album view state is stored in URL search parameters so views persist and can be shared.
+## Project Workspace Tabs
 
-## Running a Project
+### Draft
 
-Running a project enqueues only the jobs marked `pending`. A storage-limit check runs before enqueuing. See [Queue & Concurrency](/concepts/queue) for execution details, and [Workflows](/concepts/workflows) for how drafts are produced.
+Drafts are resolved workflow combinations that have not started. Each stores its prompt, media contexts, provider/model choice, output options, filename, and workflow snapshot. Start one, a selection, or every draft.
+
+### Queue
+
+Pending, processing, and failed jobs appear in Queue. You can inspect resolved prompts and contexts, retry failures, delete records, or operate on a selection. See [Queue & Concurrency](/concepts/queue).
+
+### Done
+
+Done holds completed job records. It is useful for inspecting or reusing the exact configuration that produced a result. Removing a completed job record is separate from deleting the corresponding durable album item.
+
+### Album, Texts, or Audios
+
+The final tab is named for the project modality. It contains durable `AlbumItem` records created by generation or direct upload:
+
+- Image and video projects provide visual browsing and a lightbox/player.
+- Text projects show generated text and its prompt/context; multiple text results can be compared.
+- Audio projects provide audio result controls.
+
+The collection supports selection, page-size choices, filename changes, export, copy-to-library, and recycle-bin deletion. The active tab, page, and supported filters live in URL search parameters, so navigation and shared links can preserve the same view.
+
+## Copying Results to a Library
+
+Copy selected results or the entire collection into a compatible library. You may create a library from the dialog or append to an existing library of the project output type.
+
+For generated media, choose:
+
+- **Optimized** — smaller derived asset when available.
+- **Raw** — original generated/uploaded asset.
+
+Copying creates library items; it does not move or delete the album results.
+
+## Exports
+
+Export selected album items or the full collection as a named ZIP. For supported assets, choose raw or optimized versions. Image projects can open the watermark configuration screen before queueing the archive.
+
+Exports run outside the generation queue in their own persistent worker and appear on the global Exports page. See [Exports & Delivery](/concepts/exports).
+
+## Reusing Configuration
+
+Job rows retain a workflow snapshot and resolved generation settings. The **Reuse configuration** action restores those settings into the project editor so a prior result or failure can be used as the starting point for new drafts.
+
+Reuse changes the current editable workflow/settings only after confirmation; it does not alter the old job or album item.
 
 ## Orphan Files
 
-An **orphan** is a file sitting in a project's storage folder that nothing in the project points to anymore. Generation, uploads, retries, and image editing can all leave behind objects that no longer belong to any live record — these silently consume your [storage](/concepts/storage) quota. The **Project Orphans** view finds them and lets you clean them up.
+An **orphan** is an object under a project's storage prefix that is no longer referenced by a workflow item, job, album item, or protected trash record. Uploads, retries, edits, and interrupted operations can leave such objects behind.
 
-### How orphans are detected
+The Project Orphans screen:
 
-Each project owns a folder in object storage (keyed by your user ID and the project ID). To find orphans, Remix Studio:
+1. Lists every object below the user's project prefix.
+2. Collects storage keys still referenced by direct media workflow steps, job outputs/contexts, album outputs/contexts, and trash items for that project.
+3. Reports stored objects outside that referenced set, with preview and size where possible.
 
-1. Lists **every file** under the project's storage folder.
-2. Collects **every file key still referenced** by the project's database records:
-   - **Workflow** image/video/audio inputs (value, thumbnail, optimized variants).
-   - **Jobs** — output images plus any image, video, and audio context inputs.
-   - **Album items** — output media plus their context inputs.
-   - **Trash items** belonging to the project (so [recycle-bin](/concepts/trash) contents are protected).
-3. Treats any stored file **not** in that referenced set as an orphan.
+Selected orphans can be deleted in a batch.
 
-The view lists each orphan with a preview and its size, so you can see how much space they occupy.
-
-### Cleaning up
-
-You select which orphans to remove, and Remix Studio **permanently deletes** them from storage in a batch.
-
-::: warning
-Orphan deletion is permanent — these files are removed directly from object storage and do **not** go to the recycle bin. Because trashed items are excluded from orphan detection, emptying orphans will not touch anything you have in [Trash](/concepts/trash).
+::: danger
+Orphan cleanup deletes directly from object storage and cannot be undone. It does not use the recycle bin. Trash records are included in the protected reference set, so valid recycle-bin media is not reported as orphaned.
 :::
 
-### When to use it
-
-- After heavy generation or many retries, to reclaim space that isn't tied to any album item.
-- When [storage](/concepts/storage) usage looks higher than the media you can actually see in the project.
+Use orphan cleanup when project usage is unexpectedly high after many uploads, retries, or edits. It is not a routine replacement for deleting visible album items through Trash.
 
 ## Live Updates
 
-Projects use a live hub (WebSocket) so generation progress and album changes appear in the UI in real time without manual refresh.
+An authenticated WebSocket project hub publishes job, album, trash, and project changes. The viewer refreshes the relevant data when events arrive and falls back to periodic refresh while work is processing if a live connection is unavailable.
 
-## Sharing
-
-Album views can be shared via URL, and a dedicated **Share** page exposes selected content.
+The connection validates the user, account status, project ownership, and session version. It does not expose another user's project events.
 
 ## Related
 
-- [Exports & Delivery](/concepts/exports) — package album media into ZIP archives.
-- [Campaigns](/concepts/campaigns) — turn project outputs into scheduled social posts.
-- [Storage](/concepts/storage) — how project media counts against your quota.
+- [Workflows & Combinations](/concepts/workflows) — how drafts are composed.
+- [Recycle Bin](/concepts/trash) — recoverable album deletion.
+- [Libraries & Prompts](/concepts/libraries) — reusable inputs and result copying.

--- a/docs-site/concepts/providers.md
+++ b/docs-site/concepts/providers.md
@@ -1,44 +1,86 @@
 # Providers & Models
 
-**Providers** are the AI backends Remix Studio uses to run generation jobs. Each provider stores its own credentials, optional endpoint override, and model configuration.
+A **provider** is a user-owned connection to an AI service. It stores credentials, an optional API endpoint override, concurrency, and custom model aliases. Projects and jobs refer to the provider record by ID, so two accounts—or two connections to the same vendor—remain isolated.
 
-## What a Provider Stores
+## Provider Records
 
-- A **name** and **type** (for example OpenAI-compatible, Google, Vertex AI, or other supported generators).
-- An **encrypted API key** (encrypted with `PROVIDER_ENCRYPTION_KEY`).
-- An optional **API URL override**, for proxies or self-hosted endpoints.
-- Optional **model configuration** — saved model profiles attached to the provider.
-- A **concurrency setting** controlling how many jobs run in parallel for that provider.
+| Field | Purpose |
+| :--- | :--- |
+| Name | Human-readable label shown in selectors and queue monitoring |
+| Type | Selects the generator implementation, such as Google AI, OpenAI, or Kling AI |
+| API key | Primary credential, encrypted before database storage |
+| API secret | Optional second credential used by providers such as Kling AI |
+| API URL | Optional safe endpoint override for a compatible proxy |
+| Concurrency | Maximum generation jobs this provider record may run at once |
+| Custom models | Alias definitions merged with the bundled model profiles |
 
-Provider credentials are managed inside the app rather than hardcoded into project files.
+Credentials are entered and changed in the provider screens. They are decrypted only on the server when a job or assistant call needs them.
 
-## Providers and Jobs
+## Project Defaults and Job Snapshots
 
-- A project can use a **default provider**, while individual jobs can **override** that provider when needed.
-- Model configuration is attached to the provider, so jobs choose a saved **model profile** instead of repeating raw model settings.
-- Each provider's [concurrency limit](/concepts/queue) controls its own parallelism independently of other providers.
+A project selects a default provider and model. Creating a draft copies that selection into the draft, and dispatch resolves any remaining project fallback values into the job row before calling the provider.
 
-## Custom Models & Aliases
+As a result:
 
-Beyond the bundled [model profiles](/concepts/models), you can define **custom model aliases** per provider, so jobs can target models not shipped by default. Manage these from the provider's profile screen.
+- Changing the project provider does not rewrite existing drafts/jobs.
+- Deleting a provider may leave old job history without a usable provider connection.
+- Retrying requires the snapshotted provider/model still to be available and correctly configured.
 
-## Third-Party Proxies
+Use **Reuse configuration** on a prior job when you want its settings to become the editable starting point for new work.
 
-Remix Studio supports affordable third-party API proxies for Google Gemini and OpenAI models. To configure one:
+## Concurrency
 
-1. Create a Provider with the appropriate type (`GoogleAI` or `OpenAI`).
-2. Enter your proxy's API key.
-3. In the **API URL** field, enter the proxy's base domain (for example `https://api.laozhang.ai`).
-4. The app handles path construction and supports dynamic model replacement.
+Concurrency belongs to the provider record. Two separate OpenAI connections can therefore have different limits and independent queues. A remote async task keeps its slot while being polled.
 
-## Supported Provider Families
+Choose a conservative limit that matches vendor rate limits and your media-processing capacity. Increasing it can increase provider throttling, memory use, and simultaneous object-storage writes. See [Queue & Concurrency](/concepts/queue).
 
-Generators ship for a broad set of providers across modalities, including Google AI, Vertex AI, OpenAI, Grok, Claude (Anthropic), Alibaba Cloud DashScope, RunningHub, BytePlus, Kling AI, Black Forest Labs, and Replicate. See [Model Profiles](/concepts/models) for the full bundled matrix.
+## Bundled Profiles and Custom Aliases
 
-## Security
+Bundled profiles describe:
 
-API keys are encrypted at rest with `PROVIDER_ENCRYPTION_KEY`.
+- Provider model ID and display name.
+- Output category.
+- Supported aspect ratios, formats, qualities, backgrounds, durations, resolutions, or audio formats.
+- Prompt limits and supported input contexts where applicable.
+- Whether a model is eligible for assistant chat.
+
+Custom aliases let you add a compatible model ID without waiting for a release. An alias uses the selected provider generator; it does not install a new protocol adapter. Configure its capabilities accurately, because the project editor relies on them to expose valid controls.
+
+See [Model Profiles](/concepts/models) for the bundled matrix.
+
+## Assistant Compatibility
+
+Generation support and assistant-chat support are separate. The in-app assistant currently accepts provider records of type Google AI, OpenAI, Claude, and Alibaba Cloud. Other provider families can still appear in project model selectors when their generators are implemented.
+
+See [The Assistant](/concepts/assistant).
+
+## API URL Overrides and Proxies
+
+An API URL override is intended for a service that is wire-compatible with the chosen provider type. Remix Studio constructs provider-specific paths and validates the override before use.
+
+When configuring a proxy:
+
+1. Choose the provider type whose request/response protocol the proxy implements.
+2. Enter the proxy base URL, not an arbitrary per-model URL unless that provider screen says otherwise.
+3. Add custom aliases for model IDs not in the bundled profiles.
+4. Test a small job before increasing concurrency.
+
+::: warning
+Compatibility is more than accepting the same API key. Streaming, async task polling, media upload formats, response fields, and safety/error payloads must match the selected generator.
+:::
+
+URL validation rejects unsafe endpoint forms, including attempts to direct provider calls at private/internal network targets.
+
+## Supported Families
+
+The repository includes generation adapters and bundled profiles across Google AI, Vertex AI, OpenAI, Grok, Claude, Alibaba Cloud, RunningHub, BytePlus, Kling AI, Black Forest Labs, and Replicate. Supported modalities differ by family and model; consult [Model Profiles](/concepts/models) rather than assuming every family supports text, image, video, and audio.
+
+## Credential Encryption
+
+Provider API credentials are encrypted at rest with `PROVIDER_ENCRYPTION_KEY`.
 
 ::: danger
-Do not change `PROVIDER_ENCRYPTION_KEY` after providers exist unless you are re-encrypting stored credentials — otherwise saved API keys may become unreadable. See [Configuration](/guide/configuration).
+Keep `PROVIDER_ENCRYPTION_KEY` stable. Changing it without re-encrypting existing records makes saved credentials unreadable. The effective key must be a 64-character hexadecimal value. Back it up separately from the database.
 :::
+
+The encryption key protects database contents, but anyone with both the database and deployment secret can decrypt provider credentials. Restrict environment configuration, database access, logs, and backups accordingly.

--- a/docs-site/concepts/queue.md
+++ b/docs-site/concepts/queue.md
@@ -1,44 +1,90 @@
 # Queue & Concurrency
 
-Remix Studio runs generation through a **recoverable, server-side queue**. This is what lets you expand a workflow into many drafts and execute them reliably in the background.
+Generation runs through a recoverable, server-side queue. Drafts become database-backed jobs before dispatch, while a small in-memory scheduler enforces each provider record's concurrency limit.
 
-## How Jobs Flow
+## From Draft to Job
 
-1. Running a project enqueues only jobs marked `pending`.
-2. The queue is **global and in-process**, and groups work by [provider](/concepts/providers).
-3. Each provider has its own **configurable concurrency limit**, controlling how many of its jobs run in parallel.
-4. Jobs are **snapshotted** into `processing` state before dispatch, so the worker and poller operate on resolved metadata.
-5. Providers that return a remote task ID are handed off to a **detached poller**, which checks status every 30 seconds until completion or failure.
+A draft has status `draft` and is not visible to the server worker. Starting one or more drafts:
+
+1. Validates that the jobs belong to the project and are startable.
+2. Estimates future storage at approximately 25 MB per pending job and checks the user's limit.
+3. Moves the selected `draft` or `failed` rows to `pending`.
+4. Enqueues those job IDs for the project's provider queues.
+
+Starting all drafts affects draft rows only. Existing pending/processing jobs are not duplicated.
 
 ## Job States
 
-| State | Meaning |
+| Database state | Meaning |
 | :--- | :--- |
-| `pending` | Queued, not yet dispatched |
-| `processing` | Snapshotted and dispatched (or being polled) |
-| `completed` | Finished successfully; output in the album |
-| `failed` | Errored; can be retried |
+| `draft` | Prepared in the project but not submitted to the server queue |
+| `pending` | Eligible for dispatch; may be waiting for a provider slot |
+| `processing` | A provider call is running or a remote task is being polled |
+| `completed` | Processing succeeded and the result was written to the album |
+| `failed` | Dispatch, provider execution, polling, or local processing failed |
+
+The Queue Monitor additionally derives operational states:
+
+- **Waiting** — pending in the database but not currently in the in-memory queue.
+- **Queued** — waiting in a provider's in-memory queue.
+- **Running** — executing synchronously and consuming a provider slot.
+- **Detached** — a remote async task ID is being polled and still consumes a slot.
+
+## Provider Resolution and Snapshots
+
+Before execution, the queue resolves the effective provider and writes the final provider/model and output parameters to the job. This snapshot prevents a later project edit from changing an in-flight job.
+
+Text, audio, and synchronous image/video calls finish within the worker execution path. Providers that return a remote task ID hand the job to the detached poller.
 
 ## Per-Provider Concurrency
 
-Because work is grouped by provider, you control parallelism independently for each one. A slow or rate-limited provider can run one job at a time while a fast one runs several — without blocking each other.
+Concurrency is configured on each provider record, not globally by provider family. The scheduler keeps independent queues and active-slot counts per provider ID.
+
+For example, one Google provider can run four jobs while a separate rate-limited provider runs one. A detached remote task continues to occupy its provider slot until it completes, fails, times out, or is reconciled after deletion.
+
+Changing a provider's configured concurrency affects subsequent scheduling; it does not cancel work already running remotely.
+
+## Detached Polling and Timeouts
+
+Remote async jobs are checked every 30 seconds. A remote task reaching a terminal state is passed to the image/video processor and then releases its provider slot.
+
+If a task never reaches a terminal state, it is marked failed after `JOB_PROCESSING_TIMEOUT_MS` (two hours by default). The first-observed timeout window resets on a server restart.
+
+Transient polling errors do not immediately fail a task; polling continues until the provider reports failure or the stuck timeout is reached.
 
 ## Recovery After Restart
 
-The queue is designed to survive restarts:
+On startup the recovery scan:
 
-- On server startup, **pending jobs are re-enqueued**.
-- **Interrupted `processing` jobs are recovered** so work can continue.
+- Re-enqueues every `pending` job.
+- Resets `processing` jobs without a remote task ID to `pending`, because their synchronous process was interrupted.
+- Leaves `processing` jobs with a task ID in place, reserves their provider slots, and immediately polls them.
 
-## Storage Guard
+After each detached poll cycle the queue reconciles slot tracking with the database. It also heals untracked `processing` rows without task IDs by returning them to pending, while avoiding jobs that are genuinely executing in the current process.
 
-A **storage-limit check** runs before enqueuing pending jobs for a project, so generation won't push a user past their [storage](/concepts/storage) quota.
+This is recovery by retry, not exactly-once execution. A synchronous provider request interrupted after the remote service accepted it but before Remix Studio stored the result may be submitted again.
 
-## Monitoring
+## Failures and Retry
 
-The **Queue Monitor** view shows live job status across projects, so you can watch progress, spot failures, and retry. Generated outputs can be reviewed in-app, and failures retried individually.
+Failed jobs retain their error and resolved configuration. Retry returns selected failures to pending and enqueues them again. The Queue Monitor can also clear failed job records globally, by project, or by provider queue.
+
+Clearing a failed job removes the job record; it does not delete an album item that was already saved by a successful run.
+
+## Queue Monitor
+
+Open **Projects → Queue Monitor** to see:
+
+- Total pending, processing, and failed jobs.
+- Active slots versus configured concurrency.
+- Project-grouped and provider-grouped views.
+- Waiting, queued, running, and detached counts.
+- Provider/model and output metadata for individual jobs.
+- Scoped controls for clearing failures.
+
+The monitor polls for current server state. Project pages additionally receive live WebSocket events.
 
 ## Related
 
-- [Workflows](/concepts/workflows) — how drafts become queued jobs.
-- [Providers & Models](/concepts/providers) — where concurrency limits are configured.
+- [Workflows & Combinations](/concepts/workflows) — draft creation and selection.
+- [Providers & Models](/concepts/providers) — credentials, models, and concurrency.
+- [Storage](/concepts/storage) — quota accounting and the pre-start estimate.

--- a/docs-site/concepts/selling-exports.md
+++ b/docs-site/concepts/selling-exports.md
@@ -1,39 +1,87 @@
 # Selling Exports
 
-Remix Studio can publish a finished [export](/concepts/exports) package as a **paid product** on a connected store. This turns a generated archive into a sellable digital product without leaving the app.
+A completed [export archive](/concepts/exports) can be attached to a digital product and published to a connected store. Store publishing runs through the same persistent delivery worker used by Google Drive, with additional product and cover phases.
 
-## Connecting a Store
+## Supported Store
 
-Connect a store account under **Exports → Stores**. The connection uses OAuth, and the store's access token is stored encrypted.
+The current store adapter is **Gumroad**. Configure `GUMROAD_CLIENT_ID`, `GUMROAD_CLIENT_SECRET`, and optionally `GUMROAD_SCOPE`, then connect under **Exports → Stores**.
 
-**Supported store:** **Gumroad** — connected via Gumroad's OAuth flow (`gumroad.com/oauth/authorize`).
+The OAuth redirect is:
 
-## Creating a Product
+```text
+${APP_URL}/api/stores/gumroad/callback
+```
 
-A product is created from an existing export task. When you publish, you provide:
+The connected profile and encrypted access token are stored per user. Disconnecting attempts to revoke the remote token and removes the local connection; it does not delete products already created on Gumroad.
 
-| Field | Description |
+## Prerequisites
+
+To open the sell flow:
+
+- The export must belong to the signed-in user.
+- Its status must be `completed`.
+- The export-bucket object must still exist.
+- At least one active store connection must be available.
+
+Deleting the export before publishing finishes can make the delivery task fail because the ZIP is its source file.
+
+## Product Fields
+
+| Field | Behavior |
 | :--- | :--- |
-| Store | The connected store to publish to |
-| Export task | The completed export archive to sell |
-| Title | Product title |
-| Price | Price in cents, with a currency |
-| Description | Optional product description |
-| Tags | Optional tags (up to 30) |
-| Cover items | Album items used as the listing cover (optionally watermarked) |
-| Publish immediately | Whether to publish on creation or keep as a draft |
+| Store | Connected Gumroad account |
+| Title | Required; prefilled from the ZIP/project name and limited to 200 characters in the UI |
+| Price | Non-negative amount converted to integer cents; the current screen uses USD |
+| Description | Optional product copy |
+| Tags | Comma-separated in the UI; the server keeps at most 30 non-empty tags |
+| Taxonomy ID | Optional Gumroad taxonomy/category identifier |
+| Covers | Up to eight owned image album items, in drag-reorderable order |
+| Publish immediately | Queue remote upload/product creation now; otherwise retain only the local draft record |
 
-The export archive is uploaded to the store using its multipart upload API, so large packages are supported.
+Creating the local draft stores a snapshot of the export, metadata, cover choices, and watermark settings. If **Publish immediately** is enabled, a delivery task is then queued and the product enters `publishing`.
+
+## Cover Selection
+
+Covers can come from owned album images. For each cover choose:
+
+- **Raw** — original image object.
+- **Optimized** — optimized/thumbnail source when available, with fallback to the original.
+
+Cover order in Remix Studio becomes the order sent to Gumroad. Unsupported or missing album items are skipped by validation/processing rather than granting access to an arbitrary storage key.
 
 ## Cover Watermarking
 
-Listing covers support **per-product watermark settings**, with automated image processing handled in the delivery queue — the same watermarking pipeline used for [album exports](/concepts/exports).
+The sell screen uses the per-user image watermark controls: text, position, padding, font size, opacity, and color. The chosen configuration is copied into each cover-selection record when the product is created.
 
-## Upload History
+During delivery, enabled covers are processed into temporary JPEG objects in the export bucket and those processed bytes are uploaded as listing covers. Source album images are not overwritten.
 
-A **Store Upload History** view tracks what has been published, so you can see which exports became products and their status.
+## Publishing Pipeline
+
+For an immediate publish, the delivery worker:
+
+1. Verifies the completed export and store/product ownership.
+2. Presigns a Gumroad multipart upload.
+3. Streams the ZIP from the export bucket in 100 MB upload parts while recording byte progress.
+4. Completes and verifies the remote upload.
+5. Creates the Gumroad product with title, price, description, tags, taxonomy, and uploaded file.
+6. Processes and uploads covers in order.
+7. Enables the product when immediate publishing was requested.
+8. Stores the remote product ID, file URL, short URL, and final status.
+
+Product status moves through `draft`, `publishing`, `published`, or `failed`. Delivery phase/progress is also displayed on the Exports page.
+
+## Failures and Upload History
+
+Failures store both the product error and delivery-task error. Correct the store credentials, export availability, metadata, or remote Gumroad issue before trying again.
+
+**Exports → Upload History** records successful and failed attempts with the platform, title, remote ID/URL, and error at the time of upload. Disconnecting a store or later deleting a local product does not erase the historical event automatically.
+
+::: warning
+Publishing is an external side effect. Deleting a Remix Studio record does not unpublish or refund a Gumroad product. Manage existing listings, customers, and refunds in Gumroad.
+:::
 
 ## Related
 
-- [Exports & Delivery](/concepts/exports) — produce the archive you sell.
-- [Storage](/concepts/storage) — where the source archive lives.
+- [Exports & Delivery](/concepts/exports) — source archives and worker behavior.
+- [Configuration Reference](/guide/configuration) — Gumroad OAuth variables.
+- [Storage](/concepts/storage) — source archive and temporary cover objects.

--- a/docs-site/concepts/storage.md
+++ b/docs-site/concepts/storage.md
@@ -1,40 +1,86 @@
 # Storage
 
-Remix Studio uses **S3-compatible object storage** for generated media and archives, and tracks usage against each user's limit.
+Remix Studio stores record metadata in PostgreSQL and media bytes in S3-compatible object storage. Both are required for a complete, usable deployment.
 
-## Two Buckets
+## Buckets
 
-| Bucket | Env var | Holds |
+| Bucket | Environment variable | Contents |
 | :--- | :--- | :--- |
-| Main | `S3_BUCKET` | Project images, workflow assets, library images, and related media |
-| Export | `S3_EXPORT_BUCKET` | Completed ZIP [export](/concepts/exports) archives |
+| Main | `S3_BUCKET` | Project workflow assets, generated album media, job contexts, library media, campaign media, thumbnails, and optimized variants |
+| Export | `S3_EXPORT_BUCKET` | Completed ZIP export archives |
 
-For local development, the recommended backend is **MinIO** running via Docker Compose. For deployment, point the app at AWS S3, Cloudflare R2, Google Cloud Storage, Alibaba Cloud OSS, or another S3-compatible service. See [Storage Providers](/guide/storage-providers).
+If `S3_EXPORT_BUCKET` is omitted, the server derives an export bucket by appending `-exports` to the main bucket name. Buckets can be auto-created when `S3_AUTO_CREATE_BUCKET=true`; managed production storage is usually pre-created with auto-creation disabled.
 
-## Usage Tracking
+## Object Keys and Ownership
 
-Storage analysis reports total usage against each user's storage limit, broken down into:
+Stored objects use user/project/library/campaign-scoped prefixes. Database routes still verify ownership before reading, copying, signing, or deleting a key; possession of a guessed key is not sufficient authorization.
 
-- **Projects** — album media and workflow assets.
-- **Libraries** — reusable library images and media.
-- **Archives** — completed export ZIPs.
-- **Recycle bin** — deleted items pending purge.
+Media records may reference:
 
-This usage is checked before [enqueuing generation jobs](/concepts/queue) and before creating [exports](/concepts/exports), so users cannot exceed their quota.
+- An original object.
+- An optimized display object.
+- A thumbnail.
+- Context objects used to produce a job or album item.
 
-## Recycle Bin (Trash)
+Deleting a visible record therefore may involve several keys. Orphan analysis compares stored project keys with every known reference so unreferenced leftovers can be removed deliberately.
 
-Deleted items move to a recycle bin and continue to count toward usage until purged, so you can recover from accidental deletes before reclaiming the space. See [Recycle Bin (Trash)](/concepts/trash) for restoring, batch deletion, and emptying the bin.
+## Storage Analysis and Limits
 
-## Public Endpoints & Presigned URLs
+Each user has a byte limit (5 GB by default for a newly created database record, unless changed by an admin). Account storage analysis reports:
 
-When a social platform or external store needs to fetch media, Remix Studio supplies **time-limited presigned URLs**. If you serve downloads through a different hostname than the internal endpoint, set `S3_PUBLIC_ENDPOINT` (and `S3_EXPORT_PUBLIC_ENDPOINT`).
+- **Projects** — project workflow assets, jobs, and album media.
+- **Libraries** — reusable media items.
+- **Archives** — ZIPs in the export bucket.
+- **Recycle bin** — soft-deleted project album media.
+
+The sidebar periodically refreshes total usage; the Account storage view provides the detailed analysis.
+
+Quota guards currently use estimates:
+
+- Starting generation reserves an estimate of about 25 MB for every job that will be pending.
+- Creating an export estimates from the selected source asset sizes before adding the archive.
+
+The checks reduce accidental overage but do not make the object store itself enforce a hard quota. Provider output sizes and concurrent operations can differ from estimates.
+
+## Recycle Bin and Permanent Deletion
+
+Deleting an album item first creates a trash record containing its metadata and leaves its objects available for restoration. Trash therefore continues to count toward usage.
+
+Permanent deletion or Empty Trash removes the referenced storage objects and the trash records. Library deletion and project-orphan cleanup do not use this recycle-bin flow.
+
+See [Recycle Bin](/concepts/trash).
+
+## Internal and Public Endpoints
+
+`S3_ENDPOINT` is the endpoint the Remix Studio server uses for S3 API calls. In a container network it may be private, such as `http://minio:9000`.
+
+`S3_PUBLIC_ENDPOINT` controls URLs returned to browsers or external services when the public route differs from the internal route. The export bucket can use a separate `S3_EXPORT_PUBLIC_ENDPOINT`. The corresponding `*_PUBLIC_CUSTOM_DOMAIN` flags tell URL construction whether that endpoint is a bucket-specific custom domain rather than a path-style S3 endpoint.
+
+Remix Studio normally returns time-limited presigned URLs instead of making a bucket public.
 
 ::: warning
-For [campaign](/concepts/campaigns) publishing, the public endpoint must be reachable from the public internet, because the social platform fetches the media server-side.
+Social platforms fetch campaign media from their own servers. The main public endpoint and signed object URL must therefore be reachable from the public internet. A Docker-only hostname such as `minio` will not work for X or Threads.
 :::
+
+## Storage Provider Compatibility
+
+The storage client uses S3 APIs and supports AWS S3, MinIO, Cloudflare R2, Google Cloud Storage interoperability, Alibaba Cloud OSS, and other sufficiently compatible services. Endpoint format, region, credentials, path/custom-domain behavior, and bucket-creation policy vary.
+
+See [Storage Providers](/guide/storage-providers) before deploying to a managed service.
+
+## Backup Implications
+
+A database dump contains storage keys and metadata, not object bytes. A complete backup needs:
+
+1. PostgreSQL.
+2. The main bucket.
+3. The export bucket if completed archives must be retained.
+4. Deployment secrets, especially `PROVIDER_ENCRYPTION_KEY`.
+
+Restore the database and buckets from a consistent point in time where possible. See [Backup & Restore](/operations/backup-and-restore).
 
 ## Related
 
-- [Storage Providers](/guide/storage-providers) — provider-specific configuration.
-- [Configuration Reference](/guide/configuration) — every storage environment variable.
+- [Configuration Reference](/guide/configuration) — endpoint and bucket variables.
+- [Exports & Delivery](/concepts/exports) — archive storage.
+- [Projects & Albums](/concepts/projects) — orphan analysis.

--- a/docs-site/concepts/supported-workflows.md
+++ b/docs-site/concepts/supported-workflows.md
@@ -1,19 +1,36 @@
 # Supported Workflows
 
-Remix Studio is multimodal: a [workflow](/concepts/workflows) maps one kind of input to one kind of output. The supported input → output combinations are:
+Remix Studio does not hard-code a single input-to-output pipeline. A project chooses an **output type**, a model profile declares accepted contexts and output options, and the workflow supplies the compatible text/media inputs.
 
-| Workflow | Description |
-| :--- | :--- |
-| **Text → Text** | Standard LLM generation |
-| **Text → Image** | Prompt-based image generation |
-| **Text → Video** | Prompt-based video generation |
-| **Text → Audio** | Scripted text-to-speech generation (TTS) |
-| **Text → Music** | Prompt-based music generation (e.g. with Lyria models) |
-| **Image → Text** | Describe or analyze images (multimodal) |
-| **Image → Image** | Stylize or transform images using reference images |
-| **Image → Video** | Animate images into video |
-| **Image → Music** | Generate music using reference image context |
-| **Video → Video** | Transform or edit videos using reference video context |
-| **Audio → Video** | Generate video using reference audio context (e.g. lip-sync or music) |
+## Output Types
 
-Which workflows are available to you depends on the [providers and models](/concepts/models) you have configured. See [Model Profiles](/concepts/models) for the bundled provider/model matrix.
+| Project type | Produces | Typical workflow inputs |
+| :--- | :--- | :--- |
+| **Text** | Text | Text prompts plus image/video/audio context when supported by the selected multimodal model |
+| **Image** | Images | Text, reference images, and provider-specific media context |
+| **Video** | Video | Text, source/reference images, video, or audio when the selected video model supports them |
+| **Audio** | Speech or music | Text; reference images only for audio models that explicitly declare image support |
+
+This capability-based model covers common workflows such as text-to-text, image analysis, text-to-image, image-to-image, text/image-to-video, video transformation, audio-conditioned video, text-to-speech, text-to-music, and image-conditioned music.
+
+## How Availability Is Decided
+
+A workflow is usable only when all three layers agree:
+
+1. **Project type** selects the text, image, video, or audio execution path.
+2. **Provider family** must implement that output generator.
+3. **Model profile** must advertise the required input contexts and options.
+
+The project editor uses the selected model profile to show settings such as supported aspect ratios, qualities, backgrounds, durations, resolutions, sound modes, audio formats, prompt limits, and reference-image support.
+
+::: warning
+A provider appearing in Remix Studio does not mean every model from that provider supports every workflow. Custom aliases inherit the capabilities you configure for them, so verify the upstream model and proxy behavior.
+:::
+
+## Context Behavior
+
+Workflow text is joined into the request prompt. Image, video, and audio steps become separate context arrays and are passed only through generators that implement those inputs.
+
+Audio projects intentionally hide direct video/audio workflow inputs. They are driven by text, with optional reference images only when the selected audio model allows them. Audio output configuration distinguishes speech/TTS settings from music settings.
+
+For the bundled provider/model matrix, see [Model Profiles](/concepts/models). For the exact generation settings stored with a job, see [Projects & Albums](/concepts/projects).

--- a/docs-site/concepts/trash.md
+++ b/docs-site/concepts/trash.md
@@ -1,38 +1,54 @@
 # Recycle Bin (Trash)
 
-Deleting media in Remix Studio is **soft delete** first: items move to a per-user **recycle bin** instead of being destroyed immediately. This gives you a safety net to recover from accidental deletes before the space is reclaimed.
+Trash provides recoverable deletion for project album results. It is user-scoped and preserves enough album metadata and storage references to restore an item to its original project.
 
-## What Goes to Trash
+## What Uses Trash
 
-[Album](/concepts/projects) media items (generated outputs and uploads) are moved to the recycle bin when deleted, individually or in bulk. Trashed items keep their image, thumbnail, and optimized variants so they can be previewed and restored intact.
+Deleting one or several album items from a project moves them to Trash. A trash record keeps:
 
-## Restoring
+- Original project ID and name.
+- Prompt or generated text.
+- Image, video, and audio context references.
+- Original, optimized, and thumbnail storage keys.
+- Provider/model and output metadata.
+- Size, duration, and resolution where applicable.
 
-- **Restore a single item** back to its project album.
-- **Restore in batch** — select multiple trashed items and restore them together.
+Deleting a library, an entire project, an export, a job record, or a project orphan follows a different path and is not recoverable here.
+
+## Restore
+
+Restore one item or select several for batch restore. The database recreates the album records in their original projects and removes the corresponding trash records. Project live events notify open viewers.
+
+Restoration depends on the project and referenced objects still existing. Deleting the whole project or manually removing bucket objects can make a trash record unrestorable.
 
 ## Permanent Deletion
 
-When you are sure, remove items for good:
+Trash supports:
 
-- **Delete a single item** permanently.
-- **Delete in batch** — permanently remove a selected set.
-- **Empty trash** — permanently remove everything in the recycle bin at once.
+- Permanent deletion of one item.
+- Batch permanent deletion of selected items.
+- **Empty Trash** for every item owned by the current user.
 
-::: warning
-Permanent deletion and emptying the trash cannot be undone — the underlying objects are removed from storage.
+Permanent deletion gathers the original, optimized, thumbnail, and context keys that belong to the trash records, deletes the objects, then removes the records.
+
+::: danger
+Permanent deletion cannot be undone. Verify your selection and backups before using batch delete or Empty Trash.
 :::
 
-## Trash & Storage
+## Storage Accounting
 
-Trashed items **still count toward your storage usage** until they are permanently deleted. Storage reporting breaks usage into projects, libraries, archives, and recycle-bin categories, so you can see how much space the recycle bin is holding and empty it to reclaim quota. See [Storage](/concepts/storage).
+Moving an item to Trash does not reclaim its bytes because the underlying objects remain available. Trash is shown as a separate category in account storage analysis and counts against the user's limit until permanently deleted.
 
-## Live Updates
+Project orphan analysis treats trash references as live, so valid trashed objects are not incorrectly offered as orphans.
 
-Trash and restore actions publish project events through the live hub, so album views update in real time without a manual refresh. See [Projects & Albums](/concepts/projects).
+## Working Safely
+
+- Use Trash for visible album items you may need to recover.
+- Use Project Orphans only for unreferenced storage leftovers.
+- Remove completed job records separately when you only want to clear execution history.
+- Empty Trash only after confirming no project/campaign/export workflow still depends on those results outside Remix Studio.
 
 ## Related
 
-- [Projects & Albums](/concepts/projects) — where items are trashed from and restored to.
-- [Storage](/concepts/storage) — how recycle-bin contents count against your quota.
-- [Exports & Delivery](/concepts/exports) — packaging the media you keep.
+- [Projects & Albums](/concepts/projects) — album deletion and orphan cleanup.
+- [Storage](/concepts/storage) — quota categories and object variants.

--- a/docs-site/concepts/workflows.md
+++ b/docs-site/concepts/workflows.md
@@ -1,55 +1,101 @@
 # Workflows & Combinations
 
-A **workflow** is the heart of Remix Studio. It defines the inputs that get combined into generation drafts. Instead of writing each prompt variant by hand, you assemble reusable and direct inputs, and the engine expands them.
+A **workflow** is the ordered recipe used to compose generation drafts. It contains direct text/media steps and references to reusable [libraries](/concepts/libraries). The workflow is resolved into drafts first; only the drafts you start consume provider calls.
 
-## Inputs
+## Workflow Inputs
 
-A workflow is built from two kinds of inputs across text, image, video, and audio slots:
+Workflow steps can be:
 
-- **Library-backed inputs** — pulled from reusable [libraries](/concepts/libraries) (prompt fragments, reference images, etc.).
-- **Direct inputs** — pinned or manually entered text/image/audio/video values inline in the workflow.
+- **Direct text** — fixed text added to every generated prompt.
+- **Direct image, video, or audio** — a fixed media context added to every generated draft, when the project/model accepts that modality.
+- **Library reference** — one eligible item is chosen from a text, image, video, or audio library.
 
-You can mix both freely. You can also change the source library on a workflow item, and filter library items by tags using an **AND/OR tag match mode**.
+Direct steps contribute one fixed choice. A library step contributes all of its non-empty, tag-matching items. Disabled steps are skipped entirely without being deleted.
 
-## The Combination Engine
+Text choices are joined in workflow order with a blank line between them. Media choices are collected into the corresponding image, video, and audio context arrays. This means workflow order is significant for composed text even though a library's own items are sorted only for browsing.
 
-When you run the workflow, the engine expands your inputs into draft permutations.
+## Filtering a Library Step
 
-> If you have **3** subject prompts, **4** style prompts, and **2** reference-image sets, Remix Studio produces **3 × 4 × 2 = 24** drafts from one workflow — before you send anything to a provider.
+A library step can select tags and choose an **OR** or **AND** match mode:
 
-This is the full Cartesian product across the selected inputs.
+- **OR** includes items containing at least one selected tag.
+- **AND** includes only items containing every selected tag.
+- No selected tags means every non-empty item is eligible.
+
+If filtering leaves a library step with no eligible items, that step contributes no choice. Use the library preview from the workflow to check the effective item set before creating drafts.
+
+## Combination Mode
+
+With shuffle disabled, the engine calculates the Cartesian product of all contributing choice groups.
+
+> 3 subjects × 4 styles × 2 reference images = **24 possible combinations**.
+
+The **Job Quantity** field controls how many drafts are actually created. The total shown beside it is the number of possible combinations, and the total can be copied into the quantity field for a complete sweep.
+
+Combination order is deterministic. If the requested quantity exceeds the number of unique combinations, the engine cycles from the beginning and creates repeated combinations with new job IDs and filename suffixes. Set the quantity to the displayed total or less when you require unique drafts.
 
 ## Shuffle Mode
 
-When `shuffle` is enabled, the workflow **samples** from those libraries instead of enumerating the full Cartesian product. Use it for exploratory sampling when the full combination set would be too large.
+With shuffle enabled, the engine creates exactly the requested number of samples. For every sample it:
 
-| Mode | Behavior | Use when |
+1. Keeps every non-empty direct step.
+2. Picks one random eligible item independently from each library step.
+3. Composes the resulting text and media contexts.
+
+Sampling is with replacement, so the same combination can appear more than once. Shuffle is useful for exploration or when a full Cartesian product is too large; it is not a guarantee of unique or evenly distributed combinations.
+
+| Mode | Draft selection | Best for |
 | :--- | :--- | :--- |
-| Combination (default) | Enumerates every permutation | You want exhaustive coverage |
-| Shuffle | Randomly samples permutations | You want exploratory variety without thousands of drafts |
+| Combination | Deterministic sequence through the Cartesian product | Exhaustive or reproducible coverage |
+| Shuffle | Independent random pick per library step for each draft | Fast exploration and bounded sample sizes |
 
-## Drafts → Queue
+## Draft Composition and Filenames
 
-Expanding a workflow creates **drafts**. Drafts are not executed automatically — you choose which to run:
+Creating drafts stores the resolved values, not only a pointer to the workflow:
 
-1. Expand the workflow into drafts (all permutations, or a shuffle sample).
-2. Review and select the drafts you actually want.
-3. Queue all or selected drafts. Only jobs marked `pending` are enqueued.
+- Composed prompt text.
+- Image, video, and audio context arrays.
+- Provider and model selection.
+- Output options such as aspect ratio, quality, format, duration, resolution, or sound.
+- A workflow snapshot for later inspection and reuse.
 
-This separation lets you generate a large draft set cheaply, then spend API calls only on the runs you care about. Execution is handled by the [queue](/concepts/queue) with provider-level concurrency.
+Library item titles and tags become filename parts. The project filename prefix is prepended when configured, and a short unique suffix prevents collisions.
 
-## Editing Workflow Items
+If a model declares a prompt limit, Remix Studio checks the composed drafts. When one or more exceed that limit, you can cancel or allow the app to truncate affected prompts before they are saved.
 
-The workflow list supports productivity features:
+## Drafts, Queue, and Completed Results
 
-- **Drag and drop** media files directly into the workflow list.
-- **Paste** text and media with `Cmd+V` / `Ctrl+V`.
-- The list **auto-scrolls** to the bottom as new items are added.
-- An **Image Editor** lets you crop and draw directly on workflow images, with a reset option to revert edits.
+The project separates preparation from execution:
 
-Workflow state is synchronized carefully: the app fetches fresh project state before applying updates and serializes rapid updates with database locks to avoid overwriting concurrent changes.
+1. **Draft** — review the prompt, contexts, model, and output settings. Start one, selected drafts, or all drafts.
+2. **Queue** — pending, processing, and failed jobs appear here. Retry or remove jobs individually or in a selection.
+3. **Done** — completed job records, including the configuration that produced each result.
+4. **Album / Texts / Audios** — durable output items used for viewing, copying, exporting, or campaign media.
+
+Starting a draft changes it into a pending server-side job. A storage estimate is checked before this transition. See [Queue & Concurrency](/concepts/queue) for dispatch and recovery behavior.
+
+## Editing Workflow Steps
+
+The workflow editor supports:
+
+- Reordering steps.
+- Temporarily disabling a step.
+- Changing the library used by an existing library step.
+- Previewing a library and editing its tag filter.
+- Dragging files into the workflow or pasting text/media with `Cmd+V` / `Ctrl+V`.
+- Cropping or drawing on direct workflow images, with reset support.
+- Saving direct inputs into compatible libraries.
+
+Project updates replace the stored workflow with the submitted ordered list. The UI serializes rapid saves, and assistant/MCP callers must fetch the latest project immediately before replacing a workflow so that unchanged steps are deliberately carried forward.
+
+## Output Type and Model Compatibility
+
+The project type determines the output processor: text, image, video, or audio. Input support is then constrained by the selected model's declared capabilities. For example, an audio project accepts text and only offers reference images when that audio model declares image support.
+
+The presence of an input control does not make every provider/model combination valid. Select the provider and model first, then use the options the project editor exposes for that model. See [Supported Workflows](/concepts/supported-workflows).
 
 ## Related
 
-- [Supported Workflows](/concepts/supported-workflows) — the full matrix of input → output types.
-- [Projects & Albums](/concepts/projects) — where workflows live and outputs land.
+- [Libraries & Prompts](/concepts/libraries) — reusable choice groups and tag filters.
+- [Projects & Albums](/concepts/projects) — project tabs, outputs, and reuse.
+- [Queue & Concurrency](/concepts/queue) — how selected drafts execute.

--- a/docs-site/guide/account-and-security.md
+++ b/docs-site/guide/account-and-security.md
@@ -1,47 +1,97 @@
 # Accounts & Security
 
-Remix Studio is multi-user and self-hosted. Access is protected by authentication, role-based controls, and optional strong-auth factors.
+Remix Studio is a multi-user application even when deployed for one person. Libraries, projects, providers, campaigns, exports, trash, assistant conversations, and automation tokens are scoped to the authenticated user.
 
-## Authentication Methods
+## Account Status and Roles
 
-- **Email/password** with JWT-based sessions stored in HttpOnly cookies.
-- **Google OAuth** for existing-user login and invite-based registration (requires `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET`).
-- **Passkeys / WebAuthn** registration and sign-in.
-- **Two-factor authentication (2FA)** using TOTP.
+Users have an `admin` or `user` role and an `active` or `disabled` status.
 
-## Roles & Access Control
+Admins can:
 
-- **Admin** and **user** roles.
-- User status controls, including disabling accounts.
-- Admin user management, including password reset and per-user storage limits.
-- Invite-code-based registration.
+- Create and manage invite codes.
+- View users and change account status.
+- Reset passwords.
+- Set per-user storage limits.
 
-Admins manage users and invites from the admin screens (Admin → Users, Admin → Invites).
+A disabled user cannot sign in or open a project live connection. Existing access tokens are also checked against current account state.
 
-## Two-Factor Authentication
+## Registration and Invites
 
-Set up TOTP-based 2FA from **Account → Security**. Once enabled, sign-in requires a code from your authenticator app in addition to your password.
+Self-registration is invite based. An invite has an encrypted/hash-protected code, optional note and expiry, a maximum-use count, and redemption records. Google-based registration still requires a valid invite; Google OAuth is not an unrestricted public-signup switch.
 
-## Passkeys
+The first administrator can be bootstrapped with `DEFAULT_ADMIN_EMAIL` and `DEFAULT_ADMIN_PASSWORD`. The user is created only when that email does not already exist.
 
-Register a passkey from your account settings for passwordless WebAuthn sign-in. For deployments behind a reverse proxy, configure:
+::: warning
+Replace the bootstrap password immediately and remove it from long-lived environment files when your deployment process permits. Leaving the same default credentials in every environment increases recovery and disclosure risk.
+:::
 
-- `WEBAUTHN_RP_ID` — the public site domain only (no protocol or port), e.g. `app.example.com`.
-- `WEBAUTHN_ORIGIN` — the exact external origin including `https://`, e.g. `https://app.example.com`.
-- `WEBAUTHN_RP_NAME` — the name shown during registration (defaults to `Remix Studio`).
+## Sign-in Methods
+
+### Password
+
+Passwords are hashed with bcrypt and must be at least eight characters when changed. Accounts created through another method may have no password.
+
+You can remove a password only after registering at least one passkey, and the current password is required for the removal. This prevents removing the last usable sign-in method through the account screen.
+
+### Google
+
+Google OAuth can sign in an existing account and complete invite-based registration. Configure the client ID, secret, and exact callback described in [Configuration](/guide/configuration).
+
+### Passkeys
+
+Passkeys use WebAuthn for passwordless sign-in. Register and name one or more credentials under **Account → Security**; the account page shows creation and last-used times and lets you revoke a credential.
+
+WebAuthn validates:
+
+- `WEBAUTHN_RP_ID` — public host only, with no scheme or port.
+- `WEBAUTHN_ORIGIN` — exact browser origin including scheme and any non-default port.
+- `WEBAUTHN_RP_NAME` — display name shown by the authenticator.
+
+Changing the public domain requires corresponding WebAuthn configuration and may make previously registered credentials unusable on the new relying party.
+
+### TOTP Two-Factor Authentication
+
+TOTP 2FA adds a six-digit authenticator code to password sign-in. Setup uses a temporary secret and QR code, then requires a valid code before activation. Disabling 2FA requires a current TOTP code and, when the account has a password, that password too.
+
+Passkey sign-in is already possession-based and follows the WebAuthn flow rather than the password-plus-TOTP flow.
+
+## Sessions
+
+Successful sign-in sets two HttpOnly, `SameSite=Lax` cookies:
+
+- A short-lived signed access token.
+- A database-backed refresh token with a 30-day expiry.
+
+Refresh tokens rotate. The previous row is retained briefly as a rotation tombstone so a lost/concurrent response can be recovered inside a grace window. Reuse outside that window deletes the rotation chain and requires a new sign-in.
+
+Access tokens include the user's session version. Security-sensitive admin/password/status operations can increment that version, invalidating older tokens. Normal application upgrades do **not** inherently invalidate every session; specific historical migrations or security releases may do so and are called out in release notes.
+
+Signing out deletes the current refresh-token chain on a best-effort basis and clears both cookies. Expired sessions and old rotation tombstones are cleaned periodically.
+
+## Rate Limiting and Proxies
+
+Login, 2FA, and related authentication flows use an in-memory rate limiter keyed partly by client address. Behind a reverse proxy, enable `TRUST_PROXY` only when the proxy is trusted and overwrites forwarding headers.
+
+Rate-limit state is per server process. For a multi-instance public deployment, add upstream rate limiting at the load balancer or gateway.
+
+## Provider and External Tokens
+
+Provider credentials, social/store access tokens, and connected-service refresh tokens are encrypted at rest. Their recoverability depends on `PROVIDER_ENCRYPTION_KEY`, which must remain stable and be backed up separately from PostgreSQL.
+
+MCP personal access tokens are stored as hashes and displayed only at creation. OAuth/PAT access is scoped to `mcp:tools`; revoke unused tokens and clients from **Assistant Settings → MCP**.
 
 ## Storage Limits
 
-Each user has a storage limit. Usage is tracked across projects, libraries, archives, and recycle-bin data, and is checked before enqueuing generation jobs or creating exports. See [Storage](/concepts/storage).
+Every user has a byte limit. Storage analysis includes projects, libraries, export archives, and trash. Generation and export routes perform preflight estimates before accepting work, while admins can change the underlying limit.
 
-## Session Behavior
+See [Storage](/concepts/storage) for what is counted and where estimates can differ from final output size.
 
-The authentication system uses HttpOnly cookies exclusively and embeds a session version in each token.
+## Deployment Checklist
 
-::: warning Upgrades invalidate sessions
-After upgrading, all existing sessions are invalidated and every user must sign in again. See [Upgrading](/operations/upgrading).
-:::
-
-## Default Admin
-
-On first boot, the app auto-creates a default admin user if `DEFAULT_ADMIN_EMAIL` and `DEFAULT_ADMIN_PASSWORD` are set and that user does not already exist. Change the password after first sign-in.
+- Use HTTPS for cookies, OAuth callbacks, passkeys, and PWA features.
+- Set strong, unique `JWT_SECRET` and `PROVIDER_ENCRYPTION_KEY` values.
+- Keep the encryption key out of the database backup and store a recoverable secret backup.
+- Configure exact public `APP_URL`, WebAuthn origin/RP ID, and OAuth callbacks.
+- Restrict `/api/internal/*` at the proxy if the deployment is public.
+- Enable `TRUST_PROXY` only behind a controlled proxy.
+- Disable unused accounts and revoke unused passkeys, MCP tokens, social channels, and store connections.

--- a/docs-site/guide/configuration.md
+++ b/docs-site/guide/configuration.md
@@ -1,16 +1,33 @@
 # Configuration Reference
 
-Remix Studio is configured entirely through environment variables. This page documents every variable, grouped by purpose. For local development copy `.env.example`; for containerized deployments copy one of the `docker/env.*.example` files.
+Remix Studio is configured through environment variables. This page documents the variables read by the application and the supported Docker Compose templates. For local development copy `.env.example`; for containerized deployments copy the example matching the compose layout.
 
 ## Ports & URLs
 
 | Variable | Default | Description |
 | :--- | :--- | :--- |
-| `APP_PORT` | `3000` | Port the app listens on. |
+| `PORT` | `3000` | Port the Node.js process listens on inside its runtime. |
+| `APP_PORT` | `3000` | Host port mapped to the container's `PORT` by the supplied compose files. It is not read directly by `server.ts`. |
 | `APP_URL` | `http://localhost:3000` | Public base URL. Must match the base of any OAuth callback URLs you register. |
 | `POSTGRES_PORT` | `5432` | Host-published PostgreSQL port (compose). |
 | `MINIO_API_PORT` | `9000` | Host-published MinIO API port (compose). |
 | `MINIO_CONSOLE_PORT` | `9001` | Host-published MinIO console port (compose). |
+
+`APP_URL` must be the browser-visible origin, with no path suffix. It is used to build social, store, Google login/Drive, and other callback URLs. `PORT` and `APP_PORT` can differ when a container listens on one port and the host publishes another.
+
+## Runtime & Reverse Proxy
+
+| Variable | Default | Description |
+| :--- | :--- | :--- |
+| `NODE_ENV` | development tooling dependent | Use `production` for the built server. Also changes secure defaults such as storage bucket auto-creation. |
+| `TRUST_PROXY` | `false` | When `1`, `true`, or `yes`, rate limiting uses the leading `X-Forwarded-For` address. Enable only behind a trusted proxy that overwrites this header. |
+| `JOB_PROCESSING_TIMEOUT_MS` | `7200000` (2 hours) | Maximum time an observed detached provider task may remain non-terminal before the job is failed and its concurrency slot released. |
+| `DISABLE_HMR` | unset | Development-only Vite switch used when hot-module-reload WebSockets are unsuitable. |
+| `GEMINI_API_KEY` | unset | Build-time/development compatibility variable exposed by Vite. Normal Remix Studio generation and assistant use provider credentials stored in the app. |
+
+::: warning Trust proxy carefully
+If clients can connect directly to the app and supply their own `X-Forwarded-For`, enabling `TRUST_PROXY` lets them choose the address used by the in-memory authentication rate limiter. Restrict direct access and configure the proxy to replace forwarded headers.
+:::
 
 ## Database
 
@@ -71,6 +88,16 @@ node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
 | `X_CLIENT_ID` / `X_CLIENT_SECRET` | OAuth 2.0 credentials for X (Twitter) campaigns. See [X Setup](/integrations/x-platform). |
 | `THREADS_APP_ID` / `THREADS_APP_SECRET` | Threads (Meta) use-case credentials. Redirect: `${APP_URL}/api/social/threads/callback`. See [Threads Setup](/integrations/threads-platform). |
 
+## Digital Stores
+
+| Variable | Default | Description |
+| :--- | :--- | :--- |
+| `GUMROAD_CLIENT_ID` | empty | OAuth application client ID used by **Exports → Stores**. |
+| `GUMROAD_CLIENT_SECRET` | empty | Gumroad OAuth client secret. |
+| `GUMROAD_SCOPE` | `edit_products view_profile view_sales` | Space-separated OAuth scopes requested when connecting Gumroad. |
+
+The redirect URL is `${APP_URL}/api/stores/gumroad/callback`. Store tokens are encrypted using the same deployment encryption facility as other external credentials.
+
 ## Backups (Docker)
 
 | Variable | Default | Description |
@@ -79,6 +106,18 @@ node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
 | `BACKUP_KEEP_DAYS` | `7` | Retention in days. `0` keeps all backups. |
 
 See [Backup & Restore](/operations/backup-and-restore).
+
+## Compose Service Names, Ports & Volumes
+
+These variables are consumed by the supplied compose files and helper scripts rather than by the Node.js application:
+
+| Variable | Purpose |
+| :--- | :--- |
+| `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_DB` | Bundled PostgreSQL initialization and connection values. Keep `DATABASE_URL` consistent with them. |
+| `POSTGRES_CONTAINER_NAME`, `MINIO_CONTAINER_NAME`, `APP_CONTAINER_NAME` | Optional container-name overrides used by compose templates. |
+| `POSTGRES_DATA_DIR`, `MINIO_DATA_DIR` | Host directories for persistent database and MinIO data. |
+| `POSTGRES_PORT`, `MINIO_API_PORT`, `MINIO_CONSOLE_PORT` | Host-published ports. |
+| `BACKUP_DIR`, `BACKUP_KEEP_DAYS` | Database dump mount and helper-script retention. |
 
 ## Deployment Image
 
@@ -91,3 +130,4 @@ See [Backup & Restore](/operations/backup-and-restore).
 - The app auto-creates a default admin user if `DEFAULT_ADMIN_EMAIL` and `DEFAULT_ADMIN_PASSWORD` are provided and the user does not already exist.
 - Storage is implemented against S3-compatible APIs, so MinIO works well for development and AWS S3 works for production.
 - For host-based local development (`docker compose up -d postgres minio` + `npm run dev`), reach MinIO at `http://localhost:9000`.
+- A database backup does not include bucket objects or `PROVIDER_ENCRYPTION_KEY`; back up all three separately.

--- a/docs-site/guide/docker-deployment.md
+++ b/docs-site/guide/docker-deployment.md
@@ -43,7 +43,7 @@ node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
 docker compose -f docker/compose.minio.yml --env-file .env.docker up -d
 ```
 
-The compose templates default to `ghcr.io/shinchven/remix-studio:latest`, which tracks the newest release image. For pinned release deployments, set `REMIX_STUDIO_IMAGE` in `.env.docker` to a version tag such as `ghcr.io/shinchven/remix-studio:1.5.0`.
+The compose templates default to `ghcr.io/shinchven/remix-studio:latest`, which tracks successful builds from the default branch and may be newer than the latest tagged release. For stable deployments, set `REMIX_STUDIO_IMAGE` in `.env.docker` to a SemVer tag such as `ghcr.io/shinchven/remix-studio:1.5.0`.
 
 This starts:
 

--- a/docs-site/guide/why-different.md
+++ b/docs-site/guide/why-different.md
@@ -1,27 +1,39 @@
 # Why It Feels Different
 
-Most AI generation tools ask you to prompt one asset at a time. Remix Studio is built around **reusable inputs, combinatorial expansion, and background execution**, so a single workflow can produce dozens of drafts before you spend a single API call.
+Most AI generation tools optimize a single prompt box. Remix Studio separates reusable source material, draft composition, provider execution, durable results, and distribution. That separation is what makes large, repeatable content systems manageable.
 
 ## Assistant-First Orchestration
 
-The built-in [assistant](/concepts/assistant) can inspect libraries, album summaries, model availability, and storage status, then prepare project mutations behind explicit confirmation. You can describe what you want and let it assemble a workflow, instead of clicking through every setting yourself.
+The built-in [assistant](/concepts/assistant) reads current libraries, project workflows, album summaries, model availability, storage, campaigns, and posts through the same account-scoped tools exposed over MCP. It can prepare changes, but write/destructive operations stop for review.
+
+This makes the assistant an alternative control surface over real workspace objects, not a separate chat that merely suggests text for you to copy.
 
 ## Combination Engine
 
-Workflows are built from reusable inputs, then expanded into draft permutations instead of forcing you to handcraft each prompt variant. See [Workflows & Combinations](/concepts/workflows) for the full model.
+Workflows mix fixed direct inputs with reusable text/image/video/audio libraries. Combination mode walks the Cartesian product; Shuffle samples independently from each library for a bounded draft count.
+
+Crucially, composition and execution are separate. You can inspect the resolved prompt, contexts, model, and settings before deciding which drafts deserve provider calls. See [Workflows & Combinations](/concepts/workflows).
 
 ## Campaign Workspace
 
-Campaign timelines connect generated copy, reusable media, scheduling, post history, and social channel delivery in the same app. Read more in [Campaigns](/concepts/campaigns).
+Project output does not have to end as a downloaded file. Campaigns reuse generated/library media, prepare post copy in batches, process attachments, schedule posts, and retain per-channel results for X and Threads. A failure on one target remains visible without hiding a success on another. Read [Campaigns](/concepts/campaigns).
 
 ## Batch Execution
 
-Generation runs through a recoverable [queue](/concepts/queue) with provider-specific concurrency and detached polling for async providers. Pending work resumes after a restart.
+Generation runs through a recoverable [queue](/concepts/queue) with concurrency per provider connection. Synchronous calls and remote async tasks share the same job history; detached tasks are polled without occupying a browser tab, and pending/interrupted work is reconciled after restart.
+
+Exports, external deliveries, campaign media, and social posting use their own worker loops so a slow archive upload does not become a generation job.
 
 ## Self-Hosted Control
 
-Providers, storage, exports, auth, and automation all stay in your own deployment. You bring your own API keys, your own database, and your own S3-compatible storage.
+You bring the provider accounts, PostgreSQL database, S3-compatible buckets, OAuth applications, and deployment secrets. Credentials are encrypted before database storage and every workspace route/tool applies user ownership.
+
+Self-hosting also means operational responsibility: back up PostgreSQL **and** object storage, preserve the encryption key, publish storage endpoints required by social platforms, and tune provider concurrency for your hardware and vendor limits.
 
 ## Combination-Driven Workflow at a Glance
 
-If you have 3 subject prompts, 4 style prompts, and 2 reference-image sets, Remix Studio can turn that into **24 drafts** from one workflow before you send anything to a provider. When `shuffle` is enabled, the same workflow can sample from those libraries instead of enumerating the full Cartesian product.
+If you have 3 subjects, 4 styles, and 2 reference images, the workflow has **24 possible combinations**. Set Job Quantity to 24 for one pass through the full set, or a smaller number for a prefix of that deterministic sequence.
+
+With Shuffle enabled, each draft randomly picks one item from every library step. Sampling is with replacement, so it bounds cost but does not promise unique combinations.
+
+The result of either mode is a reviewable draft set. Starting selected drafts moves only those rows into the persistent provider queue.

--- a/docs-site/integrations/chrome-extension.md
+++ b/docs-site/integrations/chrome-extension.md
@@ -1,50 +1,104 @@
 # Browser Extension
 
-Remix Studio ships a **browser importer extension** (`Remix Studio Importer`) that sends images and text from any web page straight into your Remix Studio [library](/concepts/libraries) or [project](/concepts/projects).
+The **Remix Studio Importer** is an unpacked Manifest V3 extension for Chromium-based desktop browsers. It adds context-menu actions that hand selected text or a page image to either the workspace importer or the assistant composer.
 
-## What It Does
+## Capture Actions
 
-From any page, you can capture content and push it into your workspace:
+Right-click supported page content:
 
-- **Images** — send a picture into an image library or a project.
-- **Text** — send selected text into a text library.
+| Page content | Import action | Chat action |
+| :--- | :--- | :--- |
+| Image | **Send image to Remix Studio** | **Send image to Remix Studio Chat** |
+| Selected text | **Send text to Remix Studio** | **Send text to Remix Studio Chat** |
 
-The extension adds **right-click context menu** actions and uses an options page to point at your Remix Studio instance.
+For an image, the extension fetches the image URL, converts the bytes to a data URL, and tries to use the image's `alt` text as its name. If no alt text is available, it falls back to the URL filename.
 
-## Where to Get It
+For selected text, it copies the current selection. The extension captures one context-menu item per action; it is not a bulk page scraper.
 
-The extension is a Manifest V3 extension. There is no Chrome Web Store listing — you install it manually from one of two sources:
+## Installation
 
-### Option A — Download from GitHub Releases (recommended)
+There is no Chrome Web Store listing. Install an unpacked copy:
 
-Every tagged release attaches a packaged **`remix-studio-chrome-extension.zip`** to the [GitHub Releases](https://github.com/ShinChven/remix-studio/releases) page (look under each release's **Assets**).
+### Release archive
 
-1. Download `remix-studio-chrome-extension.zip` from the latest release.
-2. Unzip it to a folder you can keep around.
-3. Open `chrome://extensions` in a Chromium-based browser (Chrome, Edge, Brave, …).
-4. Enable **Developer mode** (top-right toggle).
-5. Click **Load unpacked** and select the unzipped folder.
+1. Download `remix-studio-chrome-extension.zip` from a tagged [GitHub Release](https://github.com/ShinChven/remix-studio/releases).
+2. Extract it to a directory that will remain on disk.
+3. Open `chrome://extensions` (or the equivalent extension page in Edge/Brave).
+4. Enable **Developer mode**.
+5. Choose **Load unpacked** and select the extracted directory.
 
-### Option B — Load from the repository
+### Repository checkout
 
-The extension source also lives in the [`chrome-extension/`](https://github.com/ShinChven/remix-studio/tree/main/chrome-extension) directory of the repository, so you can load it straight from a checkout:
+Follow the same browser steps but select the repository's `chrome-extension/` directory. After pulling extension changes, return to the extension page and press **Reload**.
 
-1. Open `chrome://extensions`.
-2. Enable **Developer mode**.
-3. Click **Load unpacked** and select the `chrome-extension/` folder.
+## Configuration
 
-## Configuring It
+Open the extension's **Options** page and enter only the Remix Studio origin, for example:
 
-After loading, open the extension's **Options** page and enter your Remix Studio URL and access details so it knows where to send content.
+```text
+https://studio.example.com
+```
 
-## In-App Import
+The option is stored with Chrome sync storage and defaults to `http://localhost:3000`. A trailing slash is removed. Do not include `/import`, `/assistant`, or another path.
 
-The app also has an **Extension Import** view that receives content sent from the extension, so imported items land in the right library or project.
+The extension does not store a Remix Studio password or API token. It opens the configured site in a new tab, so that browser profile must already have—or complete—a normal Remix Studio login session.
 
-## Permissions
+## Import Destination Flow
 
-The extension requests `contextMenus`, `storage`, `activeTab`, and `scripting`, with host access to pages so it can read the image or text you choose to send.
+The normal import action opens `/import`, where you can:
 
-## On Mobile?
+- Preview and name the captured item.
+- Save text into a text library or text project.
+- Save an image into an image library or image project.
+- Create a compatible library/project from the import screen.
 
-The browser extension is for desktop Chromium browsers. On Android (and other mobile platforms), use the **system share sheet** instead — Remix Studio is an installable PWA that registers as a share target. See [Mobile Share (PWA)](/integrations/mobile-share).
+Saving to a library creates a new library item. Saving to a project uploads the image when needed and appends a new direct workflow step; it does not create a finished album result or start generation.
+
+The screen remembers the most recent destination type and compatible destination ID separately for image and text imports.
+
+## Assistant Flow
+
+The Chat action opens `/assistant?from=extension`.
+
+- Selected text becomes composer text.
+- An image is compressed for assistant attachment, and its captured name can seed empty composer text.
+
+The content is placed in the composer but is not automatically sent. Choose the provider/model, review the prompt/attachment, and send when ready.
+
+## How the Handoff Works
+
+1. The background service worker writes one payload to extension-local storage.
+2. It opens the configured Remix Studio route.
+3. The content script recognizes that exact configured origin/route and posts the payload into the page.
+4. Remix Studio acknowledges receipt.
+5. The extension clears the stored payload.
+
+The content script retries the handoff briefly while the React application starts. Only one stored payload exists, so starting another import before the first is consumed replaces the earlier payload.
+
+## Permissions and Security
+
+The manifest requests:
+
+- `contextMenus` — add capture actions.
+- `storage` — save the configured origin and pending handoff.
+- `activeTab` / `scripting` — interact with the page selected by the user.
+- `<all_urls>` host access plus a content script on all pages — read image alt text and deliver the payload when the configured Remix Studio page opens.
+
+The broad host permission also allows the background worker to fetch a chosen page image. Some sites block extension fetches, use authenticated blob URLs, or serve protected/short-lived URLs; those images may fail to import.
+
+::: warning
+Install only a trusted copy. Like any extension with all-site access, it can observe the pages covered by its content script. Review `manifest.json`, `background.js`, and `content.js` if you distribute a modified build.
+:::
+
+## Troubleshooting
+
+- **No menu item**: reload the extension, then reload the page.
+- **Wrong Remix Studio host**: correct the origin in Options; do not add a trailing path.
+- **Login page opens**: sign in in the same browser profile, then repeat the capture.
+- **No import data found**: the handoff was consumed, overwritten, or the configured origin did not match the opened page.
+- **Image capture fails**: download the image locally and upload it in Remix Studio; the site may block cross-origin extension fetching.
+- **Updated source does not run**: use **Reload** on `chrome://extensions`.
+
+## Mobile Alternative
+
+Desktop Chromium is the supported extension path. On Android, install Remix Studio as a PWA and use the system share sheet. See [Mobile Share](/integrations/mobile-share).

--- a/docs-site/integrations/mcp.md
+++ b/docs-site/integrations/mcp.md
@@ -1,8 +1,8 @@
 # MCP Support
 
-Remix Studio exposes an **MCP server** at `/mcp` for authenticated, account-scoped automation. External MCP clients can work with libraries, prompts, storage summaries, album summaries, model discovery, direct workflow inputs, and workflow-backed project creation and updates.
+Remix Studio exposes a streamable HTTP **Model Context Protocol (MCP)** endpoint at `/mcp`. It lets an external client work with the same user-scoped libraries, projects, models, storage summaries, campaigns, and posts used by the web interface.
 
-The in-app [assistant](/concepts/assistant) uses the same shared tool registry, so chat orchestration and MCP automation stay aligned.
+The [in-app assistant](/concepts/assistant) is built on the same tool registry, but authentication and write confirmation differ.
 
 ## Capabilities
 
@@ -29,21 +29,21 @@ Read tools return **storage keys**, not links. To fetch, view, or download a fil
 
 ## Authentication
 
-Clients can connect with either:
+MCP requests require a bearer token obtained through either:
 
-- **OAuth 2.0 authorization code flow**, with **PKCE** supported.
-- A **personal access token (PAT)**.
+- **OAuth 2.0 authorization code flow**, with PKCE support and refresh tokens.
+- A **personal access token (PAT)** created in Remix Studio.
 
-Manage both under **Account → MCP** (the MCP Connections page, which also includes a Claude Code and Codex CLI setup guide).
+Manage connections under **Assistant Settings → MCP**. PATs are shown only when created, are stored as hashes, can have an expiry, and can be revoked. All MCP tools use the `mcp:tools` scope and enforce the authenticated user's ownership in their handlers.
 
-OAuth metadata is available at:
+OAuth discovery metadata is available at:
 
 - `/.well-known/oauth-authorization-server`
 - `/.well-known/oauth-protected-resource`
 
-Related endpoints are `/register`, `/authorize`, and `/token`. All tools are user-scoped and use the `mcp:tools` OAuth scope.
+The related endpoints are `/register`, `/authorize`, and `/token`. Dynamically registered clients are tied to the account that created them. The server rotates OAuth refresh tokens and detects reuse outside its recovery grace window.
 
-## Client Configuration
+## Client Configuration with a PAT
 
 ```json
 {
@@ -59,18 +59,61 @@ Related endpoints are `/register`, `/authorize`, and `/token`. All tools are use
 }
 ```
 
-Replace `http://localhost:3000` with your deployed origin.
+Replace the origin with the public `APP_URL` of your deployment. Use HTTPS outside local development because the token grants access to your Remix Studio data.
+
+## Tool Catalog
+
+The exact schemas are returned by MCP tool discovery. At the current source version, the catalog is:
+
+| Area | Read tools | Write/destructive tools |
+| :--- | :--- | :--- |
+| Libraries | `list_libraries`, `get_library_items`, `search_library_items` | `create_library`, `update_library`, `create_prompt`, `batch_create_prompts`, `update_prompt`, `update_library_item`, `batch_update_library_items`, `delete_prompt` |
+| Projects | `get_project`, `list_albums`, `get_album_items`, `list_available_models`, `get_storage_usage` | `create_project_with_workflow`, `update_project` |
+| Files | `get_file_urls` | — |
+| Campaigns | `list_social_accounts`, `list_campaigns` | `create_campaign`, `update_campaign` |
+| Posts | `get_post`, `get_post_text` | `create_post`, `update_post`, `update_post_text`, `add_media_to_post`, `schedule_post` |
+
+Important boundaries:
+
+- Prompt creation/deletion is for **text libraries**.
+- `update_library_item` can update text content only for a text library; batch updates change titles/tags only and accept at most 100 items.
+- `update_project` replaces the entire workflow when `workflowItems` is supplied. Call `get_project` immediately beforehand and carry forward every step that should remain.
+- Media added to a post must be an internal storage key already owned by the authenticated user and valid for that campaign.
+- Scheduling requires a valid time, an active channel on the campaign, and ready media.
+
+## Write Confirmation Protocol
+
+External MCP writes use an argument-bound two-call protocol:
+
+1. Call the tool with the desired arguments and without `confirmed: true`.
+2. The server returns a preview containing a summary, normalized arguments, and `confirmationHash`; no mutation has occurred.
+3. Show that exact action to the user.
+4. If approved, call the same tool again with the same arguments plus `confirmed: true` and the returned `confirmationHash`.
+
+The hash binds approval to the tool name and normalized arguments. If any argument changes, the hash is rejected and a new preview is required.
+
+Read-only tools do not need this protocol. External clients cannot use the in-app assistant's per-conversation approved-tools list.
+
+## Workflow Update Safety
+
+Project workflow updates are replacement operations, not patches to one step. A safe client sequence is:
+
+1. Call `get_project`.
+2. Start from the newly returned `workflowItems`.
+3. Apply the requested edit while preserving order, selected tags, and disabled state.
+4. Preview `update_project`.
+5. Confirm the exact replacement.
+
+This prevents a long-running conversation from silently dropping workflow edits made elsewhere.
 
 ## Inspecting the Server
 
-During local development you can launch the MCP inspector against the running app:
+During local development:
 
 ```bash
 npm run mcp:inspect
 ```
 
-This connects to `http://localhost:3000/mcp` over HTTP transport.
+The script launches the MCP Inspector against `http://localhost:3000/mcp`. Sign in or provide a token as required by the inspector.
 
-## Tool Catalog
-
-The full tool catalog is defined in `server/mcp/tool-definitions.ts` in the repository.
+For source-level details, see `server/mcp/tool-definitions.ts` and `server/mcp/tool-confirmation.ts`.

--- a/docs-site/integrations/mobile-share.md
+++ b/docs-site/integrations/mobile-share.md
@@ -6,7 +6,7 @@ On Android and other mobile platforms, Remix Studio acts as a **Progressive Web 
 
 The share target accepts:
 
-- **Images** — one or more image files (the manifest accepts `image/*`).
+- **Images** — the manifest can receive one or more `image/*` files, but the current Share screen hands off only the first image and warns when more were received.
 - **Text** — selected text.
 - **URLs** — a shared link.
 - **Title** — the shared item's title, when the source app provides one.
@@ -33,16 +33,22 @@ Under the hood, the flow is:
 
 1. The system posts the shared data to Remix Studio's `/share-target` endpoint.
 2. The app's **service worker** intercepts that request, stashes the files and metadata (title, text, URL) in a temporary cache, and redirects to the in-app **`/share`** screen.
-3. The Share screen reads the cached payload and forwards it to the **Import** view (`/import`) — the same destination used by the [browser extension](/integrations/chrome-extension).
-4. From there you choose the target **library** or **project**, and the content is imported.
+3. The Share screen reads the cached payload and presents the available destinations.
+4. Choose **Save to Library or Project** to open the Import view (`/import`, the same destination used by the [browser extension](/integrations/chrome-extension)), or **Start a Chat** to place the content in the assistant composer.
+5. The Import view offers only destinations matching the handoff type. Saving to a project appends a direct workflow input; it does not create an album result.
 
-Because the hand-off goes through a one-shot cache that is cleared on each new share, only your most recently shared payload is held, and it is consumed as soon as the Import view picks it up.
+Because the hand-off goes through a one-shot cache that is cleared on each new share, only the most recent share is held. The Share screen consumes and deletes the cached entries as soon as it loads, then stores one selected handoff in session storage for Import or Chat.
+
+::: warning Multiple images
+Although Android may send several image files, Remix Studio currently previews and forwards only the first. Import the remaining images separately.
+:::
 
 ## Requirements & Notes
 
 - The app is configured with `display: standalone` and registers a service worker (`sw.js`), so it installs and runs like a native app.
 - Share-target support depends on the platform and browser. **Android Chrome** is the primary supported path; iOS Safari does not currently support the Web Share Target API, so on iOS use the app in the browser and import manually or via the desktop extension.
 - You must be **signed in** for the import to land in your account.
+- Sharing into Chat fills the composer; it does not automatically send a model request.
 
 ## Related
 

--- a/docs-site/integrations/threads-platform.md
+++ b/docs-site/integrations/threads-platform.md
@@ -77,7 +77,8 @@ APP_URL=http://localhost:3000
 Threads publishes images and videos by fetching them from a **public URL** that Meta cURLs server-side. Remix Studio supplies time-limited presigned URLs from your configured [S3-compatible storage](/concepts/storage).
 
 - Your storage's public endpoint (`S3_PUBLIC_ENDPOINT` / custom domain) must be reachable from the public internet, or Meta cannot fetch the media and publishing will fail.
-- Supported post shapes: text-only, single image, single video, and carousels of **2 to 20** image/video items.
+- The Threads adapter supports text-only, one image/video, and carousel publishing (the adapter enforces Threads' 20-item ceiling). The current Remix Studio post editor limits a post to **four** media items, so UI-created carousels contain 2–4 items.
+- Remix Studio creates child containers sequentially, waits for every child and the parent container to finish processing, then publishes. A container that reports `ERROR`/`EXPIRED` or does not finish within the polling window fails that channel execution.
 
 ## Troubleshooting
 

--- a/docs-site/operations/backup-and-restore.md
+++ b/docs-site/operations/backup-and-restore.md
@@ -1,8 +1,20 @@
-# Database Backup & Restore
+# Backup & Restore
 
-This guide covers how to back up and restore the PostgreSQL database used by Remix Studio when running via Docker. The application container includes `pg_dump`, `psql`, and automated helper scripts.
+This guide covers the PostgreSQL helper scripts shipped with the Docker image and the additional data needed for a complete Remix Studio backup.
 
-## Architecture
+::: warning A database dump is not a complete backup
+PostgreSQL stores records and object keys. Generated media, library uploads, campaign media, thumbnails, and export ZIPs live in object storage. Provider and external-service credentials also require the original `PROVIDER_ENCRYPTION_KEY` to decrypt.
+:::
+
+For a recoverable deployment, back up:
+
+1. PostgreSQL.
+2. The main object-storage bucket (`S3_BUCKET`).
+3. The export bucket (`S3_EXPORT_BUCKET`) if archives must be retained.
+4. Environment/deployment secrets, especially `PROVIDER_ENCRYPTION_KEY` and `JWT_SECRET`.
+5. The application version or image tag used at backup time.
+
+## Database Backup Architecture
 
 Backup files are generated inside the application container and saved to `/app/backups`. To ensure these backups persist across container restarts and updates, this path must be mounted as a host volume.
 
@@ -87,7 +99,32 @@ Add:
 0 2 * * * docker exec remix-studio-app /app/backup.sh >> /var/log/remix-studio-backup.log 2>&1
 ```
 
-## Restoring From a Backup
+The helper applies retention only to matching database dump files in `/app/backups`. It does not copy object storage or secrets.
+
+## Backing Up Object Storage
+
+Use the native versioning/replication/export feature of your storage provider or a compatible tool that preserves object bytes and keys.
+
+- **MinIO**: mirror both buckets to a different disk or remote target; copying the local MinIO data directory is safe only with a storage-consistent snapshot.
+- **AWS S3 / R2 / managed storage**: enable versioning and/or replication, or run a scheduled bucket copy to an independent account/location.
+- **Other S3-compatible services**: verify that multipart objects, metadata, and every prefix are included.
+
+Record the exact bucket names, endpoints, regions, and custom-domain settings. Restoring bytes under different keys will leave database references broken.
+
+For the most consistent backup, pause new generation, uploads, exports, campaign-media processing, and trash cleanup while capturing the database and buckets. If that is not possible, take storage and database snapshots as close together as possible and expect to use project orphan analysis after recovery.
+
+## Backing Up Secrets
+
+Keep an encrypted copy of production configuration in a secret manager or offline recovery store. At minimum preserve:
+
+- `PROVIDER_ENCRYPTION_KEY` — required to decrypt saved provider, social, store, and connected-service credentials.
+- `JWT_SECRET` — changing it invalidates existing access tokens.
+- Database and object-storage credentials, or the identity configuration used to obtain them.
+- OAuth client secrets for Google, X, Threads, and Gumroad.
+
+Do not put an unencrypted `.env` file in the same publicly accessible backup location as the database and buckets.
+
+## Restoring PostgreSQL
 
 ::: danger Data loss warning
 Restoring a backup will **drop and recreate** the target database. All current data is permanently lost and replaced with the state from the backup. The restore script prompts for confirmation before proceeding.
@@ -129,3 +166,30 @@ docker exec remix-studio-app npx prisma migrate deploy
 ```bash
 docker compose restart app
 ```
+
+## Restoring a Complete Deployment
+
+Use this order for a disaster recovery:
+
+1. Stop Remix Studio workers or keep the application offline.
+2. Provision PostgreSQL and both object-storage buckets.
+3. Restore the bucket objects under their original keys.
+4. Restore the PostgreSQL dump.
+5. Restore the original `PROVIDER_ENCRYPTION_KEY` and remaining environment configuration.
+6. Start the target application version and run `prisma migrate deploy`.
+7. Verify `/healthz` and `/readyz`.
+8. Test representative project media, library media, an export download, provider credential access, and a non-destructive connected-service read.
+9. Upgrade to a newer application version only after the restored version is healthy.
+
+If bucket names or public endpoints changed, update the S3 environment variables. Stored database values are generally object keys, while signed/display URLs are rebuilt by the server; however, externally cached URLs and third-party posts are not rewritten.
+
+## Verification and Retention
+
+A backup is useful only if it can be restored. Periodically:
+
+- Test-decompress a database dump with `gzip -t`.
+- Restore to an isolated PostgreSQL database.
+- Compare object counts/bytes for both buckets.
+- Open original, optimized, and thumbnail variants.
+- Confirm encrypted provider credentials can be decrypted with the recovered key.
+- Keep at least one copy outside the deployment host and storage account.

--- a/docs-site/operations/upgrading.md
+++ b/docs-site/operations/upgrading.md
@@ -15,10 +15,11 @@ In Docker deployments, the application container runs `prisma migrate deploy` au
 
 See [Docker Deployment](/guide/docker-deployment) for image-tag details.
 
-## Breaking Changes to Be Aware Of
+## Compatibility Notes
 
-- **All existing sessions are invalidated after upgrading.** The authentication system was hardened to use HttpOnly cookies exclusively and now includes a session version in each token. Existing JWTs are no longer accepted, so all users must sign in again.
-- **Reference image URLs can use HTTP or HTTPS, but cannot point to private IPs.** Jobs that reference images via internal network addresses will be rejected.
+- Normal upgrades do not automatically invalidate every current session. Individual security migrations or releases can change token/session behavior; read the release notes between your current and target versions.
+- Reference URLs can use HTTP or HTTPS, but server-side provider and media fetches reject unsafe private/internal network targets.
+- Database migrations are forward operations. Restore the pre-upgrade database and matching object-storage snapshot if a rollback requires an older schema.
 
 ## Keep PROVIDER_ENCRYPTION_KEY Stable
 
@@ -31,10 +32,12 @@ If you previously ran an older version with a longer key value, the app may have
 ## Recommended Upgrade Procedure (Docker)
 
 1. **Back up the database** first — see [Backup & Restore](/operations/backup-and-restore).
-2. Pull the new image (or update `REMIX_STUDIO_IMAGE`).
-3. Restart the stack; the container applies migrations on startup.
-4. Confirm health at `/healthz` and `/readyz`.
-5. Notify users that they will need to sign in again.
+2. Back up the main/export buckets and confirm the encryption key is recoverable.
+3. Read every release note between the installed and target versions.
+4. Pull the new image (or update `REMIX_STUDIO_IMAGE`).
+5. Restart the stack; the container applies migrations on startup.
+6. Confirm health at `/healthz` and `/readyz`.
+7. Test sign-in, provider decryption, representative media, queue dispatch, and export download.
 
 ## Changelog
 


### PR DESCRIPTION
## Summary

- Audit all 31 published documentation pages against the current Remix Studio implementation.
- Expand 23 underspecified pages with clearer feature behavior, usage flows, limits, state transitions, and operational guidance.
- Correct stale or inaccurate descriptions across workflows, libraries, projects, the assistant, MCP, campaigns, exports, storage, authentication, deployment, and integrations.
- Synchronize the documentation changes with the latest `main`, including the new MCP album browsing and signed-file URL tools.

## Why

Several documentation pages were too brief to explain how their features actually behave, while others had drifted from the implementation. This made important details—such as workflow sampling semantics, queue recovery, export persistence, backup requirements, MCP confirmation, and integration limitations—difficult to discover or potentially misleading.

This update treats the source code as the reference and documents both the user-facing workflow and the underlying rules that affect correct usage.

## What changed

### Core product concepts

- Document library types, browsing, sorting, imports, reuse semantics, tags, and reference cleanup.
- Explain workflow ordering, disabled steps, tag selection, Cartesian combinations, shuffle sampling with replacement, cycling, snapshots, and prompt limits.
- Expand project, album, queue, provider, model, storage, trash, export, and Gumroad selling behavior.
- Describe campaign, post, execution, scheduling, media-readiness, and channel-delivery states.

### Assistant and MCP

- Correct the supported assistant provider list and explain workspace context, skills, tool approvals, and conversation behavior.
- Document MCP authentication, OAuth/PAT handling, the complete tool catalog, argument-bound write confirmation, and safe workflow replacement.
- Include `get_album_items` and `get_file_urls`, including ownership checks, temporary URLs, expiration limits, and download behavior.

### Administration and integrations

- Expand environment configuration, proxy and security settings, deployment options, backup and restore requirements, and upgrade behavior.
- Correct browser-extension and mobile PWA sharing behavior and limitations.
- Clarify Threads media limits versus the current post editor limits.
- Align Docker tag guidance with the release workflow.

## User and developer impact

Users get more complete guidance for configuring and operating Remix Studio without needing to infer behavior from the UI. Administrators receive clearer deployment, security, storage, backup, and recovery expectations. Developers and MCP clients get an accurate description of data ownership, mutation safety, and workflow replacement semantics.

No application code or database schema is changed.

## Validation

- `npm run build` in `docs-site`
- VitePress production rendering for all published pages
- Internal documentation-link and public-asset target validation
- `git diff --check`

## Diff scope

- 23 documentation files changed
- 1,206 lines added
- 384 lines removed
