### PR TITLE
feat(mcp): support content edits in batch_update_library_items

### DIFF
--- a/server/assistant/system-prompt.ts
+++ b/server/assistant/system-prompt.ts
@@ -80,6 +80,7 @@ Use this pattern for:
 - \`update_library\`
 - \`create_prompt\` / \`batch_create_prompts\`
 - \`update_prompt\`
+- \`update_library_item\` / \`batch_update_library_items\`
 - \`delete_prompt\`
 - \`create_project_with_workflow\`
 - \`update_project\`
@@ -90,14 +91,16 @@ Use this pattern for:
 
 Only wait for another user turn when information is missing, the target is ambiguous, or the user is still deciding.
 
-### Bulk creation across several batches
+### Bulk work across several batches
 
-When the user asks for more items than one tool call should carry (for example "add 100 prompts"), treat the requested count as the finish line, not the first batch:
+When the user asks for more items than one tool call should carry (for example "add 100 prompts" or "rewrite every item in this library"), treat the requested count as the finish line, not the first batch:
 - state the full target and the batch plan in your proposal ("adding 100 prompts in batches of 25")
 - after each batch succeeds, immediately continue with the next batch in the same turn — do not stop to report partial progress or ask whether to keep going
 - check the count reported back by the tool against the target before you claim the work is done
 - when the run is finished, report the final total in one sentence
 - if a call comes back saying its arguments were truncated, retry that batch at about half the size and carry on
+
+This applies to edits as well as creations. \`batch_update_library_items\` changes titles, tags, and text content for many items in one call, so "update all of these" is one batched run, not one call per item. Never tell the user that each item needs its own update call, and never hand back a partially finished job asking whether to continue — work through every remaining item in batches until the set is complete.
 
 The confirmation UI is the approval step. Your assistant text should explain the proposed change, not ask the user to answer "yes" again.
 

--- a/server/mcp/tool-confirmation.ts
+++ b/server/mcp/tool-confirmation.ts
@@ -78,6 +78,17 @@ export function summarizeToolEffect(
     }
     case 'delete_prompt':
       return `Delete prompt ${getLabel(objectArgs.item_id, 'prompt')} from library ${getLabel(objectArgs.library_id, 'library')}.`;
+    case 'update_library_item': {
+      const fields = ['title', 'tags', 'content'].filter((key) => Object.prototype.hasOwnProperty.call(objectArgs, key));
+      return `Update item ${getLabel(objectArgs.item_id, 'item')} in library ${getLabel(objectArgs.library_id, 'library')}${fields.length ? ` (${fields.join(', ')})` : ''}.`;
+    }
+    case 'batch_update_library_items': {
+      const updates = Array.isArray(objectArgs.updates) ? objectArgs.updates : [];
+      const fields = ['title', 'tags', 'content'].filter((key) =>
+        updates.some((upd) => isPlainObject(upd) && Object.prototype.hasOwnProperty.call(upd, key)),
+      );
+      return `Update ${updates.length} item${updates.length === 1 ? '' : 's'} in library ${getLabel(objectArgs.library_id, 'library')}${fields.length ? ` (${fields.join(', ')})` : ''}.`;
+    }
     case 'create_project_with_workflow': {
       const workflowCount = Array.isArray(objectArgs.workflowItems) ? objectArgs.workflowItems.length : 0;
       return `Create a ${String(objectArgs.type ?? 'new')} project named "${String(objectArgs.name ?? '')}" with ${workflowCount} workflow item${workflowCount === 1 ? '' : 's'}.`;

--- a/server/mcp/tool-definitions.ts
+++ b/server/mcp/tool-definitions.ts
@@ -1817,13 +1817,14 @@ Important workflow behavior:
   tools.push({
     name: 'batch_update_library_items',
     title: 'Batch Update Library Items',
-    description: 'Update the title and/or tags of multiple items in a library in a single batch (up to 100 items). Content editing is not supported in batch — use update_library_item for that. Useful for bulk re-tagging or renaming after importing or reviewing a library.',
+    description: 'Update the title, tags, and/or text content of multiple items in a library in a single batch (up to 100 items). Each entry may change a different set of fields. Prefer this over repeated update_library_item calls whenever more than one item is being changed — including rewriting or expanding the content of many prompts at once.',
     inputSchema: {
       library_id: z.string().describe('The library ID that contains the items'),
       updates: z.array(z.object({
         item_id: z.string().describe('ID of the item to update'),
         title: z.string().optional().describe('New title (omit to keep existing; pass empty string to clear)'),
         tags: z.array(z.string()).optional().describe('Replacement tags (omit to keep existing; pass [] to clear all)'),
+        content: z.string().optional().describe('New text content (text libraries only; omit to keep existing)'),
       })).min(1).max(100).describe('List of items to update (1–100)'),
     },
     annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: false },
@@ -1831,7 +1832,7 @@ Important workflow behavior:
     handler: async (userId, input) => {
       const { library_id, updates } = input as {
         library_id: string;
-        updates: { item_id: string; title?: string; tags?: string[] }[];
+        updates: { item_id: string; title?: string; tags?: string[]; content?: string }[];
       };
 
       const library = await repository.getLibrary(userId, library_id);
@@ -1842,9 +1843,10 @@ Important workflow behavior:
       const results: { item_id: string; status: 'updated' | 'error'; error?: string }[] = [];
 
       for (const upd of updates) {
-        const itemUpdates: { title?: string; tags?: string[] } = {};
+        const itemUpdates: { title?: string; tags?: string[]; content?: string } = {};
         if (upd.title !== undefined) itemUpdates.title = upd.title;
         if (upd.tags !== undefined) itemUpdates.tags = upd.tags;
+        if (upd.content !== undefined) itemUpdates.content = upd.content;
 
         if (Object.keys(itemUpdates).length === 0) {
           results.push({ item_id: upd.item_id, status: 'error', error: 'No fields to update.' });


### PR DESCRIPTION
The batch tool only accepted title and tags, so any request to rewrite or
expand the text of several library items had to fall back to one
update_library_item call per item. The assistant would take this literally
and tell users it could not update the remaining items, handing back a
half-finished job.

- accept an optional content field per entry in batch_update_library_items
  and pass it through to updateLibraryItem, which already supported it
- add confirmation summaries for update_library_item and
  batch_update_library_items so the approval prompt names the item count
  and the fields being changed instead of &#34;Run write tool&#34;
- broaden the system prompt&#39;s bulk-work guidance to cover edits as well as
  creations, so multi-item updates run as batches through to completion
