### PR TITLE
Make library item actions always visible instead of hover-only

### DIFF
--- a/src/components/LibraryEditor.tsx
+++ b/src/components/LibraryEditor.tsx
@@ -828,8 +828,8 @@ export function LibraryEditor({ library, onUpdate, onDelete }: Props) {
                               {updatedAtLabel}
                             </span>
                           )}
-                          {/* Touch devices never hover, so the actions stay visible on phones. */}
-                          <div className="flex items-center gap-0.5 shrink-0 self-end -mr-1 sm:self-auto sm:mr-0 sm:opacity-0 sm:group-hover/item:opacity-100 transition-opacity">
+                          {/* Actions stay visible at every breakpoint — no hover required. */}
+                          <div className="flex items-center gap-0.5 shrink-0 self-end -mr-1 sm:self-auto sm:mr-0">
                           <button
                             onClick={(e) => {
                               e.stopPropagation();


### PR DESCRIPTION
## Summary
Updated the LibraryEditor component to display item actions at all times rather than only on hover for larger screens. This improves accessibility and discoverability of available actions.

## Key Changes
- Removed opacity-based hover state (`sm:opacity-0 sm:group-hover/item:opacity-100 transition-opacity`) that hid actions on desktop
- Actions now remain visible at all breakpoints, including on touch devices and desktop
- Updated comment to reflect the new behavior

## Implementation Details
The actions container previously used Tailwind&#39;s group-hover modifier to hide actions on small screens and only show them on hover for larger screens. This change simplifies the UI by keeping actions consistently visible, eliminating the need for users to discover the hover interaction pattern and improving usability on touch devices where hover is not available.
