### PR TITLE
Add Seedance 2.5 support with video and audio references

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ These are the model profiles currently bundled with the app.
 | **Alibaba Cloud DashScope** | `Qwen3.6 Max`, `Qwen3.6 Plus`, `Qwen3.6 Flash`, `Qwen3.6 VL Max`, `Qwen3.6 VL Plus` | - | - | - |
 | **Kimi (Moonshot AI)** | `Kimi K3` | - | - | - |
 | **RunningHub** | - | `nano banana 2`, `Qwen Image 2 Pro` | `Seedance 2.0 Global`, `Seedance 2.0 Global Multimodal Reference` | - |
-| **BytePlus** | - | `Seedream 5.0 Lite`, `Seedream 4.5`, `Seedream 4.0`, `Seedream 3.0 T2I`, `Seededit 3.0 I2I` | `Seedance 1.5 Pro`, `Seedance 1.0 Pro`, `Seedance 1.0 Pro Fast` | - |
+| **BytePlus** | - | `Seedream 5.0 Lite`, `Seedream 4.5`, `Seedream 4.0`, `Seedream 3.0 T2I`, `Seededit 3.0 I2I` | `Seedance 2.5`, `Seedance 1.5 Pro`, `Seedance 1.0 Pro`, `Seedance 1.0 Pro Fast` | - |
 | **Kling AI** | - | `Kling Image O1`, `Kling V3 Omni`, `Kling V3 Standard`, `Kling V2.1 Standard`, `Kling V2 Standard`, `Kling V1.5 Standard`, `Kling V1 Standard` | `Kling Video O1`, `Kling V3 Omni Video` | - |
 | **Black Forest Labs** | - | `Flux 2 Max`, `Flux 2 Pro (Preview)`, `Flux 2 Pro`, `Flux 2 Flex`, `Flux 2 Klein 9B (Preview)`, `Flux 2 Klein 9B`, `Flux 2 Klein 4B` | - | - |
 | **Replicate** | - | `Flux 2 Pro`, `Flux 2 Flex`, `Flux 2 Max` | `Seedance 2.0 Fast`, `Seedance 2.0` | - |

--- a/docs-site/concepts/models.md
+++ b/docs-site/concepts/models.md
@@ -57,7 +57,7 @@ This matrix reflects the profiles shipped with the current release. Model availa
 | **OpenAI** | `Sora 2`, `Sora 2 Pro` |
 | **Grok** | `Grok Imagine Video` |
 | **RunningHub** | `Seedance 2.0 Global`, `Seedance 2.0 Global Multimodal Reference` |
-| **BytePlus** | `Seedance 1.5 Pro`, `Seedance 1.0 Pro`, `Seedance 1.0 Pro Fast` |
+| **BytePlus** | `Seedance 2.5`, `Seedance 1.5 Pro`, `Seedance 1.0 Pro`, `Seedance 1.0 Pro Fast` |
 | **Kling AI** | `Kling Video O1`, `Kling V3 Omni Video` |
 | **Replicate** | `Seedance 2.0 Fast`, `Seedance 2.0` |
 

--- a/server/generators/byteplus-video-generator.ts
+++ b/server/generators/byteplus-video-generator.ts
@@ -19,6 +19,13 @@ type BytePlusTaskResponse = {
   };
 };
 
+type BytePlusMediaRole =
+  | 'first_frame'
+  | 'last_frame'
+  | 'reference_image'
+  | 'reference_video'
+  | 'reference_audio';
+
 type BytePlusContentItem =
   | {
       type: 'text';
@@ -29,11 +36,32 @@ type BytePlusContentItem =
       image_url: {
         url: string;
       };
-      role?: 'first_frame' | 'last_frame' | 'reference_image';
+      role?: BytePlusMediaRole;
+    }
+  | {
+      type: 'video_url';
+      video_url: {
+        url: string;
+      };
+      role?: BytePlusMediaRole;
+    }
+  | {
+      type: 'audio_url';
+      audio_url: {
+        url: string;
+      };
+      role?: BytePlusMediaRole;
     };
 
 const DEFAULT_BASE_URL = 'https://ark.ap-southeast.bytepluses.com/api/v3';
