### PR TITLE
fix(ui): compact page headers on phones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to Remix Studio are documented here by version number.
 ### Changed
 
 - **Compact Page Headers on Phones**: Page headers were sized for the desktop layout and pushed the actual content of a screen well below the fold on a phone. The shared header now uses a smaller title, tighter back link, and denser description below `md`, and the gap between it and the first content block shrank on the pages that stack their sections. The screens with hand-built headers follow the same rhythm: Import & Export drops its badge and oversized display title, the provider form's sticky bar keeps its title and buttons on one row, and Storage, Custom Models, two-factor setup, and the library editor's chips all scale down. Page padding on phones drops from 24px to 16px. Desktop layouts are unchanged.
+- **Headers Scroll Away on Phones**: The library editor and the orphaned-files cleanup kept their header on screen permanently and scrolled only the list beneath it, so a fixed band of title, description, and controls ate a quarter of a phone screen. On phones the whole page now scrolls and the header leaves with it, while the list's selection toolbar still pins to the top; from `lg` the pinned-header layout is unchanged. The Recycle Bin's pinned toolbar also stays on one row instead of stacking — roughly half its previous height — hiding the item totals only while a selection is active, and the prompt editor's header is tighter on small screens.
 
 ## [1.19.0] - 2026-08-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ All notable changes to Remix Studio are documented here by version number.
 - **Kimi (Moonshot AI) Provider**: Added Kimi as a provider type, bundled with the `Kimi K3` text profile — a 1M-token context window with native vision, so reference images can be attached to a text workflow. Kimi speaks the OpenAI Chat Completions protocol, so the text generator and chat adapter reuse the OpenAI implementations against `https://api.moonshot.ai/v1`; the API URL can be overridden to reach the mainland China endpoint. Kimi providers are also accepted by the in-app assistant, and the provider screen lists the account's models. The K2 series and `moonshot-v1` models are deliberately not bundled: K2 was discontinued in May 2026, and `kimi-k2.5` plus the `moonshot-v1` family are already closed to new accounts ahead of their August 31, 2026 sunset.
 - **Reuse a Workflow from the Album**: Reusing a configuration no longer means hunting for the right row in Done. Album, text, and audio entries now carry their own reuse control, and the image lightbox has one too (shortcut `R`), so a setup can be picked while looking at the finished piece. The settings are resolved through the job behind the item, the same confirmation applies before the project workflow is replaced, and the lightbox closes once it is. Items whose Done record has since been deleted report that the workflow is no longer available.
 
+### Changed
+
+- **Compact Page Headers on Phones**: Page headers were sized for the desktop layout and pushed the actual content of a screen well below the fold on a phone. The shared header now uses a smaller title, tighter back link, and denser description below `md`, and the gap between it and the first content block shrank on the pages that stack their sections. The screens with hand-built headers follow the same rhythm: Import & Export drops its badge and oversized display title, the provider form's sticky bar keeps its title and buttons on one row, and Storage, Custom Models, two-factor setup, and the library editor's chips all scale down. Page padding on phones drops from 24px to 16px. Desktop layouts are unchanged.
+
 ## [1.19.0] - 2026-08-02
 
 ### Added

