### PR TITLE
Add Kimi (Moonshot AI) provider support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to Remix Studio are documented here by version number.
 
 ### Added
 
+- **Kimi (Moonshot AI) Provider**: Added Kimi as a provider type, bundled with the `Kimi K3` text profile — a 1M-token context window with native vision, so reference images can be attached to a text workflow. Kimi speaks the OpenAI Chat Completions protocol, so the text generator and chat adapter reuse the OpenAI implementations against `https://api.moonshot.ai/v1`; the API URL can be overridden to reach the mainland China endpoint. Kimi providers are also accepted by the in-app assistant, and the provider screen lists the account's models. The K2 series and `moonshot-v1` models are deliberately not bundled: K2 was discontinued in May 2026, and `kimi-k2.5` plus the `moonshot-v1` family are already closed to new accounts ahead of their August 31, 2026 sunset.
 - **Reuse a Workflow from the Album**: Reusing a configuration no longer means hunting for the right row in Done. Album, text, and audio entries now carry their own reuse control, and the image lightbox has one too (shortcut `R`), so a setup can be picked while looking at the finished piece. The settings are resolved through the job behind the item, the same confirmation applies before the project workflow is replaced, and the lightbox closes once it is. Items whose Done record has since been deleted report that the workflow is no longer available.
 
 ## [1.19.0] - 2026-08-02

--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ These are the model profiles currently bundled with the app.
 | **Grok** | `Grok 4.20`, `Grok 4.1 Fast` | `Grok Imagine`, `Grok Imagine Pro` | `Grok Imagine Video` | - |
 | **Claude** | `Claude Fable 5`, `Claude Opus 4.8`, `Claude Sonnet 5`, `Claude Opus 4.7`, `Claude Sonnet 4.6`, `Claude Haiku 4.5` | - | - | - |
 | **Alibaba Cloud DashScope** | `Qwen3.6 Max`, `Qwen3.6 Plus`, `Qwen3.6 Flash`, `Qwen3.6 VL Max`, `Qwen3.6 VL Plus` | - | - | - |
+| **Kimi (Moonshot AI)** | `Kimi K3` | - | - | - |
 | **RunningHub** | - | `nano banana 2`, `Qwen Image 2 Pro` | `Seedance 2.0 Global`, `Seedance 2.0 Global Multimodal Reference` | - |
 | **BytePlus** | - | `Seedream 5.0 Lite`, `Seedream 4.5`, `Seedream 4.0`, `Seedream 3.0 T2I`, `Seededit 3.0 I2I` | `Seedance 1.5 Pro`, `Seedance 1.0 Pro`, `Seedance 1.0 Pro Fast` | - |
 | **Kling AI** | - | `Kling Image O1`, `Kling V3 Omni`, `Kling V3 Standard`, `Kling V2.1 Standard`, `Kling V2 Standard`, `Kling V1.5 Standard`, `Kling V1 Standard` | `Kling Video O1`, `Kling V3 Omni Video` | - |

--- a/docs-site/concepts/assistant.md
+++ b/docs-site/concepts/assistant.md
@@ -12,6 +12,7 @@ The chat runtime currently supports provider records of these types:
 - **OpenAI**
 - **Claude (Anthropic)**
 - **Alibaba Cloud**
+- **Kimi (Moonshot AI)**
 
 Other provider families may generate project assets without being available as the assistant's chat model. A saved provider must belong to the user and contain a decryptable API key. API URL overrides are honored after the same URL-safety validation used elsewhere in the server.
 

--- a/docs-site/concepts/models.md
+++ b/docs-site/concepts/models.md
@@ -16,6 +16,7 @@ This matrix reflects the profiles shipped with the current release. Model availa
 | **Grok** | ✅ | ✅ | ✅ | - |
 | **Claude** | ✅ | - | - | - |
 | **Alibaba Cloud DashScope** | ✅ | - | - | - |
+| **Kimi (Moonshot AI)** | ✅ | - | - | - |
 | **RunningHub** | - | ✅ | ✅ | - |
 | **BytePlus** | - | ✅ | ✅ | - |
 | **Kling AI** | - | ✅ | ✅ | - |