-const DEFAULT_MODEL = 'seedance-1-5-pro-251215';
+const DEFAULT_MODEL = 'dreamina-seedance-2-5-260628';
+
+/** Dreamina Seedance 2.x accepts video/audio references on top of the 1.x image roles. */
+const SEEDANCE_2_PATTERN = /seedance-2[-.]/;
+
+/** Per-request reference caps published for each Seedance 2.x tier. */
+const SEEDANCE_2_5_LIMITS = { images: 30, videos: 10, audios: 10 };
+const SEEDANCE_2_0_LIMITS = { images: 9, videos: 3, audios: 3 };
 
 export class BytePlusVideoGenerator extends VideoGenerator {
   private apiKey: string;
@@ -58,7 +86,12 @@ export class BytePlusVideoGenerator extends VideoGenerator {
       if (req.aspectRatio) payload.ratio = req.aspectRatio;
       if (req.resolution) payload.resolution = req.resolution;
       if (typeof req.duration === 'number') payload.duration = req.duration;
-      if (model === 'seedance-1-5-pro-251215') payload.generate_audio = true;
+      if (this.supportsGeneratedAudio(model)) payload.generate_audio = req.sound !== 'off';
+
+      if (this.isSeedance2(model)) {
+        payload.watermark = false;
+        if (typeof req.seed === 'number') payload.seed = req.seed;
+      }
 
       const res = await fetch(`${this.baseUrl}/contents/generations/tasks`, {
         method: 'POST',
@@ -173,7 +206,19 @@ export class BytePlusVideoGenerator extends VideoGenerator {
     }
   }
 
+  private isSeedance2(model: string): boolean {
+    return SEEDANCE_2_PATTERN.test(model);
+  }
+
+  private supportsGeneratedAudio(model: string): boolean {
+    return this.isSeedance2(model) || model.startsWith('seedance-1-5-pro');
+  }
+
   private buildContent(model: string, req: VideoGenerateRequest): BytePlusContentItem[] {
+    if (this.isSeedance2(model)) {
+      return this.buildSeedance2Content(model, req);
+    }
+
     const content: BytePlusContentItem[] = [];
     const prompt = (req.prompt || '').trim();
     if (prompt) {
@@ -203,6 +248,55 @@ export class BytePlusVideoGenerator extends VideoGenerator {
 
     for (const url of imageUrls.slice(0, 4)) {
       content.push(this.createImageItem(url, 'reference_image'));
+    }
+
+    return content;
+  }
+
+  /**
+   * Seedance 2.x is a single multimodal endpoint: images keep the 1.x frame roles for
+   * text/image-to-video, and any video or audio reference switches the request into
+   * omni-reference mode where every image is a `reference_image`.
+   */
+  private buildSeedance2Content(model: string, req: VideoGenerateRequest): BytePlusContentItem[] {
+    const limits = model.includes('seedance-2-5') ? SEEDANCE_2_5_LIMITS : SEEDANCE_2_0_LIMITS;
+    const content: BytePlusContentItem[] = [];
+
+    const prompt = (req.prompt || '').trim();
+    if (prompt) {
+      content.push({ type: 'text', text: prompt });
+    }
+
+    const imageUrls = this.resolveImageUrls(req).slice(0, limits.images);
+    const videoUrls = (req.refVideoUrls || []).slice(0, limits.videos);
+    const audioUrls = (req.refAudioUrls || []).slice(0, limits.audios);
+
+    if (!prompt && imageUrls.length === 0 && videoUrls.length === 0) {
+      throw new Error('BytePlus video generation requires a prompt or at least one reference image or video');
+    }
+
+    if (audioUrls.length > 0 && imageUrls.length === 0 && videoUrls.length === 0) {
+      throw new Error('Seedance reference audio requires at least one reference image or video');
+    }
+
+    const omniReference = videoUrls.length > 0 || audioUrls.length > 0 || imageUrls.length > 2;
+    if (omniReference) {
+      for (const url of imageUrls) {
+        content.push(this.createImageItem(url, 'reference_image'));
+      }
+    } else if (imageUrls.length === 1) {
+      content.push(this.createImageItem(imageUrls[0], 'first_frame'));
+    } else if (imageUrls.length === 2) {
+      content.push(this.createImageItem(imageUrls[0], 'first_frame'));
+      content.push(this.createImageItem(imageUrls[1], 'last_frame'));
+    }
+
+    for (const url of videoUrls) {
+      content.push({ type: 'video_url', video_url: { url }, role: 'reference_video' });
+    }
+
+    for (const url of audioUrls) {
+      content.push({ type: 'audio_url', audio_url: { url }, role: 'reference_audio' });
     }
 
     return content;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1225,6 +1225,23 @@ export const PROVIDER_MODELS_MAP: Record<ProviderType, ModelConfig[]> = {
       },
     },
     {
+      id: 'byteplus-seedance-2-5-video',
+      name: 'Seedance 2.5',
+      generatorId: 'BytePlus',
+      modelId: 'dreamina-seedance-2-5-260628',
+      category: 'video',
+      promptLimit: { value: 20480, unit: 'characters' },
+      options: {
+        aspectRatios: ['adaptive', '16:9', '4:3', '1:1', '3:4', '9:16', '21:9'],
+        resolutions: ['480p', '720p'],
+        durations: [4, 5, 6, 8, 10, 12, 15, 20, 25, 30, -1],
+        sounds: ['on', 'off'],
+        supportsReferenceImages: true,
+        supportsReferenceVideo: true,
+        supportsReferenceAudio: true,
+      },
+    },
+    {
       id: 'byteplus-seedance-1-5-pro-video',
       name: 'Seedance 1.5 Pro',
       generatorId: 'BytePlus',


### PR DESCRIPTION
## Summary
This PR adds support for BytePlus Seedance 2.5, a new multimodal video generation model that extends the previous 1.x capabilities with video and audio reference support. The implementation includes model detection, content building logic tailored to Seedance 2.x requirements, and per-tier reference limits.

## Key Changes

- **New Model Support**: Added `Seedance 2.5` (dreamina-seedance-2-5-260628) as the default BytePlus video model with support for:
  - Video references (up to 10 per request)
  - Audio references (up to 10 per request)
  - Image references (up to 30 per request)
  - Configurable seed parameter
  - Watermark control

- **Type System Updates**:
  - Introduced `BytePlusMediaRole` type to consolidate media role definitions
  - Extended `BytePlusContentItem` union to support `video_url` and `audio_url` types
  - Updated image role type to use the new `BytePlusMediaRole`

- **Model Detection Logic**:
  - Added `isSeedance2()` method to identify Seedance 2.x models via regex pattern matching
  - Added `supportsGeneratedAudio()` method to determine audio generation capability (Seedance 2.x and 1.5 Pro)

- **Seedance 2.x-Specific Content Building**:
  - Implemented `buildSeedance2Content()` method with omni-reference mode logic:
    - Single images use `first_frame` role
    - Two images use `first_frame` and `last_frame` roles
    - Three or more images, or any video/audio references, switch to `reference_image` role for all images
  - Enforces validation: audio references require at least one image or video reference
  - Applies per-tier reference limits (2.5 vs 2.0)

- **Request Payload Adjustments**:
  - Made `generate_audio` conditional based on model capability and `req.sound` setting
  - Added `watermark: false` and optional `seed` parameters for Seedance 2.x models

- **Documentation**: Updated README and docs-site to reflect Seedance 2.5 availability

## Notable Implementation Details

The Seedance 2.x content builder implements a smart &#34;omni-reference&#34; mode that automatically switches image role semantics when video or audio references are present, ensuring compatibility with the model&#39;s multimodal endpoint design. Reference limits are model-specific (2.5 tier supports higher limits than 2.0 tier).
