### PR TITLE
Add workflow reuse from album items and lightbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Remix Studio are documented here by version number.
 
 ## [Unreleased]
 
+### Added
+
+- **Reuse a Workflow from the Album**: Reusing a configuration no longer means hunting for the right row in Done. Album, text, and audio entries now carry their own reuse control, and the image lightbox has one too (shortcut `R`), so a setup can be picked while looking at the finished piece. The settings are resolved through the job behind the item, the same confirmation applies before the project workflow is replaced, and the lightbox closes once it is. Items whose Done record has since been deleted report that the workflow is no longer available.
+
 ## [1.19.0] - 2026-08-02
 
 ### Added

--- a/docs-site/concepts/projects.md
+++ b/docs-site/concepts/projects.md
@@ -48,7 +48,7 @@ The final tab is named for the project modality. It contains durable `AlbumItem`
 - Text projects show generated text and its prompt/context; multiple text results can be compared.
 - Audio projects provide audio result controls.
 
-The collection supports selection, page-size choices, filename changes, export, copy-to-library, and recycle-bin deletion. The active tab, page, and supported filters live in URL search parameters, so navigation and shared links can preserve the same view.
+The collection supports selection, page-size choices, filename changes, export, copy-to-library, workflow reuse, and recycle-bin deletion. The active tab, page, and supported filters live in URL search parameters, so navigation and shared links can preserve the same view.
 
 ## Copying Results to a Library
 
@@ -71,7 +71,12 @@ Exports run outside the generation queue in their own persistent worker and appe
 
 Job rows retain a workflow snapshot and resolved generation settings. The **Reuse configuration** action restores those settings into the project editor so a prior result or failure can be used as the starting point for new drafts.
 
-Reuse changes the current editable workflow/settings only after confirmation; it does not alter the old job or album item.
+The same action is available from the results themselves, so you can pick a setup by looking at the finished piece instead of a job row:
+
+- Album, text, and audio entries each carry a **Reuse workflow** control that resolves the settings through the job that produced them.
+- The image lightbox offers the same control (shortcut `R`), and closes on confirmation so you land on the restored workflow.
+
+Reuse changes the current editable workflow/settings only after confirmation; it does not alter the old job or album item. The workflow snapshot lives on the job record, so reusing from an album item whose Done record was deleted reports that the workflow is no longer available.
 
 ## Orphan Files
 

--- a/server/db/prisma-repository.ts
+++ b/server/db/prisma-repository.ts
@@ -87,6 +87,7 @@ export class PrismaRepository implements IRepository {
 
   // === Album CRUD ===
   getAllProjectAlbumItems(userId: string, projectId: string) { return this.projects.getAllProjectAlbumItems(userId, projectId); }
+  getAlbumItem(userId: string, projectId: string, itemId: string) { return this.projects.getAlbumItem(userId, projectId, itemId); }
   addAlbumItem(userId: string, projectId: string, item: AlbumItem) { return this.projects.addAlbumItem(userId, projectId, item); }
   deleteAlbumItem(userId: string, projectId: string, itemId: string) { return this.projects.deleteAlbumItem(userId, projectId, itemId); }
 

--- a/server/db/project-repository.ts
+++ b/server/db/project-repository.ts
@@ -538,6 +538,12 @@ export class ProjectRepository {
     });
   }
 
+  async getAlbumItem(userId: string, projectId: string, itemId: string): Promise<AlbumItem | null> {
+    const item = await this.prisma.albumItem.findFirst({ where: { id: itemId, projectId, userId } });
+    if (!item) return null;
+    return this.mapAlbumItem(item);
+  }
+
   async deleteAlbumItem(userId: string, projectId: string, itemId: string): Promise<AlbumItem | null> {
     const item = await this.prisma.albumItem.findFirst({ where: { id: itemId, projectId, userId } });
     if (!item) return null;

--- a/server/db/repository.ts
+++ b/server/db/repository.ts
@@ -62,6 +62,7 @@ export interface IRepository {
 
   // === Album CRUD ===
   getAllProjectAlbumItems(userId: string, projectId: string): Promise<AlbumItem[]>;
+  getAlbumItem(userId: string, projectId: string, itemId: string): Promise<AlbumItem | null>;
   addAlbumItem(userId: string, projectId: string, item: AlbumItem): Promise<void>;
   deleteAlbumItem(userId: string, projectId: string, itemId: string): Promise<AlbumItem | null>;
 

--- a/server/routes/projects.ts
+++ b/server/routes/projects.ts
@@ -411,6 +411,46 @@ export function createProjectRouter(repository: IRepository, userRepository: Use
     }
   });
 