@@ -32,6 +33,7 @@ This matrix reflects the profiles shipped with the current release. Model availa
 | **Grok** | `Grok 4.5`, `Grok 4.20`, `Grok 4.3`, `Grok 4.1 Fast` |
 | **Claude** | `Claude Fable 5`, `Claude Opus 5`, `Claude Opus 4.8`, `Claude Sonnet 5`, `Claude Opus 4.7`, `Claude Sonnet 4.6`, `Claude Haiku 4.5` |
 | **Alibaba Cloud DashScope** | `Qwen3.6 Max`, `Qwen3.6 Plus`, `Qwen3.6 Flash`, `Qwen3.6 VL Max`, `Qwen3.6 VL Plus` |
+| **Kimi (Moonshot AI)** | `Kimi K3` |
 
 ## 3. Image Generation
 
@@ -76,6 +78,7 @@ The in-app [Assistant](/concepts/assistant) can use text profiles belonging to p
 - **Anthropic (Claude)**
 - **OpenAI**
 - **Alibaba Cloud**
+- **Kimi (Moonshot AI)**
 
 Vertex AI and Grok profiles can be used by generation projects where supported, but their provider types are not accepted by the current assistant chat adapter.
 

--- a/docs-site/concepts/providers.md
+++ b/docs-site/concepts/providers.md
@@ -50,7 +50,7 @@ See [Model Profiles](/concepts/models) for the bundled matrix.
 
 ## Assistant Compatibility
 
-Generation support and assistant-chat support are separate. The in-app assistant currently accepts provider records of type Google AI, OpenAI, Claude, and Alibaba Cloud. Other provider families can still appear in project model selectors when their generators are implemented.
+Generation support and assistant-chat support are separate. The in-app assistant currently accepts provider records of type Google AI, OpenAI, Claude, Alibaba Cloud, and Kimi. Other provider families can still appear in project model selectors when their generators are implemented.
 
 See [The Assistant](/concepts/assistant).
 
@@ -73,7 +73,7 @@ URL validation rejects unsafe endpoint forms, including attempts to direct provi
 
 ## Supported Families
 
-The repository includes generation adapters and bundled profiles across Google AI, Vertex AI, OpenAI, Grok, Claude, Alibaba Cloud, RunningHub, BytePlus, Kling AI, Black Forest Labs, and Replicate. Supported modalities differ by family and model; consult [Model Profiles](/concepts/models) rather than assuming every family supports text, image, video, and audio.
+The repository includes generation adapters and bundled profiles across Google AI, Vertex AI, OpenAI, Grok, Claude, Alibaba Cloud, Kimi, RunningHub, BytePlus, Kling AI, Black Forest Labs, and Replicate. Supported modalities differ by family and model; consult [Model Profiles](/concepts/models) rather than assuming every family supports text, image, video, and audio.
 
 ## Credential Encryption
 

--- a/docs/feature_mindmap.mm.md
+++ b/docs/feature_mindmap.mm.md
@@ -61,6 +61,7 @@
       - Replicate
       - Black Forest Labs
       - Alibaba Cloud
+      - Kimi (Moonshot AI)
     - **Model Management**
       - Discover supported models from providers (Text, Image, Video, Audio)
       - Configure custom model aliases

--- a/server/assistant/chat-provider-factory.ts
+++ b/server/assistant/chat-provider-factory.ts
@@ -4,6 +4,7 @@ import { OpenAIChatProvider } from './providers/openai';
 import { ClaudeChatProvider } from './providers/anthropic';
 import { GoogleAIChatProvider } from './providers/google';
 import { AlibabacloudChatProvider } from './providers/alibabacloud';
+import { KimiChatProvider } from './providers/kimi';
 import type { ProviderRepository } from '../db/provider-repository';
 import { assertSafeProviderApiUrl } from '../utils/url-safety';
 