--- a/src/components/Assistant/AssistantHero.tsx
+++ b/src/components/Assistant/AssistantHero.tsx
@@ -30,7 +30,7 @@ export const AssistantHero: React.FC<AssistantHeroProps> = ({
 
   return (
     <div className={`w-full max-w-2xl mx-auto ${className}`}>
-      <h2 className="text-2xl md:text-3xl font-semibold text-center text-neutral-800 dark:text-neutral-200 mb-12 md:mb-16 h-[4rem] md:h-[4.5rem] flex items-center justify-center">
+      <h2 className="text-xl md:text-3xl font-semibold text-center text-neutral-800 dark:text-neutral-200 mb-6 md:mb-16 h-[3rem] md:h-[4.5rem] flex items-center justify-center">
         <div className="w-full">
           <MatrixText texts={greetings} interval={interval} />
         </div>

--- a/src/components/Home.tsx
+++ b/src/components/Home.tsx
@@ -146,7 +146,7 @@ export function Home() {
 
   return (
     <div className="h-full flex flex-col p-4 md:p-8 overflow-y-auto">
-      <div className="w-full space-y-8">
+      <div className="w-full space-y-6 md:space-y-8">
         {!isLoading && providers.length === 0 && (
           <section className="animate-in fade-in slide-in-from-top-4 duration-700">
             <div className="relative overflow-hidden rounded-card border border-indigo-500/20 bg-indigo-500/5 p-6 md:p-8 backdrop-blur-3xl dark:border-indigo-500/30 dark:bg-indigo-500/10">
@@ -182,7 +182,7 @@ export function Home() {
         )}
 
         {/* Unified Hero Section - Matrix Style */}
-        <section className="flex flex-col items-center justify-center py-10 md:py-24">
+        <section className="flex flex-col items-center justify-center py-6 md:py-24">
           <AssistantHero
             selectedProviderId={selectedProviderId}
             setSelectedProviderId={setSelectedProviderId}

--- a/src/components/LibraryEditor.tsx
+++ b/src/components/LibraryEditor.tsx
@@ -417,8 +417,9 @@ export function LibraryEditor({ library, onUpdate, onDelete }: Props) {
     });
   };
 
+  // Phones scroll the whole page so the header can leave the screen; from lg the header is pinned and only the list scrolls.
   return (
-    <div className="h-full flex flex-col p-4 md:p-8 w-full overflow-hidden animate-in fade-in duration-700">
+    <div className="h-full flex flex-col px-4 pb-4 md:p-8 w-full overflow-y-auto lg:overflow-hidden custom-scrollbar animate-in fade-in duration-700">
       <PageHeader
         title={library.name}
         description={(
@@ -439,6 +440,7 @@ export function LibraryEditor({ library, onUpdate, onDelete }: Props) {
           </div>
         )}
         size="large"
+        className="pt-4 lg:pt-0"
         actions={(
           <div className="flex flex-wrap items-center gap-3">
             <div className="relative flex-1 sm:flex-none">
@@ -549,11 +551,11 @@ export function LibraryEditor({ library, onUpdate, onDelete }: Props) {
         )}
       />
 
-      <div className="flex-1 overflow-y-auto pr-2 md:pr-4 -mr-2 md:-mr-4 custom-scrollbar space-y-3 md:space-y-6 pb-20">
+      <div className="flex-1 lg:overflow-y-auto pr-2 md:pr-4 -mr-2 md:-mr-4 custom-scrollbar space-y-3 md:space-y-6 pb-20">
         {/* Batch Action Toolbar (Mirrors item style) */}
         {items.length > -1 && (
           <div className={`
-            sticky top-0 z-20 flex flex-nowrap items-center justify-between gap-2 p-3 border transition-colors
+            sticky top-0 z-20 flex flex-nowrap items-center justify-between gap-2 p-2 md:p-3 border transition-colors
             ${selectedItemIds.size > 0
               ? 'bg-blue-600 text-white border-blue-700'
               : 'bg-white dark:bg-neutral-900 border-neutral-200 dark:border-neutral-800'}

--- a/src/components/LibraryEditor.tsx
+++ b/src/components/LibraryEditor.tsx
@@ -422,17 +422,17 @@ export function LibraryEditor({ library, onUpdate, onDelete }: Props) {
       <PageHeader
         title={library.name}
         description={(
-          <div className="mt-2 md:mt-3 space-y-3">
+          <div className="mt-1 space-y-2 md:mt-3 md:space-y-3">
             {library.description && (
-              <p className="max-w-3xl text-sm leading-6 text-neutral-600 dark:text-neutral-400">
+              <p className="max-w-3xl text-[13px] leading-snug text-neutral-600 dark:text-neutral-400 md:text-sm md:leading-6">
                 {library.description}
               </p>
             )}
-            <div className="flex flex-wrap items-center gap-4">
-              <div className="text-[10px] font-black uppercase tracking-[0.2em] text-neutral-600 dark:text-neutral-400 px-3 py-1.5 bg-neutral-100 dark:bg-neutral-900 border border-neutral-200 dark:border-neutral-800 rounded-lg shadow-sm">
+            <div className="flex flex-wrap items-center gap-2 md:gap-4">
+              <div className="text-[10px] font-black uppercase tracking-[0.2em] text-neutral-600 dark:text-neutral-400 px-2 py-1 md:px-3 md:py-1.5 bg-neutral-100 dark:bg-neutral-900 border border-neutral-200 dark:border-neutral-800 rounded-lg shadow-sm">
                 {t('libraryEditor.collectionType', { type: library.type || 'text' })}
               </div>
-              <div className="text-[10px] font-black uppercase tracking-[0.2em] text-blue-600 dark:text-blue-400 px-3 py-1.5 bg-blue-500/5 dark:bg-blue-500/10 border border-blue-500/20 rounded-lg shadow-sm">
+              <div className="text-[10px] font-black uppercase tracking-[0.2em] text-blue-600 dark:text-blue-400 px-2 py-1 md:px-3 md:py-1.5 bg-blue-500/5 dark:bg-blue-500/10 border border-blue-500/20 rounded-lg shadow-sm">
                 {t('libraries.libraryCard.items', { count: totalItems })}
               </div>
             </div>

--- a/src/components/PageHeader.tsx
+++ b/src/components/PageHeader.tsx
@@ -32,28 +32,25 @@ export function PageHeader({
 
   const titleEl = (
     <h2 className={cn(
-      "font-bold text-neutral-900 dark:text-white mb-2 font-display tracking-tight",
-      isLarge ? "text-2xl md:text-4xl" : "text-2xl md:text-3xl"
+      "font-bold text-neutral-900 dark:text-white mb-1 md:mb-2 font-display tracking-tight",
+      isLarge ? "text-xl md:text-4xl" : "text-xl md:text-3xl"
     )}>
       {title}
     </h2>
   );
 
+  const backClassName =
+    "text-xs md:text-sm text-neutral-500 dark:text-neutral-500 hover:text-neutral-900 dark:hover:text-neutral-200 inline-flex items-center gap-1 transition-colors";
+
   const backEl = backLink && (
-    <div className="mb-4">
+    <div className="mb-2 md:mb-4">
       {backLink.to ? (
-        <Link
-          to={backLink.to}
-          className="text-sm text-neutral-500 dark:text-neutral-500 hover:text-neutral-900 dark:hover:text-neutral-200 flex items-center gap-1 transition-colors"
-        >
-          <ArrowLeft className="w-4 h-4" /> {backLink.label}
+        <Link to={backLink.to} className={backClassName}>
+          <ArrowLeft className="w-3.5 h-3.5 md:w-4 md:h-4" /> {backLink.label}
         </Link>
       ) : (
-        <button
-          onClick={backLink.onClick}
-          className="text-sm text-neutral-500 dark:text-neutral-500 hover:text-neutral-900 dark:hover:text-neutral-200 flex items-center gap-1 transition-colors"
-        >
-          <ArrowLeft className="w-4 h-4" /> {backLink.label}
+        <button onClick={backLink.onClick} className={backClassName}>
+          <ArrowLeft className="w-3.5 h-3.5 md:w-4 md:h-4" /> {backLink.label}
         </button>
       )}
     </div>
@@ -62,7 +59,7 @@ export function PageHeader({
   return (
     <div className={cn(
       "flex flex-col lg:flex-row lg:items-center justify-between gap-0 md:gap-6",
-      isLarge ? "mb-8 md:mb-12" : "mb-6 md:mb-8",
+      isLarge ? "mb-5 md:mb-12" : "mb-4 md:mb-8",
       className
     )}>
       <header className={cn("flex-1 min-w-0 mb-3 lg:mb-0", headerClassName)}>
@@ -70,7 +67,7 @@ export function PageHeader({
         {titleEl}
         {description && (
           <div className={cn(
-            "text-sm md:text-base text-neutral-700 dark:text-neutral-400 leading-relaxed",
+            "text-[13px] md:text-base text-neutral-700 dark:text-neutral-400 leading-snug md:leading-relaxed",
             !isLarge && "max-w-2xl"
           )}>
             {description}

--- a/src/components/StorageView.tsx
+++ b/src/components/StorageView.tsx
@@ -90,23 +90,23 @@ export function StorageView() {
   });
 
   return (
-    <div className="flex-1 overflow-y-auto bg-neutral-50 dark:bg-neutral-950 p-6 lg:p-12 custom-scrollbar">
+    <div className="flex-1 overflow-y-auto bg-neutral-50 dark:bg-neutral-950 p-4 sm:p-6 lg:p-12 custom-scrollbar">
       {/* Header */}
-      <motion.div 
+      <motion.div
         initial={{ opacity: 0, y: -20 }}
         animate={{ opacity: 1, y: 0 }}
-        className="mb-12"
+        className="mb-6 md:mb-12"
       >
-        <div className="flex items-center gap-3 mb-2">
-          <div className="w-10 h-10 rounded-xl bg-blue-600/10 flex items-center justify-center">
-            <HardDrive className="w-6 h-6 text-blue-400" />
+        <div className="flex items-center gap-2 md:gap-3 mb-1 md:mb-2">
+          <div className="w-8 h-8 md:w-10 md:h-10 rounded-xl bg-blue-600/10 flex items-center justify-center shrink-0">
+            <HardDrive className="w-4 h-4 md:w-6 md:h-6 text-blue-400" />
           </div>
-          <h1 className="text-3xl font-black text-neutral-900 dark:text-white tracking-tight">{t('storageView.title')}</h1>
+          <h1 className="text-xl md:text-3xl font-black text-neutral-900 dark:text-white tracking-tight">{t('storageView.title')}</h1>
         </div>
-        <p className="text-neutral-600 dark:text-neutral-400 text-lg">{t('storageView.description')}</p>
+        <p className="text-neutral-600 dark:text-neutral-400 text-[13px] leading-snug md:text-lg md:leading-normal">{t('storageView.description')}</p>
       </motion.div>
 
-      <div className="grid grid-cols-1 xl:grid-cols-12 gap-12 items-start">
+      <div className="grid grid-cols-1 xl:grid-cols-12 gap-6 md:gap-12 items-start">
         {/* Left Column: Data Blocks */}
         <div className="xl:col-span-7 space-y-8">
           {/* Main 3x2 (or adaptive) Grid */}

--- a/src/components/TrashView.tsx
+++ b/src/components/TrashView.tsx
@@ -135,39 +135,47 @@ export function TrashView() {
           description={t('trash.description')}
         />
 
-      <div className="sticky top-0 z-20 flex flex-col gap-4 md:flex-row md:items-center md:justify-between bg-white/40 dark:bg-neutral-900/40 backdrop-blur-3xl border border-neutral-200/50 dark:border-white/5 p-4 rounded-card shadow-lg shadow-black/5 dark:shadow-black/20">
-        <div className="flex items-center gap-2">
-          <span className="text-[10px] font-bold text-neutral-500 dark:text-neutral-500 uppercase tracking-widest">
+      {/* Stays on one row on phones — stacking made this pinned bar twice as tall as it needs to be. */}
+      <div className="sticky top-0 z-20 flex items-center justify-between gap-2 md:gap-4 bg-white/40 dark:bg-neutral-900/40 backdrop-blur-3xl border border-neutral-200/50 dark:border-white/5 p-2.5 md:p-4 rounded-card shadow-lg shadow-black/5 dark:shadow-black/20">
+        {/* A phone cannot fit the totals next to the selection actions, and the count is already on the restore button. */}
+        <div className={`min-w-0 items-center gap-1.5 md:gap-2 ${selectedIds.size > 0 ? 'hidden sm:flex' : 'flex'}`}>
+          <span className="truncate text-[10px] font-bold text-neutral-500 dark:text-neutral-500 uppercase tracking-widest">
             {t('trash.stats.items', { count: items.length })}
           </span>
           <span className="text-neutral-800">·</span>
-          <span className="text-[10px] font-bold text-blue-400 uppercase tracking-widest">
+          <span className="truncate text-[10px] font-bold text-blue-400 uppercase tracking-widest">
             {t('trash.stats.total', { size: formatSize(totalSize) })}
           </span>
         </div>
 
-        <div className="flex items-center gap-3">
+        <div className="flex shrink-0 items-center gap-1.5 md:gap-3">
           {selectedIds.size > 0 && (
-            <div className="flex items-center gap-2 animate-in slide-in-from-right-4 duration-300">
+            <div className="flex items-center gap-1.5 md:gap-2 animate-in slide-in-from-right-4 duration-300">
               <button
                 onClick={handleRestoreBatch}
-                className="flex items-center gap-2 px-4 py-2 bg-blue-500/10 hover:bg-blue-500/20 text-blue-400 text-[10px] font-black uppercase tracking-widest rounded-xl border border-blue-500/30 transition-all shadow-lg shadow-blue-500/5"
+                title={t('trash.actions.restoreCount', { count: selectedIds.size })}
+                className="flex items-center gap-1.5 md:gap-2 px-2.5 py-1.5 md:px-4 md:py-2 bg-blue-500/10 hover:bg-blue-500/20 text-blue-400 text-[10px] font-black uppercase tracking-widest rounded-xl border border-blue-500/30 transition-all shadow-lg shadow-blue-500/5"
               >
-                <RotateCcw className="w-3.5 h-3.5" /> {t('trash.actions.restoreCount', { count: selectedIds.size })}
+                <RotateCcw className="w-3.5 h-3.5 shrink-0" />
+                <span className="hidden sm:inline">{t('trash.actions.restoreCount', { count: selectedIds.size })}</span>
+                <span className="sm:hidden">{selectedIds.size}</span>
               </button>
               <button
                 onClick={() => setShowDeleteSelectedConfirm(true)}
-                className="flex items-center gap-2 px-4 py-2 bg-red-500/10 hover:bg-red-500/20 text-red-500 text-[10px] font-black uppercase tracking-widest rounded-xl border border-red-500/30 transition-all shadow-lg shadow-red-500/5"
+                title={t('trash.actions.deletePermanently')}
+                aria-label={t('trash.actions.deletePermanently')}
+                className="flex items-center gap-2 px-2.5 py-1.5 md:px-4 md:py-2 bg-red-500/10 hover:bg-red-500/20 text-red-500 text-[10px] font-black uppercase tracking-widest rounded-xl border border-red-500/30 transition-all shadow-lg shadow-red-500/5"
               >
-                <Trash2 className="w-3.5 h-3.5" /> {t('trash.actions.deletePermanently')}
+                <Trash2 className="w-3.5 h-3.5 shrink-0" />
+                <span className="hidden sm:inline">{t('trash.actions.deletePermanently')}</span>
               </button>
             </div>
           )}
-          
+
           {items.length > 0 && (
             <button
               onClick={() => setShowEmptyConfirm(true)}
-              className="flex items-center gap-2 px-4 py-2 bg-white dark:bg-neutral-900 hover:bg-red-100 dark:hover:bg-red-900/20 text-neutral-600 dark:text-neutral-400 hover:text-red-600 dark:hover:text-red-400 text-[10px] font-black uppercase tracking-widest rounded-xl border border-neutral-200 dark:border-neutral-800 hover:border-red-500/30 transition-all ml-2"
+              className="flex items-center gap-2 px-2.5 py-1.5 md:px-4 md:py-2 bg-white dark:bg-neutral-900 hover:bg-red-100 dark:hover:bg-red-900/20 text-neutral-600 dark:text-neutral-400 hover:text-red-600 dark:hover:text-red-400 text-[10px] font-black uppercase tracking-widest rounded-xl border border-neutral-200 dark:border-neutral-800 hover:border-red-500/30 transition-all md:ml-2"
             >
               {t('trash.actions.emptyTrash')}
             </button>

--- a/src/pages/Account.tsx
+++ b/src/pages/Account.tsx
@@ -380,7 +380,7 @@ export function Account() {
 
   if (!user) {
     return (
-      <div className="p-6 lg:p-10">
+      <div className="p-4 sm:p-6 lg:p-10">
         <div className="w-full rounded-card border border-red-500/20 bg-red-500/10 p-5 text-red-300">
           <div className="flex items-start gap-3">
             <AlertCircle className="mt-0.5 h-5 w-5 flex-shrink-0" />
@@ -395,8 +395,8 @@ export function Account() {
   }
 
   return (
-    <div className="p-6 lg:p-10">
-      <div className="w-full space-y-8">
+    <div className="p-4 sm:p-6 lg:p-10">
+      <div className="w-full space-y-6 md:space-y-8">
         <PageHeader
           title={t('account.title')}
           description={t('account.description')}

--- a/src/pages/AccountTwoFactorSetup.tsx
+++ b/src/pages/AccountTwoFactorSetup.tsx
@@ -122,16 +122,16 @@ export function AccountTwoFactorSetup() {
   }
 
   return (
-    <div className="p-6 lg:p-10">
-      <div className="mx-auto max-w-5xl space-y-6">
-        <div className="flex items-center justify-between gap-4">
-          <div>
-            <Link to="/account?tab=security" className="inline-flex items-center gap-2 text-sm text-neutral-600 dark:text-neutral-400 hover:text-neutral-200">
-              <ArrowLeft className="h-4 w-4" />
+    <div className="p-4 sm:p-6 lg:p-10">
+      <div className="mx-auto max-w-5xl space-y-4 md:space-y-6">
+        <div className="flex items-start justify-between gap-3 md:items-center md:gap-4">
+          <div className="min-w-0">
+            <Link to="/account?tab=security" className="inline-flex items-center gap-2 text-xs md:text-sm text-neutral-600 dark:text-neutral-400 hover:text-neutral-200">
+              <ArrowLeft className="h-3.5 w-3.5 md:h-4 md:w-4" />
               {t('accountTwoFactorSetup.backToSecurity')}
             </Link>
-            <h2 className="mt-3 text-2xl font-bold text-neutral-900 dark:text-white">{t('accountTwoFactorSetup.title')}</h2>
-            <p className="mt-2 text-sm text-neutral-600 dark:text-neutral-400">
+            <h2 className="mt-2 text-xl font-bold text-neutral-900 dark:text-white md:mt-3 md:text-2xl">{t('accountTwoFactorSetup.title')}</h2>
+            <p className="mt-1 text-[13px] leading-snug text-neutral-600 dark:text-neutral-400 md:mt-2 md:text-sm">
               {t('accountTwoFactorSetup.description', { email: user?.email || t('accountTwoFactorSetup.thisAccount') })}
             </p>
           </div>

--- a/src/pages/AdminInvites.tsx
+++ b/src/pages/AdminInvites.tsx
@@ -107,7 +107,7 @@ export function AdminInvites() {
   };
 
   return (
-    <div className="p-6 lg:p-10">
+    <div className="p-4 sm:p-6 lg:p-10">
       <div className="mx-auto max-w-6xl space-y-8">
         <PageHeader
           title={t('adminInvites.title')}

--- a/src/pages/AdminUsers.tsx
+++ b/src/pages/AdminUsers.tsx
@@ -245,8 +245,8 @@ export function AdminUsers() {
   };
 
   return (
-    <div className="p-6 lg:p-10">
-      <div className="w-full space-y-8">
+    <div className="p-4 sm:p-6 lg:p-10">
+      <div className="w-full space-y-6 md:space-y-8">
         <PageHeader
           title={t('adminUsers.title')}
           description={t('adminUsers.description')}

--- a/src/pages/AssistantSettingsPage.tsx
+++ b/src/pages/AssistantSettingsPage.tsx
@@ -445,8 +445,8 @@ export function AssistantSettingsPage() {
         document.getElementById('mobile-header-assistant-title')!,
       )}
 
-      <div className="h-full overflow-y-auto p-6 lg:p-10">
-        <div className="w-full space-y-8">
+      <div className="h-full overflow-y-auto p-4 sm:p-6 lg:p-10">
+        <div className="w-full space-y-6 md:space-y-8">
           <PageHeader
             title={t('assistant.chatSettings', { defaultValue: 'Chat settings' })}
             description={t('assistant.chatSettingsDescription', {

--- a/src/pages/CampaignBatchActions.tsx
+++ b/src/pages/CampaignBatchActions.tsx
@@ -312,7 +312,7 @@ export function CampaignBatchActions() {
 
   return (
     <div className="h-full flex flex-col p-4 md:p-8 overflow-y-auto relative">
-      <div className="w-full space-y-8 pb-24">
+      <div className="w-full space-y-6 md:space-y-8 pb-24">
         <PageHeader
           title="Batch Actions"
           description={<>Manage multiple posts for <span className="font-semibold text-neutral-950 dark:text-white">{campaign?.name}</span></>}

--- a/src/pages/CampaignBatchCreate.tsx
+++ b/src/pages/CampaignBatchCreate.tsx
@@ -325,7 +325,7 @@ export function CampaignBatchCreate() {
 
   return (
     <div className="relative flex h-full flex-col overflow-y-auto p-4 md:p-8">
-      <div className="w-full space-y-8 pb-32">
+      <div className="w-full space-y-6 md:space-y-8 pb-32">
         <PageHeader
           title="Create Batch"
           description={<>Queue media from uploads, libraries, or albums for <span className="font-semibold text-neutral-950 dark:text-white">{campaign?.name}</span></>}

--- a/src/pages/CampaignChannels.tsx
+++ b/src/pages/CampaignChannels.tsx
@@ -105,7 +105,7 @@ export function CampaignChannels() {
 
   return (
     <div className="h-full flex flex-col p-4 md:p-8 overflow-y-auto relative">
-      <div className="w-full space-y-8 pb-20">
+      <div className="w-full space-y-6 md:space-y-8 pb-20">
         <PageHeader
           title="Channels"
           description="Connect and manage the accounts campaigns publish to."

--- a/src/pages/CampaignDetail.tsx
+++ b/src/pages/CampaignDetail.tsx
@@ -621,7 +621,7 @@ export function CampaignDetail() {
 
   return (
     <div className="h-full flex flex-col p-4 md:p-8 overflow-y-auto relative">
-      <div className="w-full space-y-8 pb-20">
+      <div className="w-full space-y-6 md:space-y-8 pb-20">
         <PageHeader
           title={(
             <span className="inline-flex items-center gap-2">

--- a/src/pages/CampaignForm.tsx
+++ b/src/pages/CampaignForm.tsx
@@ -148,7 +148,7 @@ export function CampaignForm() {
 
   return (
     <div className="h-full flex flex-col p-4 md:p-8 overflow-y-auto relative">
-      <div className="w-full space-y-8 pb-20">
+      <div className="w-full space-y-6 md:space-y-8 pb-20">
         <PageHeader
           title={isEditing ? 'Edit Campaign' : 'Create New Campaign'}
           description={isEditing ? 'Update your campaign settings and target channels.' : 'Set up a new campaign and select which channels will participate.'}

--- a/src/pages/Campaigns.tsx
+++ b/src/pages/Campaigns.tsx
@@ -234,7 +234,7 @@ export function Campaigns() {
 
   return (
     <div className="h-full flex flex-col p-4 md:p-8 overflow-y-auto relative">
-      <div className="w-full space-y-8 pb-20">
+      <div className="w-full space-y-6 md:space-y-8 pb-20">
         <PageHeader
           title={t('title')}
           description={t('description')}

--- a/src/pages/ExtensionImport.tsx
+++ b/src/pages/ExtensionImport.tsx
@@ -356,7 +356,7 @@ export default function ExtensionImport() {
 
   return (
     <div className="h-full flex flex-col p-4 md:p-8 overflow-y-auto relative">
-      <div className="w-full space-y-8 pb-20 animate-in fade-in slide-in-from-bottom-4 duration-500">
+      <div className="w-full space-y-6 md:space-y-8 pb-20 animate-in fade-in slide-in-from-bottom-4 duration-500">
         <PageHeader
           title={`Import ${importData.type === 'image' ? 'Image' : 'Text'}`}
           description="Save this item to your Remix Studio workspace."

--- a/src/pages/Libraries.tsx
+++ b/src/pages/Libraries.tsx
@@ -174,7 +174,7 @@ export function Libraries() {
 
   return (
     <div className="h-full flex flex-col p-4 md:p-8 overflow-y-auto relative">
-      <div className="w-full space-y-8 pb-20">
+      <div className="w-full space-y-6 md:space-y-8 pb-20">
         <PageHeader
           title={t('libraries.title')}
           description={t('libraries.description')}

--- a/src/pages/LibraryCleanup.tsx
+++ b/src/pages/LibraryCleanup.tsx
@@ -107,7 +107,7 @@ export function LibraryCleanup() {
 
   return (
     <div className="h-full flex flex-col p-4 md:p-8 overflow-y-auto">
-      <div className="w-full space-y-8">
+      <div className="w-full space-y-6 md:space-y-8">
         {/* Header */}
         <PageHeader
           title={t('libraryCleanup.title')}

--- a/src/pages/LibraryForm.tsx
+++ b/src/pages/LibraryForm.tsx
@@ -82,7 +82,7 @@ export function LibraryForm() {
 
   return (
     <div className="h-full overflow-y-auto p-4 md:p-8">
-      <div className="w-full space-y-8 pb-20">
+      <div className="w-full space-y-6 md:space-y-8 pb-20">
         <PageHeader
           title={isNew ? t('libraryForm.newTitle') : t('libraryForm.editTitle')}
           description={t('libraryForm.description')}

--- a/src/pages/LibraryImportExport.tsx
+++ b/src/pages/LibraryImportExport.tsx
@@ -375,49 +375,49 @@ export function LibraryImportExport() {
 
   return (
     <div className="h-full overflow-y-auto bg-[radial-gradient(circle_at_top_left,_rgba(59,130,246,0.12),_transparent_30%),radial-gradient(circle_at_top_right,_rgba(34,197,94,0.10),_transparent_28%),linear-gradient(180deg,_#09090b_0%,_#050505_100%)] custom-scrollbar">
-      <div className="mx-auto flex w-full max-w-[1600px] flex-col gap-8 px-4 py-4 md:px-8 md:py-8">
-        <div className="flex flex-col gap-5 xl:flex-row xl:items-end xl:justify-between">
-          <div className="flex items-start gap-4">
+      <div className="mx-auto flex w-full max-w-[1600px] flex-col gap-5 px-4 py-4 md:gap-8 md:px-8 md:py-8">
+        <div className="flex flex-col gap-4 md:gap-5 xl:flex-row xl:items-end xl:justify-between">
+          <div className="flex items-start gap-3 md:gap-4">
             <button
               onClick={() => navigate(`/library/${id}`)}
-              className="mt-1 rounded-card border border-neutral-200/80 dark:border-neutral-800/80 bg-neutral-50/70 dark:bg-neutral-950/70 p-3 text-neutral-500 dark:text-neutral-500 transition-all hover:border-neutral-700 hover:text-neutral-900 dark:hover:text-white hover:bg-neutral-900/80"
+              className="mt-0.5 md:mt-1 rounded-card border border-neutral-200/80 dark:border-neutral-800/80 bg-neutral-50/70 dark:bg-neutral-950/70 p-2 md:p-3 text-neutral-500 dark:text-neutral-500 transition-all hover:border-neutral-700 hover:text-neutral-900 dark:hover:text-white hover:bg-neutral-900/80"
             >
-              <ChevronLeft className="h-6 w-6" />
+              <ChevronLeft className="h-5 w-5 md:h-6 md:w-6" />
             </button>
 
-            <div className="space-y-3">
-              <div className="inline-flex items-center gap-2 rounded-full border border-blue-500/20 bg-blue-500/10 px-3 py-1 text-[10px] font-black uppercase tracking-[0.22em] text-blue-400">
+            <div className="min-w-0 space-y-2 md:space-y-3">
+              <div className="hidden md:inline-flex items-center gap-2 rounded-full border border-blue-500/20 bg-blue-500/10 px-3 py-1 text-[10px] font-black uppercase tracking-[0.22em] text-blue-400">
                 <FileText className="h-3.5 w-3.5" />
                 {t('libraryImportExport.badge')}
               </div>
 
               <div>
-                <h1 className="text-3xl font-black tracking-tight text-neutral-900 dark:text-white md:text-5xl">
+                <h1 className="text-xl font-black tracking-tight text-neutral-900 dark:text-white md:text-5xl">
                   {t('libraryImportExport.title')}
                 </h1>
-                <p className="mt-2 max-w-2xl text-sm leading-relaxed text-neutral-600 dark:text-neutral-400">
+                <p className="mt-1 max-w-2xl text-[13px] leading-snug text-neutral-600 dark:text-neutral-400 md:mt-2 md:text-sm md:leading-relaxed">
                   {t('libraryImportExport.description')}
                 </p>
               </div>
             </div>
           </div>
 
-          <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
-            <div className="rounded-card border border-neutral-200/50 dark:border-white/5 bg-white/70 dark:bg-neutral-900/70 backdrop-blur-xl p-4 shadow-sm">
+          <div className="grid grid-cols-2 gap-2 sm:grid-cols-4 md:gap-3">
+            <div className="rounded-card border border-neutral-200/50 dark:border-white/5 bg-white/70 dark:bg-neutral-900/70 backdrop-blur-xl p-3 shadow-sm md:p-4">
               <div className="text-[10px] font-black uppercase tracking-[0.2em] text-neutral-500 dark:text-neutral-500">{t('libraryImportExport.stats.library')}</div>
-              <div className="mt-2 truncate text-sm font-bold text-neutral-900 dark:text-white">{library.name}</div>
+              <div className="mt-1 truncate text-sm font-bold text-neutral-900 dark:text-white md:mt-2">{library.name}</div>
             </div>
-            <div className="rounded-card border border-neutral-200/50 dark:border-white/5 bg-white/70 dark:bg-neutral-900/70 backdrop-blur-xl p-4 shadow-sm">
+            <div className="rounded-card border border-neutral-200/50 dark:border-white/5 bg-white/70 dark:bg-neutral-900/70 backdrop-blur-xl p-3 shadow-sm md:p-4">
               <div className="text-[10px] font-black uppercase tracking-[0.2em] text-neutral-500 dark:text-neutral-500">{t('libraryImportExport.stats.currentItems')}</div>
-              <div className="mt-2 text-2xl font-black text-neutral-900 dark:text-white">{library.items.length}</div>
+              <div className="mt-1 text-xl font-black text-neutral-900 dark:text-white md:mt-2 md:text-2xl">{library.items.length}</div>
             </div>
-            <div className="rounded-card border border-neutral-200/50 dark:border-white/5 bg-white/70 dark:bg-neutral-900/70 backdrop-blur-xl p-4 shadow-sm">
+            <div className="rounded-card border border-neutral-200/50 dark:border-white/5 bg-white/70 dark:bg-neutral-900/70 backdrop-blur-xl p-3 shadow-sm md:p-4">
               <div className="text-[10px] font-black uppercase tracking-[0.2em] text-neutral-500 dark:text-neutral-500">{t('libraryImportExport.stats.currentTags')}</div>
-              <div className="mt-2 text-2xl font-black text-neutral-900 dark:text-white">{libraryTagCount}</div>
+              <div className="mt-1 text-xl font-black text-neutral-900 dark:text-white md:mt-2 md:text-2xl">{libraryTagCount}</div>
             </div>
-            <div className="rounded-card border border-neutral-200/50 dark:border-white/5 bg-white/70 dark:bg-neutral-900/70 backdrop-blur-xl p-4 shadow-sm">
+            <div className="rounded-card border border-neutral-200/50 dark:border-white/5 bg-white/70 dark:bg-neutral-900/70 backdrop-blur-xl p-3 shadow-sm md:p-4">
               <div className="text-[10px] font-black uppercase tracking-[0.2em] text-neutral-500 dark:text-neutral-500">{t('libraryImportExport.stats.readyToImport')}</div>
-              <div className="mt-2 text-2xl font-black text-blue-400">{previewItems.length}</div>
+              <div className="mt-1 text-xl font-black text-blue-400 md:mt-2 md:text-2xl">{previewItems.length}</div>
             </div>
           </div>
         </div>
@@ -490,7 +490,7 @@ export function LibraryImportExport() {
               </div>
 
               <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_auto]">
-                <label className="rounded-card border border-neutral-200/50 dark:border-white/5 bg-white/70 dark:bg-neutral-900/70 backdrop-blur-xl p-4 shadow-sm">
+                <label className="rounded-card border border-neutral-200/50 dark:border-white/5 bg-white/70 dark:bg-neutral-900/70 backdrop-blur-xl p-3 shadow-sm md:p-4">
                   <div className="flex items-center gap-2 text-[10px] font-black uppercase tracking-[0.2em] text-neutral-500 dark:text-neutral-500">
                     <Tag className="h-3.5 w-3.5 text-blue-400" />
                     {t('libraryImportExport.importSource.sharedTags')}
@@ -505,11 +505,11 @@ export function LibraryImportExport() {
                 </label>
 
                 <div className="grid grid-cols-2 gap-3 lg:w-[240px]">
-                  <div className="rounded-card border border-neutral-200/50 dark:border-white/5 bg-white/70 dark:bg-neutral-900/70 backdrop-blur-xl p-4 shadow-sm">
+                  <div className="rounded-card border border-neutral-200/50 dark:border-white/5 bg-white/70 dark:bg-neutral-900/70 backdrop-blur-xl p-3 shadow-sm md:p-4">
                     <div className="text-[10px] font-black uppercase tracking-[0.2em] text-neutral-500 dark:text-neutral-500">{t('libraryImportExport.importSource.detectedTags')}</div>
                     <div className="mt-2 text-xl font-black text-neutral-900 dark:text-white">{previewTagCount}</div>
                   </div>
-                  <div className="rounded-card border border-neutral-200/50 dark:border-white/5 bg-white/70 dark:bg-neutral-900/70 backdrop-blur-xl p-4 shadow-sm">
+                  <div className="rounded-card border border-neutral-200/50 dark:border-white/5 bg-white/70 dark:bg-neutral-900/70 backdrop-blur-xl p-3 shadow-sm md:p-4">
                     <div className="text-[10px] font-black uppercase tracking-[0.2em] text-neutral-500 dark:text-neutral-500">{t('libraryImportExport.importSource.skippedLines')}</div>
                     <div className={`mt-2 text-xl font-black ${parseIssues.length > 0 ? 'text-amber-300' : 'text-neutral-900 dark:text-white'}`}>
                       {parseIssues.length}

--- a/src/pages/PostForm.tsx
+++ b/src/pages/PostForm.tsx
@@ -306,7 +306,7 @@ export function PostForm() {
 
   return (
     <div className="h-full flex flex-col p-4 md:p-8 overflow-y-auto relative">
-      <div className="w-full space-y-8 pb-20">
+      <div className="w-full space-y-6 md:space-y-8 pb-20">
         <PageHeader
           title={isEditing ? 'Edit Post' : 'Create New Post'}
           description={isEditing ? 'Update your campaign post.' : 'Add a new post to your campaign.'}

--- a/src/pages/ProjectForm.tsx
+++ b/src/pages/ProjectForm.tsx
@@ -121,7 +121,7 @@ export function ProjectForm() {
 
   return (
     <div className="h-full overflow-y-auto p-4 md:p-8">
-      <div className="w-full space-y-8 pb-20">
+      <div className="w-full space-y-6 md:space-y-8 pb-20">
         <PageHeader
           title={isNew ? t('projectForm.newTitle') : t('projectForm.editTitle')}
           description={t('projectForm.description')}

--- a/src/pages/ProjectOrphans.tsx
+++ b/src/pages/ProjectOrphans.tsx
@@ -136,8 +136,9 @@ export function ProjectOrphans() {
 
   const totalSize = orphans.reduce((acc, current) => acc + (current.size || 0), 0);
 
+  // Phones scroll the whole page so the header can leave the screen; from lg the header is pinned and only the list scrolls.
   return (
-    <div className="h-full flex flex-col bg-neutral-50 dark:bg-neutral-950 overflow-hidden">
+    <div className="h-full flex flex-col bg-neutral-50 dark:bg-neutral-950 overflow-y-auto lg:overflow-hidden custom-scrollbar">
       {/* Header */}
       <PageHeader
         title={t('projectOrphans.title')}
@@ -186,7 +187,7 @@ export function ProjectOrphans() {
       />
 
       {/* Main Content */}
-      <main className="flex-1 overflow-y-auto p-4 md:p-8 custom-scrollbar">
+      <main className="flex-1 lg:overflow-y-auto p-4 md:p-8 custom-scrollbar">
         <div className="w-full space-y-6 md:space-y-8">
           
           {/* Legend / Stats */}

--- a/src/pages/ProjectOrphans.tsx
+++ b/src/pages/ProjectOrphans.tsx
@@ -187,7 +187,7 @@ export function ProjectOrphans() {
 
       {/* Main Content */}
       <main className="flex-1 overflow-y-auto p-4 md:p-8 custom-scrollbar">
-        <div className="w-full space-y-8">
+        <div className="w-full space-y-6 md:space-y-8">
           
           {/* Legend / Stats */}
           <div className="grid grid-cols-1 md:grid-cols-3 gap-4">

--- a/src/pages/Projects.tsx
+++ b/src/pages/Projects.tsx
@@ -165,7 +165,7 @@ export function Projects() {
 
   return (
     <div className="h-full flex flex-col p-4 md:p-8 overflow-y-auto relative">
-      <div className="w-full space-y-8 pb-20">
+      <div className="w-full space-y-6 md:space-y-8 pb-20">
         <PageHeader
           title={t('projects.title')}
           description={t('projects.description')}

--- a/src/pages/PromptEditor.tsx
+++ b/src/pages/PromptEditor.tsx
@@ -87,11 +87,11 @@ export function PromptEditor() {
 
   return (
     <div className={`h-full flex flex-col bg-neutral-50 dark:bg-neutral-950 transition-all ${isFullScreen ? 'fixed inset-0 z-[60] p-4 md:p-6' : 'p-4 md:p-8'}`}>
-      <div className="w-full flex flex-col h-full gap-6 animate-in fade-in duration-500">
+      <div className="w-full flex flex-col h-full gap-3 md:gap-6 animate-in fade-in duration-500">
 
         {/* Header */}
-        <div className="flex flex-col md:flex-row md:items-center justify-between gap-4 bg-white/40 dark:bg-neutral-900/40 border border-neutral-200/50 dark:border-white/5 rounded-card md:rounded-card p-4 md:pl-6 shadow-2xl backdrop-blur-3xl">
-          <div className="flex items-center gap-3 md:gap-4 flex-1">
+        <div className="flex flex-col md:flex-row md:items-center justify-between gap-2 md:gap-4 bg-white/40 dark:bg-neutral-900/40 border border-neutral-200/50 dark:border-white/5 rounded-card md:rounded-card p-3 md:p-4 md:pl-6 shadow-2xl backdrop-blur-3xl">
+          <div className="flex items-center gap-2 md:gap-4 flex-1 min-w-0">
             <button
               onClick={() => navigate(`/library/${id}`)}
               className="p-2 md:p-3 text-neutral-500 dark:text-neutral-500 hover:text-neutral-900 dark:hover:text-white hover:bg-neutral-200/80 dark:hover:bg-neutral-800/80 rounded-xl md:rounded-card transition-all border border-neutral-200/50 dark:border-neutral-800/50"

--- a/src/pages/ProviderCustomModels.tsx
+++ b/src/pages/ProviderCustomModels.tsx
@@ -135,23 +135,23 @@ export function ProviderCustomModels() {
 
   return (
     <div className="h-full flex flex-col p-4 md:p-8 overflow-y-auto">
-      <div className="w-full space-y-6">
+      <div className="w-full space-y-4 md:space-y-6">
         {/* Back */}
         <button
           onClick={() => navigate(`/provider/${id}`)}
-          className="text-sm text-neutral-500 dark:text-neutral-500 hover:text-neutral-300 flex items-center gap-1 transition-colors"
+          className="text-xs md:text-sm text-neutral-500 dark:text-neutral-500 hover:text-neutral-300 flex items-center gap-1 transition-colors"
         >
-          <ArrowLeft className="w-4 h-4" /> {t('providerCustomModels.backToProvider', { name: provider.name })}
+          <ArrowLeft className="w-3.5 h-3.5 md:w-4 md:h-4" /> {t('providerCustomModels.backToProvider', { name: provider.name })}
         </button>
 
         {/* Header */}
-        <header className="flex items-center justify-between">
-          <div>
-            <h2 className="text-2xl md:text-3xl font-bold text-neutral-900 dark:text-white font-display flex items-center gap-3">
-              <Layers className="w-7 h-7 text-cyan-500" />
+        <header className="flex items-start justify-between gap-3 md:items-center">
+          <div className="min-w-0">
+            <h2 className="text-xl md:text-3xl font-bold text-neutral-900 dark:text-white font-display flex items-center gap-2 md:gap-3">
+              <Layers className="w-5 h-5 md:w-7 md:h-7 text-cyan-500 shrink-0" />
               {t('providerCustomModels.title')}
             </h2>
-            <p className="text-sm text-neutral-600 dark:text-neutral-400 mt-1">
+            <p className="text-[13px] md:text-sm text-neutral-600 dark:text-neutral-400 mt-1 leading-snug">
               {t('providerCustomModels.description')}
             </p>
           </div>

--- a/src/pages/ProviderForm.tsx
+++ b/src/pages/ProviderForm.tsx
@@ -121,23 +121,23 @@ export function ProviderForm() {
     <div className="min-h-full flex flex-col bg-white dark:bg-neutral-950">
       <div className="flex-1 w-full flex flex-col overflow-y-auto">
         {/* Header */}
-        <div className="px-6 py-6 border-b border-neutral-200/50 dark:border-white/5 bg-white/50 dark:bg-neutral-950/50 backdrop-blur-3xl sticky top-0 z-20">
+        <div className="px-4 py-3 md:px-6 md:py-6 border-b border-neutral-200/50 dark:border-white/5 bg-white/50 dark:bg-neutral-950/50 backdrop-blur-3xl sticky top-0 z-20">
           <div className="mx-auto w-full">
-            <div className="flex flex-col md:flex-row md:items-center justify-between gap-4">
-              <div className="flex items-center gap-4">
-                <div>
-                  <h2 className="text-2xl font-bold text-neutral-900 dark:text-white tracking-tight">
+            <div className="flex flex-row items-center justify-between gap-3 md:gap-4">
+              <div className="flex min-w-0 items-center gap-4">
+                <div className="min-w-0">
+                  <h2 className="text-lg md:text-2xl font-bold text-neutral-900 dark:text-white tracking-tight truncate">
                     {isEditing ? t('providerForm.editTitle') : t('providerForm.newTitle')}
                   </h2>
-                  <p className="text-sm text-neutral-500 dark:text-neutral-500 font-medium">{t('providerForm.securityNote')}</p>
+                  <p className="hidden md:block text-sm text-neutral-500 dark:text-neutral-500 font-medium">{t('providerForm.securityNote')}</p>
                 </div>
               </div>
 
-              <div className="flex items-center gap-3">
+              <div className="flex shrink-0 items-center gap-2 md:gap-3">
                 <button
                   type="button"
                   onClick={() => isEditing ? navigate(`/provider/${id}`) : navigate('/providers')}
-                  className="px-6 py-2.5 bg-white dark:bg-neutral-900 border border-neutral-200 dark:border-white/5 hover:bg-neutral-100 dark:hover:bg-neutral-800 text-neutral-700 dark:text-neutral-300 rounded-lg text-xs font-black uppercase tracking-widest transition-all active:scale-95 shadow-sm"
+                  className="px-3 py-2 md:px-6 md:py-2.5 bg-white dark:bg-neutral-900 border border-neutral-200 dark:border-white/5 hover:bg-neutral-100 dark:hover:bg-neutral-800 text-neutral-700 dark:text-neutral-300 rounded-lg text-[10px] md:text-xs font-black uppercase tracking-widest transition-all active:scale-95 shadow-sm"
                 >
                   {t('providerForm.cancel')}
                 </button>
@@ -145,9 +145,9 @@ export function ProviderForm() {
                   form="provider-form"
                   type="submit"
                   disabled={isSubmitting || !name.trim()}
-                  className="px-8 py-2.5 bg-amber-500 hover:bg-amber-600 text-white dark:text-black rounded-lg text-xs font-black uppercase tracking-widest transition-all shadow-xl shadow-amber-500/20 active:scale-95 disabled:opacity-30 flex items-center justify-center gap-2 border border-amber-600"
+                  className="px-4 py-2 md:px-8 md:py-2.5 bg-amber-500 hover:bg-amber-600 text-white dark:text-black rounded-lg text-[10px] md:text-xs font-black uppercase tracking-widest transition-all shadow-xl shadow-amber-500/20 active:scale-95 disabled:opacity-30 flex items-center justify-center gap-1.5 md:gap-2 border border-amber-600"
                 >
-                   <Save className="w-4 h-4" />
+                   <Save className="w-3.5 h-3.5 md:w-4 md:h-4" />
                   {isSubmitting ? t('providerForm.saving') : isEditing ? t('providerForm.submitSave') : t('providerForm.submitCreate')}
                 </button>
               </div>
@@ -155,7 +155,7 @@ export function ProviderForm() {
           </div>
         </div>
 
-        <div className="px-6 md:px-8 py-10 space-y-10 max-w-screen-2xl mx-auto w-full">
+        <div className="px-4 py-6 md:px-8 md:py-10 space-y-6 md:space-y-10 max-w-screen-2xl mx-auto w-full">
           {/* Provider Type Selection Grid / Read-only Display during Edit */}
           <section className="space-y-6">
             {isEditing ? (

--- a/src/pages/ProviderProfile.tsx
+++ b/src/pages/ProviderProfile.tsx
@@ -111,7 +111,7 @@ export function ProviderProfile() {
 
   return (
     <div className="h-full flex flex-col p-4 md:p-8 overflow-y-auto">
-      <div className="w-full space-y-8">
+      <div className="w-full space-y-6 md:space-y-8">
         {/* Header */}
         <PageHeader
           title={(

--- a/src/pages/Providers.tsx
+++ b/src/pages/Providers.tsx
@@ -78,7 +78,7 @@ export function Providers() {
 
   return (
     <div className="h-full flex flex-col p-4 md:p-8 overflow-y-auto">
-      <div className="w-full space-y-8">
+      <div className="w-full space-y-6 md:space-y-8">
         <PageHeader
           title={t('providers.title')}
           description={t('providers.description')}

--- a/src/pages/StoreSettings.tsx
+++ b/src/pages/StoreSettings.tsx
@@ -83,7 +83,7 @@ export function StoreSettings() {
 
   return (
     <div className="h-full flex flex-col p-4 md:p-8 overflow-y-auto relative">
-      <div className="w-full space-y-8 pb-20">
+      <div className="w-full space-y-6 md:space-y-8 pb-20">
         <PageHeader
           title={t('exports.stores.title')}
           description={t('exports.stores.description')}


### PR DESCRIPTION
Page headers were sized for the desktop layout: a 24px title, a 14px
description on a relaxed line height, and 24-32px of margin below. On a
390px screen that pushed the first content block ~120px down a plain
page and ~200px down one with a back link and an action button, under a
fixed 64px app header.

The shared PageHeader now scales below md — 20px title, 13px snug
description, tighter back link and margins — and keeps every desktop
value from md up. Pages that stack sections in a space-y container also
halve that gap on phones, since it added to the header&#39;s own margin.

Screens with hand-built headers get the same treatment: Import &amp; Export
drops the badge and its 30px display title, the provider form&#39;s sticky
bar keeps title and buttons on one row instead of stacking, and Storage,
Custom Models, two-factor setup, the library editor chips, and the
assistant hero all scale down. Phone page padding goes 24px -&gt; 16px.

Measured at 390px: a title + description header goes 122px -&gt; 96px to
first content, and one with a back link and an action 202px -&gt; 172px.