+  /**
+   * GET /api/projects/:id/album/:itemId/configuration
+   *
+   * Same payload as the job configuration endpoint, resolved from the album
+   * item's originating job so a finished result can be reused straight from the
+   * album. The workflow snapshot only lives on the job, so it comes back empty
+   * once that job has been deleted; the item's own settings still fill the rest.
+   */
+  router.get('/api/projects/:id/album/:itemId/configuration', authMiddleware, async (c) => {
+    try {
+      const user = c.get('user') as JwtPayload;
+      const projectId = c.req.param('id');
+      const itemId = c.req.param('itemId');
+      if (!projectId || !itemId) return c.json({ error: 'Project id and album item id are required' }, 400);
+
+      const item = await repository.getAlbumItem(user.userId, projectId, itemId);
+      if (!item) return c.json({ error: 'Album item not found' }, 404);
+
+      const job = item.jobId ? await repository.getJob(user.userId, projectId, item.jobId) : null;
+
+      return c.json({
+        workflowSnapshot: job?.workflowSnapshot
+          ? await signWorkflowItems(job.workflowSnapshot, storage)
+          : [],
+        providerId: job?.providerId ?? item.providerId,
+        modelConfigId: job?.modelConfigId ?? item.modelConfigId,
+        aspectRatio: job?.aspectRatio ?? item.aspectRatio,
+        quality: job?.quality ?? item.quality,
+        background: job?.background,
+        format: job?.format ?? item.format,
+        duration: job?.duration ?? item.duration,
+        resolution: job?.resolution ?? item.resolution,
+        sound: job?.sound,
+      });
+    } catch (e) {
+      console.error('[GET /api/projects/:id/album/:itemId/configuration]', e);
+      return c.json({ error: 'Failed to get album item configuration' }, 500);
+    }
+  });
+
   router.delete('/api/projects/:id/jobs/:jobId', authMiddleware, async (c) => {
     try {
       const user = c.get('user') as JwtPayload;

--- a/src/api.ts
+++ b/src/api.ts
@@ -547,9 +547,18 @@ export async function fetchProjectCompletedJobs(
 export async function fetchProjectJobConfiguration(
   id: string,
   jobId: string,
-): Promise<Pick<import('./types').Job, 'workflowSnapshot' | 'providerId' | 'modelConfigId' | 'aspectRatio' | 'quality' | 'background' | 'format' | 'duration' | 'resolution' | 'sound'>> {
+): Promise<import('./types').JobConfiguration> {
   const res = await apiFetch(`/api/projects/${id}/jobs/${jobId}/configuration`, { headers: getHeaders(false) });
-  return handleResponse<Pick<import('./types').Job, 'workflowSnapshot' | 'providerId' | 'modelConfigId' | 'aspectRatio' | 'quality' | 'background' | 'format' | 'duration' | 'resolution' | 'sound'>>(res, 'Failed to get job configuration');
+  return handleResponse<import('./types').JobConfiguration>(res, 'Failed to get job configuration');
+}
+
+/** Resolve the generation settings behind an album item (via the job that produced it). */
+export async function fetchProjectAlbumItemConfiguration(
+  id: string,
+  itemId: string,
+): Promise<import('./types').JobConfiguration> {
+  const res = await apiFetch(`/api/projects/${id}/album/${itemId}/configuration`, { headers: getHeaders(false) });
+  return handleResponse<import('./types').JobConfiguration>(res, 'Failed to get album item configuration');
 }
 
 export async function deleteProjectJob(id: string, jobId: string): Promise<void> {

--- a/src/components/ProjectViewer.tsx
+++ b/src/components/ProjectViewer.tsx
@@ -7,6 +7,7 @@ import {
   DEFAULT_AUDIO_PROJECT_CONFIG,
   Project,
   Job,
+  JobConfiguration,
   Library,
   WorkflowItem as WorkflowItemType,
   WorkflowItemType as WorkflowItemTypeKind,
@@ -21,7 +22,7 @@ import {
   serializeAudioProjectConfig,
   truncatePromptToLimit,
 } from '../types';
-import { saveImage, saveVideo, saveAudio, fetchProviders, fetchProjectWorkflow, fetchProjectJobs, fetchProjectCompletedJobs, fetchProjectAlbum, fetchProjectJobConfiguration, updateProject as apiUpdateProject, startProjectJobs as apiStartProjectJobs, imageDisplayUrl as apiImageDisplayUrl, moveToTrash, moveToTrashBatch, renameAlbumItem as apiRenameAlbumItem, fetchLibraries, fetchLibrary, clearFailedQueueJobs, deleteProjectJobs as apiDeleteProjectJobs, createLibraryItem } from '../api';
+import { saveImage, saveVideo, saveAudio, fetchProviders, fetchProjectWorkflow, fetchProjectJobs, fetchProjectCompletedJobs, fetchProjectAlbum, fetchProjectJobConfiguration, fetchProjectAlbumItemConfiguration, updateProject as apiUpdateProject, startProjectJobs as apiStartProjectJobs, imageDisplayUrl as apiImageDisplayUrl, moveToTrash, moveToTrashBatch, renameAlbumItem as apiRenameAlbumItem, fetchLibraries, fetchLibrary, clearFailedQueueJobs, deleteProjectJobs as apiDeleteProjectJobs, createLibraryItem } from '../api';
 import { CheckCircle2, List, Grid, ChevronLeft, Plus, Loader2 } from 'lucide-react';
 import { toast } from 'sonner';
 import { countWorkflowCombinations, generateJobs } from '../lib/remixEngine';
@@ -196,7 +197,7 @@ export function ProjectViewer({ project, libraries, onUpdate: onUpdateProp, onDe
   const [showDeleteProjectModal, setShowDeleteProjectModal] = useState(false);
   const [itemToRemoveId, setItemToRemoveId] = useState<string | null>(null);
   const [jobToDeleteId, setJobToDeleteId] = useState<string | null>(null);
-  const [jobToReuse, setJobToReuse] = useState<Job | null>(null);
+  const [configToReuse, setConfigToReuse] = useState<JobConfiguration | null>(null);
 
 
 
@@ -207,7 +208,7 @@ export function ProjectViewer({ project, libraries, onUpdate: onUpdateProp, onDe
   const [showLibrarySelector, setShowLibrarySelector] = useState(false);
   const [previewingLibrary, setPreviewingLibrary] = useState<Library | null>(null);
   const [previewingWorkflowItemId, setPreviewingWorkflowItemId] = useState<string | null>(null);
-  const [reuseConfigJobId, setReuseConfigJobId] = useState<string | null>(null);
+  const [reuseConfigSourceId, setReuseConfigSourceId] = useState<string | null>(null);
   const [providers, setProviders] = useState<Provider[]>([]);
   const [selectedProviderId, setSelectedProviderId] = useState<string>(project.providerId || '');
   const [selectedModelId, setSelectedModelId] = useState<string>('');
@@ -456,49 +457,71 @@ export function ProjectViewer({ project, libraries, onUpdate: onUpdateProp, onDe
     setCompletedPage(1);
   }, []);
 
-  const handleReuseWorkflow = async (job: Job) => {
-    if (reuseConfigJobId) return;
+  /** Load a job's or album item's configuration, then ask for confirmation before applying it. */
+  const loadReuseConfiguration = async (
+    sourceId: string,
+    load: () => Promise<JobConfiguration>,
+    unavailableMessage: string,
+  ) => {
+    if (reuseConfigSourceId) return;
 
-    setReuseConfigJobId(job.id);
+    setReuseConfigSourceId(sourceId);
     try {
-      const config = await fetchProjectJobConfiguration(localProject.id, job.id);
+      const config = await load();
       if (!config.workflowSnapshot || config.workflowSnapshot.length === 0) {
-        toast.error(t('projectViewer.common.reuseConfigurationUnavailable'));
+        toast.error(unavailableMessage);
         return;
       }
-      setJobToReuse({ ...job, ...config });
+      setConfigToReuse(config);
     } catch (e: any) {
-      toast.error(e?.message || t('projectViewer.common.reuseConfigurationUnavailable'));
+      toast.error(e?.message || unavailableMessage);
     } finally {
-      setReuseConfigJobId(null);
+      setReuseConfigSourceId(null);
     }
   };
 
-  const confirmReuseWorkflow = () => {
-    if (!jobToReuse || !jobToReuse.workflowSnapshot) return;
+  const handleReuseWorkflow = (job: Job) =>
+    loadReuseConfiguration(
+      job.id,
+      () => fetchProjectJobConfiguration(localProject.id, job.id),
+      t('projectViewer.common.reuseConfigurationUnavailable'),
+    );
 
-    const newProviderId = jobToReuse.providerId || localProject.providerId;
-    const newModelConfigId = jobToReuse.modelConfigId || localProject.modelConfigId;
+  const handleReuseAlbumWorkflow = (item: AlbumItem) =>
+    loadReuseConfiguration(
+      item.id,
+      () => fetchProjectAlbumItemConfiguration(localProject.id, item.id),
+      t('projectViewer.album.reuseWorkflowUnavailable'),
+    );
+
+  const confirmReuseWorkflow = () => {
+    if (!configToReuse || !configToReuse.workflowSnapshot) return;
+
+    const newProviderId = configToReuse.providerId || localProject.providerId;
+    const newModelConfigId = configToReuse.modelConfigId || localProject.modelConfigId;
 
     const updated = {
       ...localProject,
-      workflow: jobToReuse.workflowSnapshot,
+      workflow: configToReuse.workflowSnapshot,
       providerId: newProviderId,
       modelConfigId: newModelConfigId,
-      aspectRatio: jobToReuse.aspectRatio || localProject.aspectRatio,
-      quality: jobToReuse.quality || localProject.quality,
-      format: jobToReuse.format || localProject.format,
-      background: jobToReuse.background || localProject.background,
-      duration: jobToReuse.duration || localProject.duration,
-      resolution: jobToReuse.resolution || localProject.resolution,
-      sound: jobToReuse.sound || localProject.sound,
+      aspectRatio: configToReuse.aspectRatio || localProject.aspectRatio,
+      quality: configToReuse.quality || localProject.quality,
+      format: configToReuse.format || localProject.format,
+      background: configToReuse.background || localProject.background,
+      duration: configToReuse.duration || localProject.duration,
+      resolution: configToReuse.resolution || localProject.resolution,
+      sound: configToReuse.sound || localProject.sound,
     };
 
     setLocalProject(updated);
     if (newProviderId) setSelectedProviderId(newProviderId);
     if (newModelConfigId) setSelectedModelId(newModelConfigId);
     onUpdate(updated);
-    setJobToReuse(null);
+    setConfigToReuse(null);
+    // Reusing from the album is done from the lightbox too; close it so the
+    // restored workflow is what the user lands on.
+    setLightboxData(null);
     toast.success(t('projectViewer.common.reuseConfiguration'));
     setMobileView('workflow');
   };
@@ -2356,6 +2379,8 @@ export function ProjectViewer({ project, libraries, onUpdate: onUpdateProp, onDe
               setShowDeleteAlbumModal={setShowDeleteAlbumModal} getProviderName={getProviderName} getModelName={getModelName}
               setLightboxData={setLightboxData}
               onRenameAlbumItem={renameAlbumItem}
+              onReuseWorkflow={handleReuseAlbumWorkflow}
+              reusingAlbumItemId={reuseConfigSourceId}
               onExportStarted={() => navigate('/exports')}
               projectType={localProject.type || 'image'}
               page={albumPage}
@@ -2375,7 +2400,7 @@ export function ProjectViewer({ project, libraries, onUpdate: onUpdateProp, onDe
         </div>
       </div>
 
-      <ConfirmModal isOpen={jobToReuse !== null} onClose={() => setJobToReuse(null)} onConfirm={confirmReuseWorkflow} title={t('projectViewer.confirm.reuseConfiguration.title')} message={t('projectViewer.confirm.reuseConfiguration.message')} confirmText={t('projectViewer.confirm.reuseConfiguration.confirm')} type="info" />
+      <ConfirmModal isOpen={configToReuse !== null} onClose={() => setConfigToReuse(null)} onConfirm={confirmReuseWorkflow} title={t('projectViewer.confirm.reuseConfiguration.title')} message={t('projectViewer.confirm.reuseConfiguration.message')} confirmText={t('projectViewer.confirm.reuseConfiguration.confirm')} type="info" />
       <ConfirmModal isOpen={itemToRemoveId !== null} onClose={() => setItemToRemoveId(null)} onConfirm={confirmRemoveWorkflowItem} title={t('projectViewer.confirm.removeWorkflowItem.title')} message={t('projectViewer.confirm.removeWorkflowItem.message')} confirmText={t('projectViewer.confirm.removeWorkflowItem.confirm')} type="danger" />
       <PromptModal item={editingItem} onClose={() => setEditingItem(null)} onSave={(value) => { if (editingItem) updateWorkflowItem(editingItem.id, value); setEditingItem(null); }} />
       {editingImageItem && editingImageItem.value && (
@@ -2519,6 +2544,11 @@ export function ProjectViewer({ project, libraries, onUpdate: onUpdateProp, onDe
               setShowDeleteAlbumModal(true);
             }
           } : lightboxData.onDelete}
+          onReuse={lightboxData.albumItemIds ? (index) => {
+            const albumItemId = lightboxData.albumItemIds?.[index];
+            const item = albumItemId ? localAlbumRef.current.find((albumItem) => albumItem.id === albumItemId) : undefined;
+            if (item) handleReuseAlbumWorkflow(item);
+          } : undefined}
           onIndexChange={(index) => {
             setLightboxData((current) => current && current.index !== index ? { ...current, index } : current);
             lightboxData.onIndexChange?.(index);

--- a/src/components/ProjectViewer/AlbumTab.tsx
+++ b/src/components/ProjectViewer/AlbumTab.tsx
@@ -210,17 +210,19 @@ export function AlbumTab({
     return decoded || item.id;
   };
 
-  const renderReuseButton = (item: AlbumItem, variant: 'overlay' | 'inline') => {
+  // 'title' sits beside the filename's edit pencil on media cards; 'inline'
+  // sits with the row actions in the text and audio lists.
+  const renderReuseButton = (item: AlbumItem, variant: 'title' | 'inline') => {
     if (!onReuseWorkflow) return null;
     const isLoading = reusingAlbumItemId === item.id;
-    const iconClass = variant === 'overlay' ? 'w-4 h-4' : 'w-3.5 h-3.5';
+    const iconClass = variant === 'title' ? 'w-[1em] h-[1em]' : 'w-3.5 h-3.5';
     return (
       <button
         type="button"
         onClick={(e) => { e.stopPropagation(); onReuseWorkflow(item); }}
         disabled={Boolean(reusingAlbumItemId)}
-        className={variant === 'overlay'
-          ? 'w-7 h-7 rounded-xl bg-white/10 backdrop-blur-md border border-white/20 flex items-center justify-center text-neutral-900 dark:text-white hover:bg-white/20 transition-all shadow-lg disabled:opacity-50'
+        className={variant === 'title'
+          ? 'flex-shrink-0 inline-flex items-center justify-center rounded-sm text-[13px] leading-none text-neutral-500 hover:text-blue-500 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/60 disabled:opacity-50'
           : 'flex-shrink-0 p-1.5 text-neutral-500 dark:text-neutral-500 hover:text-blue-500 hover:bg-blue-500/10 rounded-lg transition-colors disabled:opacity-50'}
         title={t('projectViewer.album.reuseWorkflow')}
         aria-label={t('projectViewer.album.reuseWorkflow')}
@@ -710,8 +712,6 @@ export function AlbumTab({
                       >
                         <ExternalLink className="w-4 h-4" />
                       </a>
-
-                      {renderReuseButton(item, 'overlay')}
                     </div>
 
                     <img
@@ -807,6 +807,7 @@ export function AlbumTab({
                       >
                         <Pencil className="w-[1em] h-[1em]" />
                       </button>
+                      {renderReuseButton(item, 'title')}
                     </div>
                     <button
                       type="button"

--- a/src/components/ProjectViewer/AlbumTab.tsx
+++ b/src/components/ProjectViewer/AlbumTab.tsx
@@ -1,7 +1,7 @@
 import React, { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
-import { Layers, CheckSquare, Square, Trash2, ImageIcon, CheckCircle2, ExternalLink, FileArchive, FileText, Play, Pause, Video as VideoIcon, Music, Copy, ArrowDownWideNarrow, ArrowUpWideNarrow, ChevronDown, Pencil, X, Filter, List } from 'lucide-react';
+import { Layers, CheckSquare, Square, Trash2, ImageIcon, CheckCircle2, ExternalLink, FileArchive, FileText, Play, Pause, Video as VideoIcon, Music, Copy, ArrowDownWideNarrow, ArrowUpWideNarrow, ChevronDown, Pencil, X, Filter, List, RefreshCw, Loader2 } from 'lucide-react';
 import { AlbumItem, AspectRatioCount, ProjectType } from '../../types';
 import { imageDisplayUrl, startAlbumExport } from '../../api';
 import type { AlbumExportVersion } from '../../api';
@@ -29,6 +29,10 @@ interface AlbumTabProps {
   getModelName: (providerId?: string, modelId?: string) => string;
   setLightboxData: (data: { images: string[], index: number, albumItemIds?: string[], onDelete?: (index: number) => void, onIndexChange?: (index: number) => void } | null) => void;
   onRenameAlbumItem: (itemId: string, filename: string) => Promise<AlbumItem>;
+  /** Restore the workflow that produced this item onto the project. */
+  onReuseWorkflow?: (item: AlbumItem) => void;
+  /** Id of the item whose configuration is currently being loaded. */
+  reusingAlbumItemId?: string | null;
   onExportStarted: () => void;
   projectType?: ProjectType;
   page: number;
@@ -159,6 +163,8 @@ export function AlbumTab({
   getModelName,
   setLightboxData,
   onRenameAlbumItem,
+  onReuseWorkflow,
+  reusingAlbumItemId,
   onExportStarted,
   projectType = 'image',
   page,
@@ -202,6 +208,26 @@ export function AlbumTab({
     const path = (item.imageUrl || '').split('?')[0];
     const decoded = decodeURIComponent(path.split('/').pop() || '');
     return decoded || item.id;
+  };
+
+  const renderReuseButton = (item: AlbumItem, variant: 'overlay' | 'inline') => {
+    if (!onReuseWorkflow) return null;
+    const isLoading = reusingAlbumItemId === item.id;
+    const iconClass = variant === 'overlay' ? 'w-4 h-4' : 'w-3.5 h-3.5';
+    return (
+      <button
+        type="button"
+        onClick={(e) => { e.stopPropagation(); onReuseWorkflow(item); }}
+        disabled={Boolean(reusingAlbumItemId)}
+        className={variant === 'overlay'
+          ? 'w-7 h-7 rounded-xl bg-white/10 backdrop-blur-md border border-white/20 flex items-center justify-center text-neutral-900 dark:text-white hover:bg-white/20 transition-all shadow-lg disabled:opacity-50'
+          : 'flex-shrink-0 p-1.5 text-neutral-500 dark:text-neutral-500 hover:text-blue-500 hover:bg-blue-500/10 rounded-lg transition-colors disabled:opacity-50'}
+        title={t('projectViewer.album.reuseWorkflow')}
+        aria-label={t('projectViewer.album.reuseWorkflow')}
+      >
+        {isLoading ? <Loader2 className={`${iconClass} animate-spin`} /> : <RefreshCw className={iconClass} />}
+      </button>
+    );
   };
 
   const openRenameModal = (item: AlbumItem) => {
@@ -501,6 +527,8 @@ export function AlbumTab({
                     <span className="hidden sm:block flex-shrink-0 text-[9px] font-black uppercase tracking-[0.18em] text-blue-400/80">{t('projectViewer.album.view')}</span>
                   </button>
 
+                  {renderReuseButton(item, 'inline')}
+
                   <button
                     onClick={(e) => {
                       e.stopPropagation();
@@ -560,6 +588,8 @@ export function AlbumTab({
                     >
                       {isPlaying ? <Pause className="w-4 h-4" /> : <Play className="w-4 h-4 fill-current" />}
                     </button>
+
+                    {renderReuseButton(item, 'inline')}
 
                     <button
                       onClick={(e) => {
@@ -680,6 +710,8 @@ export function AlbumTab({
                       >
                         <ExternalLink className="w-4 h-4" />
                       </a>
+
+                      {renderReuseButton(item, 'overlay')}
                     </div>
 
                     <img

--- a/src/components/ProjectViewer/ImageLightbox.tsx
+++ b/src/components/ProjectViewer/ImageLightbox.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
-import { X, ChevronLeft, ChevronRight, Trash2, Play, Pause, Maximize, Minimize, Wand2 } from 'lucide-react';
+import { X, ChevronLeft, ChevronRight, Trash2, Play, Pause, Maximize, Minimize, Wand2, RefreshCw } from 'lucide-react';
 import { useWakeLock } from '../../hooks/useWakeLock';
 
 interface ImageLightboxProps {
@@ -9,6 +9,8 @@ interface ImageLightboxProps {
   startIndex: number;
   onClose: () => void;
   onDelete?: (index: number) => void;
+  /** Restore the workflow that produced the image being viewed. */
+  onReuse?: (index: number) => void;
   onIndexChange?: (index: number) => void;
 }
 
@@ -72,7 +74,7 @@ function loadStoredInterval() {
   }
 }
 
-export function ImageLightbox({ images, startIndex, onClose, onDelete, onIndexChange }: ImageLightboxProps) {
+export function ImageLightbox({ images, startIndex, onClose, onDelete, onReuse, onIndexChange }: ImageLightboxProps) {
   const { t } = useTranslation();
   const [currentIndex, setCurrentIndex] = useState(() => clampIndex(startIndex, images.length));
   const [slideshowOn, setSlideshowOn] = useState(false);
@@ -172,6 +174,13 @@ export function ImageLightbox({ images, startIndex, onClose, onDelete, onIndexCh
     // Pause the slideshow before prompting deletion; the modal shows over fullscreen.
     setSlideshowOn(false);
     onDelete(index);
+  };
+
+  const requestReuse = (index: number) => {
+    if (!onReuse) return;
+    // Same as deletion: the confirmation shows over the lightbox, so stop advancing.
+    setSlideshowOn(false);
+    onReuse(index);
   };
 
   const applyInterval = (value: number) => {
@@ -282,6 +291,12 @@ export function ImageLightbox({ images, startIndex, onClose, onDelete, onIndexCh
         requestDelete(clampIndex(currentIndex, images.length));
         return;
       }
+      if (e.key === 'r' || e.key === 'R') {
+        if (inInput || !onReuse) return;
+        e.preventDefault();
+        requestReuse(clampIndex(currentIndex, images.length));
+        return;
+      }
       if (e.key === 'ArrowUp') {
         if (inInput) return;
         e.preventDefault();
@@ -313,7 +328,7 @@ export function ImageLightbox({ images, startIndex, onClose, onDelete, onIndexCh
     };
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [images.length, onClose, onDelete, currentIndex]);
+  }, [images.length, onClose, onDelete, onReuse, currentIndex]);
 
   if (!images || images.length === 0) return null;
   const boundedIndex = clampIndex(currentIndex, images.length);
@@ -434,6 +449,15 @@ export function ImageLightbox({ images, startIndex, onClose, onDelete, onIndexCh
               )}
             </div>
           </>
+        )}
+        {onReuse && (
+          <button
+            onClick={(e) => { e.stopPropagation(); requestReuse(boundedIndex); }}
+            className="p-2 text-white/50 hover:text-blue-400 transition-colors bg-black/50 hover:bg-black/80 rounded-full"
+            title={`${t('projectViewer.album.reuseWorkflow')} (R)`}
+          >
+            <RefreshCw className="w-6 h-6" />
+          </button>
         )}
         {onDelete && (
           <button

--- a/src/components/ProjectViewer/JobListItem.tsx
+++ b/src/components/ProjectViewer/JobListItem.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import { CheckSquare, ChevronDown, Square, RefreshCw } from 'lucide-react';
 import { Job } from '../../types';
 import { InfoChip } from './InfoChip';
@@ -63,6 +64,7 @@ export function JobListItem({
   onToggleSelect,
   onReuse,
 }: JobListItemProps) {
+  const { t } = useTranslation();
   const headerClassName = isSelected
     ? accentClasses[accentColor]
     : isExpanded
@@ -142,7 +144,7 @@ export function JobListItem({
                 <button
                   onClick={(e) => { e.stopPropagation(); onReuse(job); }}
                   className="p-1.5 text-neutral-500 dark:text-neutral-500 hover:text-blue-500 hover:bg-blue-500/10 rounded-lg transition-colors"
-                  title="Reuse Configuration"
+                  title={t('projectViewer.common.reuseConfiguration')}
                 >
                   <RefreshCw className="w-3.5 h-3.5" />
                 </button>

--- a/src/locales/en/project-viewer.json
+++ b/src/locales/en/project-viewer.json
@@ -322,6 +322,8 @@
       "imageContexts": "+{{count}} img",
       "view": "View",
       "openOriginal": "Open Original",
+      "reuseWorkflow": "Reuse Workflow",
+      "reuseWorkflowUnavailable": "The workflow behind this result is no longer available.",
       "playVideo": "Play video",
       "viewFullPrompt": "Click to view full prompt",
       "raw": "RAW",

--- a/src/locales/fr/project-viewer.json
+++ b/src/locales/fr/project-viewer.json
@@ -322,6 +322,8 @@
       "imageContexts": "+{{count}} img",
       "view": "Voir",
       "openOriginal": "Ouvrir l'original",
+      "reuseWorkflow": "Réutiliser le workflow",
+      "reuseWorkflowUnavailable": "Le workflow de ce résultat n'est plus disponible.",
       "playVideo": "Lire la vidéo",
       "viewFullPrompt": "Cliquer pour voir le prompt complet",
       "raw": "BRUT",

--- a/src/locales/ja/project-viewer.json
+++ b/src/locales/ja/project-viewer.json
@@ -322,6 +322,8 @@
       "imageContexts": "+{{count}} 画像",
       "view": "表示",
       "openOriginal": "元画像を開く",
+      "reuseWorkflow": "ワークフローを再利用",
+      "reuseWorkflowUnavailable": "この結果のワークフローは利用できません。",
       "playVideo": "動画を再生",
       "viewFullPrompt": "クリックして完全なプロンプトを表示",
       "raw": "RAW",

--- a/src/locales/ko/project-viewer.json
+++ b/src/locales/ko/project-viewer.json
@@ -322,6 +322,8 @@
       "imageContexts": "+{{count}} img",
       "view": "보기",
       "openOriginal": "원본 열기",
+      "reuseWorkflow": "워크플로 재사용",
+      "reuseWorkflowUnavailable": "이 결과의 워크플로를 사용할 수 없습니다.",
       "playVideo": "비디오 재생",
       "viewFullPrompt": "클릭하여 전체 프롬프트 보기",
       "raw": "원본",

--- a/src/locales/zh-CN/project-viewer.json
+++ b/src/locales/zh-CN/project-viewer.json
@@ -322,6 +322,8 @@
       "imageContexts": "+{{count}} 图",
       "view": "查看",
       "openOriginal": "打开原图",
+      "reuseWorkflow": "重用工作流",
+      "reuseWorkflowUnavailable": "该作品的工作流已不可用。",
       "playVideo": "播放视频",
       "viewFullPrompt": "点击查看完整提示词",
       "raw": "原始",

--- a/src/locales/zh-TW/project-viewer.json
+++ b/src/locales/zh-TW/project-viewer.json
@@ -322,6 +322,8 @@
       "imageContexts": "+{{count}} 圖",
       "view": "查看",
       "openOriginal": "開啟原圖",
+      "reuseWorkflow": "重用工作流",
+      "reuseWorkflowUnavailable": "此作品的工作流已無法使用。",
       "playVideo": "播放影片",
       "viewFullPrompt": "點擊查看完整提示詞",
       "raw": "原始",

--- a/src/types.ts
+++ b/src/types.ts
@@ -1545,6 +1545,16 @@ export interface Job {
   workflowSnapshot?: WorkflowItem[];
 }
 
+/**
+ * The generation settings that can be pushed back onto a project ("reuse").
+ * Sourced from the job that produced a result, so it can be resolved from a
+ * queue/completed job or from the album item that job left behind.
+ */
+export type JobConfiguration = Pick<
+  Job,
+  'workflowSnapshot' | 'providerId' | 'modelConfigId' | 'aspectRatio' | 'quality' | 'background' | 'format' | 'duration' | 'resolution' | 'sound'
+>;
+
 export interface AlbumItem {
   id: string;
   jobId: string;


### PR DESCRIPTION
## Summary
Extends the &#34;reuse workflow&#34; feature to allow users to restore generation settings directly from album items, text results, audio results, and the image lightbox—eliminating the need to hunt through the Done jobs list to find the right configuration.

## Key Changes

- **New API endpoint** (`GET /api/projects/:id/album/:itemId/configuration`): Resolves generation settings from an album item by fetching the workflow snapshot and settings from its originating job, or falls back to the item&#39;s own settings if the job has been deleted.

- **Refactored reuse logic**: Extracted the configuration loading and confirmation flow into a generic `loadReuseConfiguration` helper that works with both jobs and album items, reducing duplication and making the pattern reusable.

- **Album tab integration**: Added &#34;Reuse Workflow&#34; buttons to album, text, and audio item rows with loading states and disabled states during configuration fetch.

- **Image lightbox enhancement**: Added a &#34;Reuse Workflow&#34; button to the lightbox toolbar with keyboard shortcut `R`, and closes the lightbox on confirmation so users land on the restored workflow.

- **State management updates**: Renamed `jobToReuse` → `configToReuse` and `reuseConfigJobId` → `reuseConfigSourceId` to reflect that configurations can now come from multiple sources (jobs or album items).

- **Type definition**: Introduced `JobConfiguration` type to represent the reusable subset of job settings, improving type safety and clarity.

- **Localization**: Added translations for &#34;Reuse Workflow&#34; and &#34;workflow unavailable&#34; messages across all supported languages (EN, FR, JA, KO, ZH-CN, ZH-TW).

- **Documentation**: Updated concepts guide to describe the new reuse capabilities from album/result views and lightbox.

## Implementation Details

- The album item configuration endpoint gracefully handles deleted jobs by returning empty `workflowSnapshot` while preserving the item&#39;s own settings (provider, model, format, etc.).
- The lightbox reuse button only appears when the callback is provided, maintaining backward compatibility.
- Loading states prevent multiple simultaneous configuration fetches.
- The lightbox closes after reuse confirmation to provide immediate visual feedback that the workflow has been restored.