@@ -12,6 +13,7 @@ export const ASSISTANT_SUPPORTED_PROVIDER_TYPES: ProviderType[] = [
   'Claude',
   'GoogleAI',
   'Alibabacloud',
+  'Kimi',
 ];
 
 export function isAssistantCapableProviderType(type: ProviderType): boolean {
@@ -29,6 +31,8 @@ export function buildChatProvider(type: ProviderType, apiKey: string, apiUrl?: s
       return new GoogleAIChatProvider(apiKey, safeApiUrl);
     case 'Alibabacloud':
       return new AlibabacloudChatProvider(apiKey, safeApiUrl);
+    case 'Kimi':
+      return new KimiChatProvider(apiKey, safeApiUrl);
     default:
       throw new Error(`Provider type '${type}' is not supported by the assistant chat runtime`);
   }

--- a/server/assistant/providers/kimi.ts
+++ b/server/assistant/providers/kimi.ts
@@ -1,0 +1,15 @@
+import { OpenAIChatProvider } from './openai';
+
+const DEFAULT_KIMI_BASE_URL = 'https://api.moonshot.ai/v1';
+
+/**
+ * Moonshot AI (Kimi) chat adapter. The Kimi platform speaks the OpenAI Chat
+ * Completions protocol, so we point the OpenAI adapter at the Moonshot base
+ * URL by default. Users can override the URL when registering the provider to
+ * target the mainland China endpoint (api.moonshot.cn).
+ */
+export class KimiChatProvider extends OpenAIChatProvider {
+  constructor(apiKey: string, apiUrl?: string) {
+    super(apiKey, apiUrl ?? DEFAULT_KIMI_BASE_URL);
+  }
+}

--- a/server/generators/build-audio-generator.ts
+++ b/server/generators/build-audio-generator.ts
@@ -25,6 +25,7 @@ export function buildAudioGenerator(
     case 'Replicate':
     case 'BlackForestLabs':
     case 'Alibabacloud':
+    case 'Kimi':
       throw new Error(`Provider type '${type}' does not support audio generation`);
     default:
       throw new Error(`Provider type '${type}' does not support audio generation`);

--- a/server/generators/build-generator.ts
+++ b/server/generators/build-generator.ts
@@ -47,6 +47,8 @@ export function buildGenerator(
       throw new Error(`Provider type 'Claude' does not support image generation`);
     case 'Alibabacloud':
       throw new Error(`Provider type 'Alibabacloud' does not support image generation`);
+    case 'Kimi':
+      throw new Error(`Provider type 'Kimi' does not support image generation`);
     default: {
       // Exhaustiveness check — TypeScript will error here if a new ProviderType is added
       const _never: never = type;

--- a/server/generators/build-text-generator.ts
+++ b/server/generators/build-text-generator.ts
@@ -6,6 +6,7 @@ import { OpenAITextGenerator } from './openai-text-generator';
 import { ClaudeTextGenerator } from './claude-text-generator';
 import { GrokTextGenerator } from './grok-text-generator';
 import { AlibabacloudTextGenerator } from './alibabacloud-text-generator';
+import { KimiTextGenerator } from './kimi-text-generator';
 import { assertSafeProviderApiUrl } from '../utils/url-safety';
 
 /**
@@ -32,6 +33,8 @@ export function buildTextGenerator(
       return new GrokTextGenerator(apiKey, safeApiUrl);
     case 'Alibabacloud':
       return new AlibabacloudTextGenerator(apiKey, safeApiUrl);
+    case 'Kimi':
+      return new KimiTextGenerator(apiKey, safeApiUrl);
     case 'RunningHub':
     case 'KlingAI':
     case 'BytePlus':

--- a/server/generators/build-video-generator.ts
+++ b/server/generators/build-video-generator.ts
@@ -44,6 +44,8 @@ export function buildVideoGenerator(
       throw new Error(`Provider type 'BlackForestLabs' does not support video generation`);
     case 'Alibabacloud':
       throw new Error(`Provider type 'Alibabacloud' does not support video generation`);
+    case 'Kimi':
+      throw new Error(`Provider type 'Kimi' does not support video generation`);
     default:
       throw new Error(`Unknown provider type: ${type}`);
   }

--- a/server/generators/kimi-text-generator.ts
+++ b/server/generators/kimi-text-generator.ts
@@ -1,0 +1,15 @@
+import { OpenAITextGenerator } from './openai-text-generator';
+
+const DEFAULT_KIMI_BASE_URL = 'https://api.moonshot.ai/v1';
+
+/**
+ * Moonshot AI (Kimi) text generator. The Kimi platform exposes an OpenAI
+ * Chat Completions-compatible endpoint, so we reuse the OpenAI generator with
+ * the Moonshot base URL. Users can override the URL when registering the
+ * provider to target the mainland China endpoint (api.moonshot.cn).
+ */
+export class KimiTextGenerator extends OpenAITextGenerator {
+  constructor(apiKey: string, apiUrl?: string) {
+    super(apiKey, apiUrl ?? DEFAULT_KIMI_BASE_URL);
+  }
+}

--- a/server/routes/providers.ts
+++ b/server/routes/providers.ts
@@ -7,7 +7,7 @@ import crypto from 'crypto';
 import { assertSafeProviderApiUrl } from '../utils/url-safety';
 import { listProviderModels } from '../services/provider-model-lister';
 
-const VALID_TYPES: ProviderType[] = ['GoogleAI', 'VertexAI', 'RunningHub', 'KlingAI', 'OpenAI', 'Grok', 'Claude', 'BytePlus', 'Replicate', 'BlackForestLabs', 'Alibabacloud'];
+const VALID_TYPES: ProviderType[] = ['GoogleAI', 'VertexAI', 'RunningHub', 'KlingAI', 'OpenAI', 'Grok', 'Claude', 'BytePlus', 'Replicate', 'BlackForestLabs', 'Alibabacloud', 'Kimi'];
 type Variables = { user: JwtPayload };
 
 function parseCustomModels(raw: unknown, providerType: ProviderType): CustomModelAlias[] | undefined {

--- a/server/services/provider-model-lister.ts
+++ b/server/services/provider-model-lister.ts
@@ -51,6 +51,9 @@ export async function listProviderModels(
     case 'Alibabacloud':
       result = await listAlibabacloudModels(apiKey, apiUrl);
       break;
+    case 'Kimi':
+      result = await listKimiModels(apiKey, apiUrl);
+      break;
     case 'RunningHub':
     case 'KlingAI':
     case 'BytePlus':
@@ -341,4 +344,40 @@ function categorizeAlibabacloudModel(id: string): 'text' | 'image' | 'video' | '
   if (lower.includes('video') || lower.includes('wanvideo')) return 'video';
   if (lower.includes('audio') || lower.includes('tts') || lower.includes('paraformer') || lower.includes('sambert')) return 'audio';
   return 'text';
+}
+
+// ---------------------------------------------------------------------------
+// Kimi (Moonshot AI) — OpenAI-compatible API
+// ---------------------------------------------------------------------------
+
+async function listKimiModels(
+  apiKey: string,
+  apiUrl?: string | null,
+): Promise<ProviderModelsResult> {
+  const base = (apiUrl || 'https://api.moonshot.ai/v1').replace(/\/$/, '');
+
+  try {
+    const res = await fetch(`${base}/models`, {
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+      },
+    });
+    if (!res.ok) {
+      const text = await res.text();
+      return { models: [], error: `HTTP ${res.status}: ${text}` };
+    }
+    const data: any = await res.json();
+    // Kimi's catalogue is chat-only today, so every listed model is text.
+    const models: ProviderModel[] = (data.data || []).map((m: any) => ({
+      id: m.id,
+      name: m.id,
+      description: '',
+      category: 'text' as const,
+    }));
+    models.sort((a, b) => a.id.localeCompare(b.id));
+    return { models };
+  } catch (e: any) {
+    return { models: [], error: e.message };
+  }
 }

--- a/src/components/ProviderIcon.tsx
+++ b/src/components/ProviderIcon.tsx
@@ -56,6 +56,13 @@ export function ProviderIcon({ type, className = "w-5 h-5" }: ProviderIconProps)
       );
     case 'Alibabacloud':
       return <SiAlibabacloud className={className} />;
+    case 'Kimi':
+      // Crescent mark for Moonshot AI — react-icons has no Kimi/Moonshot glyph.
+      return (
+        <svg className={className} viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+          <path d="M20.5 15.5A9 9 0 0 1 8.5 3.5a9 9 0 1 0 12 12Z" />
+        </svg>
+      );
     default:
       // Fallback key icon
       return (

--- a/src/pages/ProviderForm.tsx
+++ b/src/pages/ProviderForm.tsx
@@ -6,7 +6,7 @@ import { ProviderType, PROVIDER_MODELS_MAP } from '../types';
 import { Save, Eye, EyeOff, Loader2, MessageSquare, Image as ImageIcon, Video, Music, Plus, Minus } from 'lucide-react';
 import { ProviderIcon } from '../components/ProviderIcon';
 
-const PROVIDER_TYPES: ProviderType[] = ['GoogleAI', 'VertexAI', 'OpenAI', 'Claude', 'Grok', 'Alibabacloud', 'RunningHub', 'KlingAI', 'BytePlus', 'Replicate', 'BlackForestLabs'];
+const PROVIDER_TYPES: ProviderType[] = ['GoogleAI', 'VertexAI', 'OpenAI', 'Claude', 'Grok', 'Alibabacloud', 'Kimi', 'RunningHub', 'KlingAI', 'BytePlus', 'Replicate', 'BlackForestLabs'];
 
 
 

--- a/src/pages/ProviderProfile.tsx
+++ b/src/pages/ProviderProfile.tsx
@@ -23,6 +23,7 @@ const TYPE_COLORS: Record<ProviderType, { icon: string; badge: string }> = {
   Replicate:  { icon: 'bg-fuchsia-50 dark:bg-fuchsia-500/10 text-fuchsia-700 dark:text-fuchsia-400', badge: 'bg-fuchsia-100 dark:bg-fuchsia-600/10 text-fuchsia-800 dark:text-fuchsia-300 border-fuchsia-200 dark:border-fuchsia-600/30' },
   BlackForestLabs: { icon: 'bg-stone-100 dark:bg-stone-500/10 text-stone-900 dark:text-stone-200', badge: 'bg-stone-200 dark:bg-stone-600/10 text-stone-900 dark:text-stone-200 border-stone-300 dark:border-stone-600/30' },
   Alibabacloud: { icon: 'bg-violet-50 dark:bg-violet-500/10 text-violet-700 dark:text-violet-400', badge: 'bg-violet-100 dark:bg-violet-600/10 text-violet-800 dark:text-violet-400 border-violet-200 dark:border-violet-600/30' },
+  Kimi:       { icon: 'bg-indigo-50 dark:bg-indigo-500/10 text-indigo-700 dark:text-indigo-400', badge: 'bg-indigo-100 dark:bg-indigo-600/10 text-indigo-800 dark:text-indigo-400 border-indigo-200 dark:border-indigo-600/30' },
 };
 const DEFAULT_TYPE_COLORS = {
   icon: 'bg-neutral-100 dark:bg-neutral-500/10 text-neutral-700 dark:text-neutral-300',

--- a/src/pages/Providers.tsx
+++ b/src/pages/Providers.tsx
@@ -20,6 +20,7 @@ const TYPE_COLORS: Record<ProviderType, { icon: string; badge: string }> = {
   Replicate:  { icon: 'bg-fuchsia-500/10 text-fuchsia-600 dark:text-fuchsia-400', badge: 'bg-fuchsia-600/10 text-fuchsia-700 dark:text-fuchsia-300 border-fuchsia-600/20 dark:border-fuchsia-600/30' },
   BlackForestLabs: { icon: 'bg-stone-500/10 text-stone-800 dark:text-stone-200', badge: 'bg-stone-600/10 text-stone-800 dark:text-stone-200 border-stone-600/20 dark:border-stone-600/30' },
   Alibabacloud: { icon: 'bg-violet-500/10 text-violet-600 dark:text-violet-400', badge: 'bg-violet-600/10 text-violet-700 dark:text-violet-400 border-violet-600/20 dark:border-violet-600/30' },
+  Kimi:       { icon: 'bg-indigo-500/10 text-indigo-600 dark:text-indigo-400', badge: 'bg-indigo-600/10 text-indigo-700 dark:text-indigo-400 border-indigo-600/20 dark:border-indigo-600/30' },
 };
 const DEFAULT_TYPE_COLORS = {
   icon: 'bg-neutral-500/10 text-neutral-600 dark:text-neutral-300',

--- a/src/types.ts
+++ b/src/types.ts
@@ -1390,6 +1390,20 @@ export const PROVIDER_MODELS_MAP: Record<ProviderType, ModelConfig[]> = {
       },
     },
   ],
+  Kimi: [
+    {
+      id: 'kimi-k3-text',
+      name: 'Kimi K3',
+      generatorId: 'Kimi',
+      modelId: 'kimi-k3',
+      category: 'text',
+      promptLimit: { value: 1048576, unit: 'tokens' },
+      options: {
+        temperatures: [0, 0.2, 0.5, 0.7, 1.0, 1.5, 2.0],
+        maxTokenOptions: [256, 512, 1024, 2048, 4096, 8192, 16384, 32768],
+      },
+    },
+  ],
   BlackForestLabs: [
     {
       id: 'bfl-flux-2-max',
@@ -1623,7 +1637,7 @@ export interface Project {
   showDisabledItems?: boolean;
 }
 
-export type ProviderType = 'GoogleAI' | 'VertexAI' | 'RunningHub' | 'KlingAI' | 'OpenAI' | 'Grok' | 'Claude' | 'BytePlus' | 'Replicate' | 'BlackForestLabs' | 'Alibabacloud';
+export type ProviderType = 'GoogleAI' | 'VertexAI' | 'RunningHub' | 'KlingAI' | 'OpenAI' | 'Grok' | 'Claude' | 'BytePlus' | 'Replicate' | 'BlackForestLabs' | 'Alibabacloud' | 'Kimi';
 
 /**
  * A custom model variant that inherits all options from a built-in base model


### PR DESCRIPTION
## Summary
This PR adds support for Kimi (Moonshot AI) as a new provider type, enabling users to integrate Kimi&#39;s OpenAI-compatible API for text generation and assistant chat capabilities.

## Key Changes

- **Provider Type Registration**: Added `&#39;Kimi&#39;` to the `ProviderType` union across the codebase
- **Chat Provider**: Created `KimiChatProvider` class that extends `OpenAIChatProvider`, defaulting to `https://api.moonshot.ai/v1` with support for custom endpoints (e.g., mainland China&#39;s `api.moonshot.cn`)
- **Text Generator**: Created `KimiTextGenerator` class that extends `OpenAITextGenerator` with the same endpoint configuration
- **Model Listing**: Implemented `listKimiModels()` function to dynamically fetch available models from Kimi&#39;s `/models` endpoint
- **Bundled Model Profile**: Added `Kimi K3` text model with 1M token context window and configurable temperature/max token options
- **Assistant Support**: Registered Kimi in `ASSISTANT_SUPPORTED_PROVIDER_TYPES` and integrated into `buildChatProvider()` factory
- **Generator Factories**: Updated `buildTextGenerator()` to instantiate `KimiTextGenerator`; added error handling in image, video, and audio generator factories
- **UI Components**: 
  - Added crescent moon SVG icon for Kimi in `ProviderIcon`
  - Updated provider type selectors in `ProviderForm` and provider management pages
  - Added color styling for Kimi provider badges
- **Documentation**: Updated provider lists, model matrices, and assistant compatibility docs to include Kimi
- **Validation**: Added Kimi to the valid provider types list in the providers API route

## Implementation Details

- Kimi leverages OpenAI&#39;s Chat Completions protocol, so implementation reuses existing OpenAI adapters with a different base URL
- Model discovery is dynamic via API call, with fallback error handling
- All models from Kimi&#39;s catalog are categorized as text-only (chat)
- Users can override the default API URL when registering a provider to target alternative endpoints
