### PR TITLE
fix(workflow): show image references uncropped on phones

### DIFF
--- a/src/components/ProjectViewer/WorkflowItem.tsx
+++ b/src/components/ProjectViewer/WorkflowItem.tsx
@@ -277,13 +277,23 @@ export function WorkflowItem({
       {item.type === 'image' && (
         <div className={`space-y-2 ${gridView ? 'lg:flex-1 lg:min-h-0 lg:flex lg:flex-col' : ''}`}>
           {item.value && !uploadingItemIds.has(item.id) && (
-            <div className={`relative aspect-video rounded-lg overflow-hidden border border-neutral-200 dark:border-neutral-800 ${gridView ? 'lg:aspect-auto lg:flex-1 lg:min-h-0' : ''}`}>
-               <img 
-                 src={imageDisplayUrl(item.thumbnailUrl || item.value)} 
-                 alt="Reference" 
-                 className="w-full h-full object-cover cursor-pointer hover:opacity-80 transition-opacity" 
-                 onClick={() => onLightbox([imageDisplayUrl(item.optimizedUrl || item.value)], 0)} 
+            // Phones show the reference uncropped (portrait references are the norm and a
+            // 16:9 crop leaves only a sliver visible); desktop keeps the compact 16:9 tile.
+            <div className={`relative flex items-center justify-center rounded-lg overflow-hidden border border-neutral-200 dark:border-neutral-800 bg-neutral-100/70 dark:bg-black/40 lg:block lg:aspect-video ${gridView ? 'lg:aspect-auto lg:flex-1 lg:min-h-0' : ''}`}>
+               <img
+                 src={imageDisplayUrl(item.thumbnailUrl || item.value)}
+                 alt="Reference"
+                 className="w-auto max-w-full max-h-[50vh] object-contain cursor-pointer hover:opacity-80 transition-opacity lg:w-full lg:h-full lg:max-h-none lg:object-cover"
+                 onClick={() => onLightbox([imageDisplayUrl(item.optimizedUrl || item.value)], 0)}
                />
+               <button
+                 type="button"
+                 onClick={() => onLightbox([imageDisplayUrl(item.optimizedUrl || item.value)], 0)}
+                 className="absolute top-2 right-2 p-2 bg-white/90 dark:bg-neutral-900/90 rounded-md border border-neutral-200 dark:border-neutral-800 shadow-sm text-neutral-500 hover:text-blue-500 hover:border-blue-200 transition-colors lg:hidden"
+                 aria-label={t('projectViewer.common.preview', { defaultValue: 'Preview' })}
+               >
+                 <Maximize2 className="w-3.5 h-3.5" />
+               </button>
             </div>
           )}
         </div>

--- a/src/locales/en/project-viewer.json
+++ b/src/locales/en/project-viewer.json
@@ -15,6 +15,7 @@
       "save": "Save",
       "cancel": "Cancel",
       "close": "Close",
+      "preview": "Preview",
       "copy": "Copy",
       "edit": "Edit",
       "copyToLibrary": "Copy to Library",

--- a/src/locales/fr/project-viewer.json
+++ b/src/locales/fr/project-viewer.json
@@ -16,6 +16,7 @@
       "save": "Enregistrer",
       "cancel": "Annuler",
       "close": "Fermer",
+      "preview": "Aperçu",
       "copy": "Copier",
       "edit": "Modifier",
       "copyToLibrary": "Copier dans la bibliothèque",

--- a/src/locales/ja/project-viewer.json
+++ b/src/locales/ja/project-viewer.json
@@ -15,6 +15,7 @@
       "save": "保存",
       "cancel": "キャンセル",
       "close": "閉じる",
+      "preview": "プレビュー",
       "copy": "コピー",
       "edit": "編集",
       "copyToLibrary": "ライブラリにコピー",

--- a/src/locales/ko/project-viewer.json
+++ b/src/locales/ko/project-viewer.json
@@ -15,6 +15,7 @@
       "save": "저장",
       "cancel": "취소",
       "close": "닫기",
+      "preview": "미리보기",
       "copy": "복사",
       "edit": "편집",
       "copyToLibrary": "라이브러리에 복사",

--- a/src/locales/zh-CN/project-viewer.json
+++ b/src/locales/zh-CN/project-viewer.json
@@ -15,6 +15,7 @@
       "save": "保存",
       "cancel": "取消",
       "close": "关闭",
+      "preview": "预览",
       "copy": "复制",
       "edit": "编辑",
       "copyToLibrary": "复制到库",

--- a/src/locales/zh-TW/project-viewer.json
+++ b/src/locales/zh-TW/project-viewer.json
@@ -15,6 +15,7 @@
       "save": "保存",
       "cancel": "取消",
       "close": "關閉",
+      "preview": "預覽",
       "copy": "複製",
       "edit": "編輯",
       "copyToLibrary": "複製到資源庫",


### PR DESCRIPTION
The workflow image preview forced every reference into a 16:9 tile with
object-cover. That reads fine in the narrow desktop panel, but on a phone
the panel is full width and portrait references — the common case — were
cropped down to a thin horizontal slice.

Below lg the preview now scales the image to fit (object-contain, capped
at 50vh) on a neutral backdrop, and gets an explicit expand button since
the hover affordance does nothing on touch. Desktop and the expanded grid
view keep their existing compact tiles.
