### PR TITLE
perf(ui): drive progress bars with transform instead of width

### DIFF
--- a/src/pages/CampaignDetail.tsx
+++ b/src/pages/CampaignDetail.tsx
@@ -673,7 +673,7 @@ export function CampaignDetail() {
               <h2 className="mb-4 text-sm font-semibold uppercase tracking-wider text-neutral-500 dark:text-neutral-400">Campaign Progress</h2>
               <div className="mt-4 text-3xl font-bold text-indigo-600 dark:text-indigo-400">{progress}%</div>
               <div className="mt-2 h-1.5 w-full overflow-hidden rounded-full bg-neutral-200 dark:bg-neutral-800">
-                <div className="h-full bg-indigo-600" style={{ width: `${progress}%` }} />
+                <div className="h-full w-full origin-left bg-indigo-600 transition-transform" style={{ transform: `scaleX(${progress / 100})` }} />
               </div>
               <p className="mt-2 mb-4 text-xs text-neutral-500 dark:text-neutral-400">{counts.completed} of {totalPosts} posts published</p>
 

--- a/src/pages/Exports.tsx
+++ b/src/pages/Exports.tsx
@@ -441,8 +441,8 @@ export function Exports() {
                         <div className="flex items-center gap-2 group-hover/task:translate-x-1 transition-transform">
                           <div className="w-20 sm:w-24 h-1.5 bg-neutral-100 dark:bg-neutral-900 rounded-full overflow-hidden border border-neutral-200 dark:border-neutral-800 shadow-inner">
                             <div
-                              className="h-full bg-blue-500 transition-all duration-500"
-                              style={{ width: task.status === 'pending' || task.total <= 0 ? '0%' : `${(task.current / task.total) * 100}%` }}
+                              className="h-full w-full bg-blue-500 origin-left transition-transform duration-500"
+                              style={{ transform: `scaleX(${task.status === 'pending' || task.total <= 0 ? 0 : task.current / task.total})` }}
                             />
                           </div>
                           <span className="text-[8px] font-black text-blue-500 uppercase tracking-tighter">
@@ -456,8 +456,8 @@ export function Exports() {
                         <div className="flex items-center gap-2">
                           <div className="w-16 sm:w-20 h-1.5 bg-white dark:bg-neutral-900 rounded-full overflow-hidden border border-emerald-200 dark:border-emerald-900/40 shadow-inner">
                             <div
-                              className="h-full bg-emerald-500 transition-all duration-500"
-                              style={{ width: driveDelivery?.status === 'pending' ? '5%' : `${driveProgress}%` }}
+                              className="h-full w-full bg-emerald-500 origin-left transition-transform duration-500"
+                              style={{ transform: `scaleX(${driveDelivery?.status === 'pending' ? 0.05 : driveProgress / 100})` }}
                             />
                           </div>
                           <span className="text-[8px] font-black text-emerald-500 uppercase tracking-tighter">
@@ -471,8 +471,8 @@ export function Exports() {
                         <div className="flex items-center gap-2">
                           <div className="w-16 sm:w-20 h-1.5 bg-white dark:bg-neutral-900 rounded-full overflow-hidden border border-pink-200 dark:border-pink-900/40 shadow-inner">
                             <div
-                              className="h-full bg-pink-500 transition-all duration-500"
-                              style={{ width: gumroadDelivery?.status === 'pending' ? '5%' : `${gumroadProgress}%` }}
+                              className="h-full w-full bg-pink-500 origin-left transition-transform duration-500"
+                              style={{ transform: `scaleX(${gumroadDelivery?.status === 'pending' ? 0.05 : gumroadProgress / 100})` }}
                             />
                           </div>
                           <span className="text-[8px] font-black text-pink-500 uppercase tracking-tighter">

--- a/src/pages/QueueMonitor.tsx
+++ b/src/pages/QueueMonitor.tsx
@@ -256,7 +256,7 @@ function ProviderPanel({
               <InfoChip className="text-neutral-500 dark:text-neutral-500">{provider.type}</InfoChip>
             </div>
             <div className="mt-2 h-2 w-48 max-w-full overflow-hidden rounded-full bg-neutral-200 dark:bg-neutral-800">
-              <div className="h-full rounded-full bg-blue-500 transition-all" style={{ width: `${slotPercent}%` }} />
+              <div className="h-full w-full origin-left rounded-full bg-blue-500 transition-transform" style={{ transform: `scaleX(${slotPercent / 100})` }} />
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary

Progress bar fills in three views animated their `width` on every update. Width changes force layout and paint on each tick, and these bars update frequently (export task polling, queue slot polling, campaign progress).

Each fill now renders at full width and is scaled with a left-origin `scaleX()` transform, so updates stay on the compositor.

- [src/pages/Exports.tsx](src/pages/Exports.tsx) — export task, drive upload, and Gumroad publish bars
- [src/pages/QueueMonitor.tsx](src/pages/QueueMonitor.tsx) — provider slot utilization bar
- [src/pages/CampaignDetail.tsx](src/pages/CampaignDetail.tsx) — campaign progress bar

Visual output is unchanged; `transition-all` became `transition-transform` on the bars that animated.

## Notes for reviewers

- These edits predated the branch and were rebased onto current `main`. The export task bar conflicted with the releases rebrand, which had added a `task.total <= 0` divide-by-zero guard — that guard is preserved in the transform version.
- `scaleX` scales the element's border box, so the rounded corners on the `QueueMonitor` fill scale with it. The fill sits inside a `rounded-full` clipping parent, so the visible shape is unaffected.

## Testing

- `npm run lint` — no errors in the three changed files. The 22 errors it reports are pre-existing in `server/` and come from a stale Prisma client plus the not-yet-installed `yauzl` and `megajs` deps, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)