### PR TITLE
Replace viewport breakpoints with container queries for responsive UI

### DIFF
--- a/src/components/ProjectViewer.tsx
+++ b/src/components/ProjectViewer.tsx
@@ -2269,7 +2269,14 @@ export function ProjectViewer({ project, libraries, onUpdate: onUpdateProp, onDe
         onFilesDrop={handleFilesDrop}
       />
 
-      <div className={`flex-1 flex-col overflow-hidden min-h-0 ${mobileView === 'jobs' ? 'flex h-full' : 'hidden'} ${isWorkflowExpanded ? 'lg:hidden' : 'lg:flex'}`}>
+      {/*
+        `@container/pane` makes this column a query container. Everything inside it
+        (toolbars, job rows, the album grid) sizes itself against the pane's own
+        width instead of the viewport — the pane is only ~30% of the window on
+        desktop, so viewport breakpoints would hand it desktop-sized chrome and
+        the toolbar rows would collide.
+      */}
+      <div className={`@container/pane flex-1 flex-col overflow-hidden min-h-0 ${mobileView === 'jobs' ? 'flex h-full' : 'hidden'} ${isWorkflowExpanded ? 'lg:hidden' : 'lg:flex'}`}>
         <div className="p-3 border-b border-neutral-200/50 dark:border-white/5 bg-white/40 dark:bg-black/40 backdrop-blur-3xl shadow-sm flex flex-col gap-3 relative z-10">
           <div className="min-h-[40px] flex items-center justify-center gap-4">
             <div className="flex bg-neutral-100/30 dark:bg-black/40 border border-neutral-200/50 dark:border-white/5 rounded-xl p-1 flex-1 max-w-lg shadow-inner backdrop-blur-md">

--- a/src/components/ProjectViewer/AlbumTab.tsx
+++ b/src/components/ProjectViewer/AlbumTab.tsx
@@ -94,14 +94,14 @@ const AspectRatioFilterControl = memo(function AspectRatioFilterControl({
         onClick={() => setShowAspectRatioFilter((show) => !show)}
         title={t('projectViewer.album.aspectRatioFilter')}
         aria-label={t('projectViewer.album.aspectRatioFilter')}
-        className={`flex items-center justify-center gap-1.5 min-h-8 min-w-8 px-2 sm:px-3 py-1.5 text-[9px] font-black uppercase tracking-widest rounded-lg border transition-all ${
+        className={`flex items-center justify-center gap-1.5 min-h-8 min-w-8 px-2 @min-[56rem]/pane:px-3 py-1.5 text-[9px] font-black uppercase tracking-widest rounded-lg border transition-all ${
           hasAspectRatioFilter
             ? 'bg-blue-500/10 hover:bg-blue-500/20 text-blue-500 border-blue-500/30'
             : 'bg-neutral-900/5 hover:bg-neutral-900/10 text-neutral-700 border-neutral-300 dark:bg-white/5 dark:hover:bg-white/10 dark:text-neutral-200 dark:border-neutral-700'
         }`}
       >
         <Filter className="w-3 h-3" />
-        <span className="hidden sm:inline">
+        <span className="hidden @min-[56rem]/pane:inline">
           {selectedAspectRatios.length === 0
             ? t('projectViewer.album.aspectRatioFilter')
             : t('projectViewer.album.aspectRatioFilterCount', { count: selectedAspectRatios.length })}
@@ -370,8 +370,6 @@ export function AlbumTab({
             totalCount={displayItems.length}
             selectedCount={selectedDisplayItemIds.length}
             onToggleSelectAll={() => toggleSelectAllAlbum(displayItemIds)}
-            mobileSingleLine
-            mobileActionsRight
             prefix={!isTextProject && (
               <div className="flex items-center gap-2 text-[10px] font-bold text-neutral-600 dark:text-neutral-400 uppercase tracking-widest">
                 <Layers className="w-4 h-4 text-blue-500" />
@@ -386,10 +384,10 @@ export function AlbumTab({
                   onClick={() => openExportDialog(!hasVisibleSelection)}
                   title={hasVisibleSelection ? t('projectViewer.album.exportSelected') : t('projectViewer.album.exportAll')}
                   aria-label={hasVisibleSelection ? t('projectViewer.album.exportSelected') : t('projectViewer.album.exportAll')}
-                  className="flex items-center justify-center gap-1.5 min-h-8 min-w-8 px-2 sm:px-3 py-1.5 bg-blue-500/10 hover:bg-blue-500/20 text-blue-500 text-[9px] font-black uppercase tracking-widest rounded-lg border border-blue-500/20 transition-all disabled:opacity-50"
+                  className="flex items-center justify-center gap-1.5 min-h-8 min-w-8 px-2 @min-[56rem]/pane:px-3 py-1.5 bg-blue-500/10 hover:bg-blue-500/20 text-blue-500 text-[9px] font-black uppercase tracking-widest rounded-lg border border-blue-500/20 transition-all disabled:opacity-50"
                 >
                   <FileArchive className="w-3 h-3" />
-                  <span className="hidden sm:inline">
+                  <span className="hidden @min-[56rem]/pane:inline">
                     {hasVisibleSelection ? t('projectViewer.album.exportSelected') : t('projectViewer.album.exportAll')}
                   </span>
                 </button>
@@ -397,10 +395,10 @@ export function AlbumTab({
                   onClick={() => setShowCopyDialog(true)}
                   title={hasVisibleSelection ? t('projectViewer.common.copyToLibrary') : t('projectViewer.album.copyAllToLibrary')}
                   aria-label={hasVisibleSelection ? t('projectViewer.common.copyToLibrary') : t('projectViewer.album.copyAllToLibrary')}
-                  className="flex items-center justify-center gap-1.5 min-h-8 min-w-8 px-2 sm:px-3 py-1.5 bg-purple-500/10 hover:bg-purple-500/20 text-purple-400 text-[9px] font-black uppercase tracking-widest rounded-lg border border-purple-500/20 transition-all"
+                  className="flex items-center justify-center gap-1.5 min-h-8 min-w-8 px-2 @min-[56rem]/pane:px-3 py-1.5 bg-purple-500/10 hover:bg-purple-500/20 text-purple-400 text-[9px] font-black uppercase tracking-widest rounded-lg border border-purple-500/20 transition-all"
                 >
                   <Copy className="w-3 h-3" />
-                  <span className="hidden sm:inline">
+                  <span className="hidden @min-[56rem]/pane:inline">
                     {hasVisibleSelection ? t('projectViewer.common.copyToLibrary') : t('projectViewer.album.copyAllToLibrary')}
                   </span>
                 </button>
@@ -409,10 +407,10 @@ export function AlbumTab({
                     onClick={() => setShowCompareDialog(true)}
                     title={t('projectViewer.album.compareSelected')}
                     aria-label={t('projectViewer.album.compareSelected')}
-                    className="flex items-center justify-center gap-1.5 min-h-8 min-w-8 px-2 sm:px-3 py-1.5 bg-neutral-900/5 hover:bg-neutral-900/10 text-neutral-700 dark:bg-white/5 dark:hover:bg-white/10 dark:text-neutral-200 text-[9px] font-black uppercase tracking-widest rounded-lg border border-neutral-300 dark:border-neutral-700 transition-all"
+                    className="flex items-center justify-center gap-1.5 min-h-8 min-w-8 px-2 @min-[56rem]/pane:px-3 py-1.5 bg-neutral-900/5 hover:bg-neutral-900/10 text-neutral-700 dark:bg-white/5 dark:hover:bg-white/10 dark:text-neutral-200 text-[9px] font-black uppercase tracking-widest rounded-lg border border-neutral-300 dark:border-neutral-700 transition-all"
                   >
                     <Layers className="w-3 h-3" />
-                    <span className="hidden sm:inline">{t('projectViewer.album.compareSelected')}</span>
+                    <span className="hidden @min-[56rem]/pane:inline">{t('projectViewer.album.compareSelected')}</span>
                   </button>
                 )}
                 {hasVisibleSelection && (
@@ -424,10 +422,10 @@ export function AlbumTab({
                     }}
                     title={t('projectViewer.common.deleteSelected')}
                     aria-label={t('projectViewer.common.deleteSelected')}
-                    className="flex items-center justify-center gap-1.5 min-h-8 min-w-8 px-2 sm:px-3 py-1.5 bg-red-500/10 hover:bg-red-500/20 text-red-500 text-[9px] font-black uppercase tracking-widest rounded-lg border border-red-500/20 transition-all"
+                    className="flex items-center justify-center gap-1.5 min-h-8 min-w-8 px-2 @min-[56rem]/pane:px-3 py-1.5 bg-red-500/10 hover:bg-red-500/20 text-red-500 text-[9px] font-black uppercase tracking-widest rounded-lg border border-red-500/20 transition-all"
                   >
                     <Trash2 className="w-3 h-3" />
-                    <span className="hidden sm:inline">{t('projectViewer.common.deleteSelected')}</span>
+                    <span className="hidden @min-[56rem]/pane:inline">{t('projectViewer.common.deleteSelected')}</span>
                   </button>
                 )}
                 {showAspectRatioFilterControl && (
@@ -441,7 +439,7 @@ export function AlbumTab({
                 )}
                 <label
                   title={t('pagination.pageSize')}
-                  className="flex items-center gap-1.5 min-h-8 px-2 sm:px-3 py-1.5 bg-neutral-900/5 hover:bg-neutral-900/10 text-neutral-700 dark:bg-white/5 dark:hover:bg-white/10 dark:text-neutral-200 rounded-lg border border-neutral-300 dark:border-neutral-700 transition-all cursor-pointer"
+                  className="flex items-center gap-1.5 min-h-8 px-2 @min-[56rem]/pane:px-3 py-1.5 bg-neutral-900/5 hover:bg-neutral-900/10 text-neutral-700 dark:bg-white/5 dark:hover:bg-white/10 dark:text-neutral-200 rounded-lg border border-neutral-300 dark:border-neutral-700 transition-all cursor-pointer"
                 >
                   <List className="w-3 h-3" />
                   <span className="sr-only">{t('pagination.pageSize')}</span>
@@ -465,14 +463,14 @@ export function AlbumTab({
                   onClick={() => onSortChange(sort === 'newest' ? 'oldest' : 'newest')}
                   title={sort === 'newest' ? t('projectViewer.album.sortNewest') : t('projectViewer.album.sortOldest')}
                   aria-label={sort === 'newest' ? t('projectViewer.album.sortNewest') : t('projectViewer.album.sortOldest')}
-                  className="flex items-center justify-center gap-1.5 min-h-8 min-w-8 px-2 sm:px-3 py-1.5 bg-neutral-900/5 hover:bg-neutral-900/10 text-neutral-700 dark:bg-white/5 dark:hover:bg-white/10 dark:text-neutral-200 text-[9px] font-black uppercase tracking-widest rounded-lg border border-neutral-300 dark:border-neutral-700 transition-all"
+                  className="flex items-center justify-center gap-1.5 min-h-8 min-w-8 px-2 @min-[56rem]/pane:px-3 py-1.5 bg-neutral-900/5 hover:bg-neutral-900/10 text-neutral-700 dark:bg-white/5 dark:hover:bg-white/10 dark:text-neutral-200 text-[9px] font-black uppercase tracking-widest rounded-lg border border-neutral-300 dark:border-neutral-700 transition-all"
                 >
                   {sort === 'newest' ? (
                     <ArrowDownWideNarrow className="w-3 h-3" />
                   ) : (
                     <ArrowUpWideNarrow className="w-3 h-3" />
                   )}
-                  <span className="hidden sm:inline">
+                  <span className="hidden @min-[56rem]/pane:inline">
                     {sort === 'newest' ? t('projectViewer.album.sortNewest') : t('projectViewer.album.sortOldest')}
                   </span>
                 </button>
@@ -522,11 +520,11 @@ export function AlbumTab({
                       {item.textContent || item.prompt}
                     </p>
                     {(item.imageContexts?.length || 0) > 0 && (
-                      <span className="hidden sm:block flex-shrink-0 text-[9px] font-black uppercase tracking-[0.18em] text-neutral-500 dark:text-neutral-500">
+                      <span className="hidden @min-[56rem]/pane:block flex-shrink-0 text-[9px] font-black uppercase tracking-[0.18em] text-neutral-500 dark:text-neutral-500">
                         {t('projectViewer.album.imageContexts', { count: item.imageContexts?.length || 0 })}
                       </span>
                     )}
-                    <span className="hidden sm:block flex-shrink-0 text-[9px] font-black uppercase tracking-[0.18em] text-blue-400/80">{t('projectViewer.album.view')}</span>
+                    <span className="hidden @min-[56rem]/pane:block flex-shrink-0 text-[9px] font-black uppercase tracking-[0.18em] text-blue-400/80">{t('projectViewer.album.view')}</span>
                   </button>
 
                   {renderReuseButton(item, 'inline')}
@@ -557,7 +555,7 @@ export function AlbumTab({
                   key={item.id}
                   className={`group rounded-card border px-4 py-3 transition-ui backdrop-blur-xl ${isSelected ? 'border-cyan-500/50 bg-cyan-500/10 shadow-lg shadow-cyan-500/10' : 'border-neutral-200/50 dark:border-white/5 bg-white/40 dark:bg-neutral-900/40 hover:border-cyan-500/30'}`}
                 >
-                  <div className="flex items-center gap-2 sm:gap-3">
+                  <div className="flex items-center gap-2 @xl/pane:gap-3">
                     <button
                       onClick={(e) => { e.stopPropagation(); toggleAlbumSelection(item.id, e.shiftKey, displayItemIds); }}
                       className={`flex-shrink-0 w-7 h-7 rounded-lg flex items-center justify-center border transition-all ${isSelected ? 'border-cyan-500 text-cyan-400 bg-cyan-500/10' : 'border-neutral-200 dark:border-neutral-800 text-neutral-600 dark:text-neutral-400 hover:text-neutral-900 dark:hover:text-white hover:border-neutral-400 dark:hover:border-neutral-700'}`}
@@ -577,7 +575,7 @@ export function AlbumTab({
                     </button>
 
                     {item.createdAt && (
-                      <span className="hidden sm:inline flex-shrink-0 text-[9px] font-bold uppercase tracking-widest text-neutral-500 dark:text-neutral-500 whitespace-nowrap">
+                      <span className="hidden @min-[56rem]/pane:inline flex-shrink-0 text-[9px] font-bold uppercase tracking-widest text-neutral-500 dark:text-neutral-500 whitespace-nowrap">
                         {formatAudioTimestamp(item.createdAt)}
                       </span>
                     )}
@@ -670,36 +668,39 @@ export function AlbumTab({
             })}
           </div>
         ) : (
-          <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4 p-4">
+          // Column count follows the pane's width, not the window's. Each step keeps
+          // cards at ~200px or wider — below that the overlay controls and the
+          // metadata rows stop fitting.
+          <div className="grid grid-cols-1 @min-[26rem]/pane:grid-cols-2 @min-[44rem]/pane:grid-cols-3 @min-[60rem]/pane:grid-cols-4 @min-[76rem]/pane:grid-cols-5 @min-[92rem]/pane:grid-cols-6 gap-3 @xl/pane:gap-4 p-3 @xl/pane:p-4">
             {displayItems.map((item, index) => {
               const isSelected = selectedAlbumIds.has(item.id);
               const aspectRatioStr = getCssAspectRatio(item.aspectRatio);
               return (
-                <div key={item.id} id={`album-item-${item.id}`} className={`bg-white/20 dark:bg-black/20 border overflow-hidden flex flex-col group transition-ui duration-300 active:scale-100 rounded-xl border-neutral-200/20 dark:border-white/5 backdrop-blur-md ${isSelected ? 'ring-2 ring-inset ring-blue-500 shadow-xl shadow-blue-500/20 z-10 scale-[1.02]' : 'hover:shadow-2xl hover:z-10 hover:-translate-y-1'}`}>
+                <div key={item.id} id={`album-item-${item.id}`} className={`@container/card bg-white/20 dark:bg-black/20 border overflow-hidden flex flex-col group transition-ui duration-300 active:scale-100 rounded-xl border-neutral-200/20 dark:border-white/5 backdrop-blur-md ${isSelected ? 'ring-2 ring-inset ring-blue-500 shadow-xl shadow-blue-500/20 z-10 scale-[1.02]' : 'hover:shadow-2xl hover:z-10 hover:-translate-y-1'}`}>
                   <div className="bg-neutral-50 dark:bg-neutral-950 relative flex items-center justify-center overflow-hidden" style={{ aspectRatio: aspectRatioStr }}>
                     {/* Selection Overlay */}
-                    <div className={`absolute top-4 left-4 z-20 transition-all opacity-100`}>
+                    <div className="absolute top-2 left-2 @min-[16rem]/card:top-3 @min-[16rem]/card:left-3 z-20 transition-all opacity-100">
                       <button
                         onClick={(e) => { e.stopPropagation(); toggleAlbumSelection(item.id, e.shiftKey, displayItemIds); }}
-                        className={`w-7 h-7 rounded-xl flex items-center justify-center border transition-ui ${isSelected ? 'bg-blue-600 border-blue-500 shadow-lg shadow-blue-500/20' : 'bg-black/60 border-white/20 hover:border-white/40'}`}
+                        className={`w-6 h-6 @min-[16rem]/card:w-7 @min-[16rem]/card:h-7 rounded-lg @min-[16rem]/card:rounded-xl flex items-center justify-center border transition-ui ${isSelected ? 'bg-blue-600 border-blue-500 shadow-lg shadow-blue-500/20' : 'bg-black/60 border-white/20 hover:border-white/40'}`}
                       >
-                        {isSelected && <CheckSquare className="w-4 h-4 text-neutral-900 dark:text-white" />}
-                        {!isSelected && <Square className="w-4 h-4 text-white/40" />}
+                        {isSelected && <CheckSquare className="w-3.5 h-3.5 @min-[16rem]/card:w-4 @min-[16rem]/card:h-4 text-neutral-900 dark:text-white" />}
+                        {!isSelected && <Square className="w-3.5 h-3.5 @min-[16rem]/card:w-4 @min-[16rem]/card:h-4 text-white/40" />}
                       </button>
                     </div>
 
                     {/* Actions Overlay */}
-                    <div className="absolute top-4 right-4 z-20 opacity-100 transition-all flex flex-col gap-2">
+                    <div className="absolute top-2 right-2 @min-[16rem]/card:top-3 @min-[16rem]/card:right-3 z-20 opacity-100 transition-all flex flex-col gap-1.5 @min-[16rem]/card:gap-2">
                       <button
                         onClick={(e) => {
                           e.stopPropagation();
                           setAlbumItemsToDelete([item]);
                           setShowDeleteAlbumModal(true);
                         }}
-                        className="w-7 h-7 rounded-xl bg-red-600/90 border border-red-500/50 flex items-center justify-center text-white hover:bg-red-600 transition-ui shadow-lg"
+                        className="w-6 h-6 @min-[16rem]/card:w-7 @min-[16rem]/card:h-7 rounded-lg @min-[16rem]/card:rounded-xl bg-red-600/90 border border-red-500/50 flex items-center justify-center text-white hover:bg-red-600 transition-ui shadow-lg"
                         title={t('projectViewer.common.delete')}
                       >
-                        <Trash2 className="w-4 h-4" />
+                        <Trash2 className="w-3.5 h-3.5 @min-[16rem]/card:w-4 @min-[16rem]/card:h-4" />
                       </button>
 
                       <a
@@ -707,10 +708,10 @@ export function AlbumTab({
                         target="_blank"
                         rel="noreferrer"
                         onClick={(e) => e.stopPropagation()}
-                        className="w-7 h-7 rounded-xl bg-white/25 border border-white/20 flex items-center justify-center text-neutral-900 dark:text-white hover:bg-white/40 transition-ui shadow-lg"
+                        className="w-6 h-6 @min-[16rem]/card:w-7 @min-[16rem]/card:h-7 rounded-lg @min-[16rem]/card:rounded-xl bg-white/25 border border-white/20 flex items-center justify-center text-neutral-900 dark:text-white hover:bg-white/40 transition-ui shadow-lg"
                         title={t('projectViewer.album.openOriginal')}
                       >
-                        <ExternalLink className="w-4 h-4" />
+                        <ExternalLink className="w-3.5 h-3.5 @min-[16rem]/card:w-4 @min-[16rem]/card:h-4" />
                       </a>
                     </div>
 
@@ -759,27 +760,27 @@ export function AlbumTab({
                         className="absolute inset-0 z-10 flex items-center justify-center pointer-events-auto group/play"
                         title={t('projectViewer.album.playVideo')}
                       >
-                        <div className="w-14 h-14 rounded-full bg-black/60 border border-white/30 flex items-center justify-center shadow-2xl transition-ui group-hover/play:scale-110 group-hover/play:bg-purple-600/70">
-                          <Play className="w-6 h-6 text-neutral-900 dark:text-white fill-white ml-0.5" />
+                        <div className="w-10 h-10 @min-[16rem]/card:w-14 @min-[16rem]/card:h-14 rounded-full bg-black/60 border border-white/30 flex items-center justify-center shadow-2xl transition-ui group-hover/play:scale-110 group-hover/play:bg-purple-600/70">
+                          <Play className="w-4 h-4 @min-[16rem]/card:w-6 @min-[16rem]/card:h-6 text-neutral-900 dark:text-white fill-white ml-0.5" />
                         </div>
                       </button>
                     )}
 
                     {/* Sequential Identifier Overlay */}
-                    <div className="absolute bottom-4 right-4 z-10 px-2 py-0.5 bg-black/70 rounded-lg text-[10px] font-mono text-white/80 border border-white/10 opacity-100 transition-opacity pointer-events-none">
+                    <div className="absolute bottom-2 right-2 @min-[16rem]/card:bottom-3 @min-[16rem]/card:right-3 z-10 px-1.5 @min-[16rem]/card:px-2 py-0.5 bg-black/70 rounded-lg text-[9px] @min-[16rem]/card:text-[10px] font-mono text-white/80 border border-white/10 opacity-100 transition-opacity pointer-events-none">
                       #{(index + 1).toString().padStart(2, '0')}
                     </div>
 
-                    {/* Aspect Ratio + Date Pill */}
+                    {/* Aspect Ratio + Date Pill — capped so it can never run under the #NN pill. */}
                     {(item.aspectRatio || item.createdAt) && (
-                      <div className="absolute bottom-4 left-4 z-10 flex items-center gap-1.5 opacity-100 transition-opacity duration-500 delay-75 pointer-events-none">
+                      <div className="absolute bottom-2 left-2 @min-[16rem]/card:bottom-3 @min-[16rem]/card:left-3 z-10 flex items-center gap-1 @min-[16rem]/card:gap-1.5 max-w-[calc(100%-4.5rem)] opacity-100 transition-opacity duration-500 delay-75 pointer-events-none">
                         {item.aspectRatio && (
-                          <span className="px-2 py-0.5 bg-black/60 rounded-full text-[9px] font-bold text-white/60 border border-white/5 uppercase tracking-widest leading-none">
+                          <span className="px-1.5 @min-[16rem]/card:px-2 py-0.5 bg-black/60 rounded-full text-[9px] font-bold text-white/60 border border-white/5 uppercase tracking-widest leading-none whitespace-nowrap">
                             {item.aspectRatio}
                           </span>
                         )}
                         {item.createdAt && (
-                          <span className="px-2 py-0.5 bg-black/60 rounded-full text-[9px] font-bold text-white/60 border border-white/5 tracking-widest leading-none">
+                          <span className="hidden @min-[15rem]/card:inline px-2 py-0.5 bg-black/60 rounded-full text-[9px] font-bold text-white/60 border border-white/5 tracking-widest leading-none truncate">
                             {new Date(item.createdAt).toLocaleString(undefined, { year: '2-digit', month: '2-digit', day: '2-digit', hour: '2-digit', minute: '2-digit' })}
                           </span>
                         )}
@@ -788,13 +789,13 @@ export function AlbumTab({
 
                     {isSelected && (
                       <div className="absolute inset-0 flex items-center justify-center pointer-events-none bg-blue-500/20">
-                        <CheckCircle2 className="w-14 h-14 text-blue-500 animate-in zoom-in duration-300" />
+                        <CheckCircle2 className="w-10 h-10 @min-[16rem]/card:w-14 @min-[16rem]/card:h-14 text-blue-500 animate-in zoom-in duration-300" />
                       </div>
                     )}
                   </div>
-                  <div className="mt-auto min-h-[160px] flex flex-col bg-white/40 dark:bg-black/40 backdrop-blur-md relative border-t border-neutral-200/50 dark:border-white/5">
-                    <div className="p-5 flex-1 flex flex-col justify-start">
-                    <div className="mb-3 flex items-center gap-1.5">
+                  <div className="mt-auto @min-[16rem]/card:min-h-[160px] flex flex-col bg-white/40 dark:bg-black/40 backdrop-blur-md relative border-t border-neutral-200/50 dark:border-white/5">
+                    <div className="p-3 @min-[16rem]/card:p-4 @min-[20rem]/card:p-5 flex-1 flex flex-col justify-start">
+                    <div className="mb-2 @min-[16rem]/card:mb-3 flex items-center gap-1.5">
                       <h3 className="min-w-0 flex-1 truncate text-[13px] font-black leading-5 text-neutral-900 dark:text-white" title={getAlbumFilename(item)}>
                         {getAlbumFilename(item)}
                       </h3>
@@ -812,7 +813,7 @@ export function AlbumTab({
                     <button
                       type="button"
                       onClick={() => setPromptItem(item)}
-                      className="mb-4 block w-full text-left rounded-xl focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/60 h-10"
+                      className="mb-3 @min-[16rem]/card:mb-4 block w-full text-left rounded-xl focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/60 h-10"
                       title={t('projectViewer.album.viewFullPrompt')}
                     >
                       <p className="text-[11px] leading-relaxed text-neutral-600 dark:text-neutral-400 line-clamp-2 font-medium group-hover:text-neutral-200 transition-colors cursor-pointer hover:text-white">
@@ -820,7 +821,7 @@ export function AlbumTab({
                       </p>
                     </button>
                     <div className="mt-auto flex flex-col items-start gap-2 w-full">
-                      <div className="grid grid-cols-2 gap-1.5 p-1 bg-neutral-50/50 dark:bg-neutral-950/50 rounded-lg border border-neutral-200/50 dark:border-white/5 w-full">
+                      <div className="grid grid-cols-1 @min-[13rem]/card:grid-cols-2 gap-1.5 p-1 bg-neutral-50/50 dark:bg-neutral-950/50 rounded-lg border border-neutral-200/50 dark:border-white/5 w-full">
                         <span className="text-[8px] font-black text-neutral-500 dark:text-neutral-500 uppercase tracking-widest px-1.5 py-0.5 bg-white/50 dark:bg-neutral-900/50 rounded border border-neutral-200/50 dark:border-white/5 text-center truncate" title={getProviderName(item.providerId)}>
                           {getProviderName(item.providerId)}
                         </span>
@@ -829,7 +830,7 @@ export function AlbumTab({
                         </span>
                       </div>
 
-                      <div className="grid grid-cols-3 gap-1 px-1.5 py-1 bg-neutral-50/30 dark:bg-neutral-950/30 rounded-lg border border-neutral-200/30 dark:border-neutral-800/30 w-full">
+                      <div className="grid grid-cols-1 @min-[13rem]/card:grid-cols-3 gap-1 px-1.5 py-1 bg-neutral-50/30 dark:bg-neutral-950/30 rounded-lg border border-neutral-200/30 dark:border-neutral-800/30 w-full">
                         {[
                           { label: t('projectViewer.album.raw'), size: item.size },
                           { label: t('projectViewer.album.optimized'), size: item.optimizedSize },
@@ -846,7 +847,7 @@ export function AlbumTab({
                         ) : <div key={i} />)}
                       </div>
 
-                      <div className="flex justify-between items-center gap-1.5 h-6 w-full">
+                      <div className="flex flex-wrap justify-between items-center gap-1.5 min-h-6 w-full">
                         {item.resolution && (
                           <span className="flex-1 flex items-center justify-center px-2 text-[9px] font-bold text-neutral-500 dark:text-neutral-500 bg-neutral-50/30 dark:bg-neutral-950/30 rounded-md border border-neutral-200/50 dark:border-white/5 uppercase tracking-widest truncate">
                             {item.resolution}

--- a/src/components/ProjectViewer/CompletedTab.tsx
+++ b/src/components/ProjectViewer/CompletedTab.tsx
@@ -67,8 +67,6 @@ export function CompletedTab({
             selectedCount={selectedCompletedIds.size}
             accentColor="emerald"
             onToggleSelectAll={toggleSelectAllCompleted}
-            mobileSingleLine
-            mobileActionsRight
             rightActions={
               <>
                 {selectedCompletedIds.size > 0 && (
@@ -76,20 +74,20 @@ export function CompletedTab({
                     onClick={() => setShowDeleteSelectedModal(true)}
                     title={t('projectViewer.common.deleteSelected')}
                     aria-label={t('projectViewer.common.deleteSelected')}
-                    className="flex items-center justify-center gap-1.5 min-h-8 min-w-8 px-2 sm:px-3 py-1.5 bg-red-500/10 hover:bg-red-500/20 text-red-500 text-[9px] font-black uppercase tracking-widest rounded-lg border border-red-500/20 transition-all"
+                    className="flex items-center justify-center gap-1.5 min-h-8 min-w-8 px-2 @min-[56rem]/pane:px-3 py-1.5 bg-red-500/10 hover:bg-red-500/20 text-red-500 text-[9px] font-black uppercase tracking-widest rounded-lg border border-red-500/20 transition-all"
                   >
                     <Trash2 className="w-3 h-3" />
-                    <span className="hidden sm:inline">{t('projectViewer.common.deleteSelected')}</span>
+                    <span className="hidden @min-[56rem]/pane:inline">{t('projectViewer.common.deleteSelected')}</span>
                   </button>
                 )}
                 <button
                   onClick={() => onSortChange(sort === 'newest' ? 'oldest' : 'newest')}
                   title={sort === 'newest' ? t('projectViewer.album.sortNewest') : t('projectViewer.album.sortOldest')}
                   aria-label={sort === 'newest' ? t('projectViewer.album.sortNewest') : t('projectViewer.album.sortOldest')}
-                  className="flex items-center justify-center gap-1.5 min-h-8 min-w-8 px-2 sm:px-3 py-1.5 bg-neutral-900/5 hover:bg-neutral-900/10 text-neutral-700 dark:bg-white/5 dark:hover:bg-white/10 dark:text-neutral-200 text-[9px] font-black uppercase tracking-widest rounded-lg border border-neutral-300 dark:border-neutral-700 transition-all"
+                  className="flex items-center justify-center gap-1.5 min-h-8 min-w-8 px-2 @min-[56rem]/pane:px-3 py-1.5 bg-neutral-900/5 hover:bg-neutral-900/10 text-neutral-700 dark:bg-white/5 dark:hover:bg-white/10 dark:text-neutral-200 text-[9px] font-black uppercase tracking-widest rounded-lg border border-neutral-300 dark:border-neutral-700 transition-all"
                 >
                   {sort === 'newest' ? <ArrowDownWideNarrow className="w-3 h-3" /> : <ArrowUpWideNarrow className="w-3 h-3" />}
-                  <span className="hidden sm:inline">
+                  <span className="hidden @min-[56rem]/pane:inline">
                     {sort === 'newest' ? t('projectViewer.album.sortNewest') : t('projectViewer.album.sortOldest')}
                   </span>
                 </button>
@@ -153,7 +151,7 @@ export function CompletedTab({
                       {job.imageContexts && job.imageContexts.length > 0 && (
                         <div className="space-y-3">
                             <label className="text-[9px] font-black uppercase tracking-[0.1em] text-neutral-600 px-1">{t('projectViewer.queue.visualContexts')}</label>
-                            <div className="grid grid-cols-4 sm:grid-cols-6 md:grid-cols-8 gap-3">
+                            <div className="grid grid-cols-3 @md/pane:grid-cols-4 @2xl/pane:grid-cols-6 @4xl/pane:grid-cols-8 gap-3">
                               {job.imageContexts.map((ctx, idx) => (
                                 <div key={idx} className="group/ctx relative aspect-square rounded-xl overflow-hidden bg-neutral-50 dark:bg-neutral-950 border border-neutral-200 dark:border-neutral-800 shadow-sm transition-all hover:scale-110 hover:shadow-xl hover:z-10 hover:border-emerald-500/50">
                                   <img 
@@ -177,7 +175,7 @@ export function CompletedTab({
                       {job.videoContexts && job.videoContexts.length > 0 && (
                         <div className="space-y-3">
                           <label className="text-[9px] font-black uppercase tracking-[0.1em] text-violet-300/70 px-1">Reference Videos</label>
-                          <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+                          <div className="grid grid-cols-1 @2xl/pane:grid-cols-2 gap-3">
                             {job.videoContexts.map((ctx, idx) => (
                               <video key={idx} src={imageDisplayUrl(ctx)} controls className="w-full rounded-lg border border-neutral-200 dark:border-neutral-800 bg-black" />
                             ))}

--- a/src/components/ProjectViewer/DraftsTab.tsx
+++ b/src/components/ProjectViewer/DraftsTab.tsx
@@ -60,9 +60,9 @@ export function DraftsTab({
   const displayAlbumItems = albumItems.slice(0, 5);
 
   const StackedGallery = () => (
-    <div className="min-h-full py-12 md:py-20 flex flex-col items-center justify-center animate-in fade-in zoom-in duration-1000">
+    <div className="min-h-full py-12 @2xl/pane:py-20 flex flex-col items-center justify-center animate-in fade-in zoom-in duration-1000">
       {projectType !== 'text' && projectType !== 'audio' && (
-        <div className="relative w-64 h-64 md:w-80 md:h-80 mb-12 group cursor-pointer" onClick={onSwitchToAlbum}>
+        <div className="relative w-56 h-56 @xl/pane:w-64 @xl/pane:h-64 @3xl/pane:w-80 @3xl/pane:h-80 mb-12 group cursor-pointer" onClick={onSwitchToAlbum}>
           {displayAlbumItems.map((item, idx) => {
             const rotations = [-6, 4, -2, 5, -3];
             const xOffsets = [-20, 15, -5, 25, -10];
@@ -96,7 +96,7 @@ export function DraftsTab({
         </div>
       )}
 
-      <div className="w-full max-w-xl mx-auto px-4 sm:px-6 text-center space-y-4 flex flex-col items-center">
+      <div className="w-full max-w-xl mx-auto px-4 @xl/pane:px-6 text-center space-y-4 flex flex-col items-center">
         <h3 className="text-lg font-black text-neutral-900 dark:text-white uppercase tracking-widest bg-gradient-to-r from-blue-400 to-emerald-400 bg-clip-text text-transparent">
           {displayAlbumItems.length > 0 ? projectName : t('projectViewer.drafts.emptyCanvas')}
         </h3>
@@ -134,19 +134,17 @@ export function DraftsTab({
               totalCount={draftJobs.length}
               selectedCount={selectedDraftIds.size}
               onToggleSelectAll={toggleSelectAllDrafts}
-              mobileSingleLine
-              mobileActionsRight
               rightActions={
                 <>
                 <button
                   onClick={selectedDraftIds.size > 0 ? () => setShowDeleteSelectedModal(true) : () => setShowDeleteAllDraftsModal(true)}
                   disabled={isStartingDrafts}
-                  className="flex items-center justify-center gap-1.5 min-h-8 min-w-8 px-2 sm:px-3 py-1.5 bg-red-500/10 hover:bg-red-500/20 text-red-500 text-[9px] font-black uppercase tracking-widest rounded-lg border border-red-500/20 transition-all"
+                  className="flex items-center justify-center gap-1.5 min-h-8 min-w-8 px-2 @min-[56rem]/pane:px-3 py-1.5 bg-red-500/10 hover:bg-red-500/20 text-red-500 text-[9px] font-black uppercase tracking-widest rounded-lg border border-red-500/20 transition-all"
                   title={selectedDraftIds.size > 0 ? t('projectViewer.common.deleteSelected') : t('projectViewer.drafts.deleteAllDrafts')}
                   aria-label={selectedDraftIds.size > 0 ? t('projectViewer.common.deleteSelected') : t('projectViewer.drafts.deleteAllDrafts')}
                 >
                   <Trash2 className="w-3 h-3" />
-                  <span className="hidden sm:inline">
+                  <span className="hidden @min-[56rem]/pane:inline">
                     {selectedDraftIds.size > 0 ? t('projectViewer.common.deleteSelected') : t('projectViewer.common.deleteAll')}
                   </span>
                 </button>
@@ -155,12 +153,12 @@ export function DraftsTab({
                   disabled={isStartingDrafts}
                   title={selectedDraftIds.size > 0 ? t('projectViewer.drafts.startSelected') : t('projectViewer.drafts.startAllNow')}
                   aria-label={selectedDraftIds.size > 0 ? t('projectViewer.drafts.startSelected') : t('projectViewer.drafts.startAllNow')}
-                  className="flex items-center justify-center gap-1.5 min-h-8 min-w-8 px-2 sm:px-3 py-1.5 bg-blue-500/10 hover:bg-blue-500/20 text-blue-500 text-[9px] font-black uppercase tracking-widest rounded-lg border border-blue-500/20 transition-all disabled:cursor-wait disabled:opacity-70"
+                  className="flex items-center justify-center gap-1.5 min-h-8 min-w-8 px-2 @min-[56rem]/pane:px-3 py-1.5 bg-blue-500/10 hover:bg-blue-500/20 text-blue-500 text-[9px] font-black uppercase tracking-widest rounded-lg border border-blue-500/20 transition-all disabled:cursor-wait disabled:opacity-70"
                 >
                   {isStartingDrafts
                     ? <Loader2 className="w-3 h-3 animate-spin" />
                     : <Play className="w-3 h-3 fill-current" />}
-                  <span className="hidden sm:inline">
+                  <span className="hidden @min-[56rem]/pane:inline">
                     {isStartingDrafts
                       ? t('projectViewer.drafts.starting', { defaultValue: 'Starting…' })
                       : selectedDraftIds.size > 0
@@ -263,7 +261,7 @@ export function DraftsTab({
                       {task.imageContexts && task.imageContexts.length > 0 && (
                         <div className="space-y-3">
                             <label className="text-[9px] font-black uppercase tracking-[0.2em] text-neutral-600 px-1">{t('projectViewer.queue.visualContexts')}</label>
-                            <div className="grid grid-cols-4 sm:grid-cols-6 md:grid-cols-8 gap-3">
+                            <div className="grid grid-cols-3 @md/pane:grid-cols-4 @2xl/pane:grid-cols-6 @4xl/pane:grid-cols-8 gap-3">
                               {task.imageContexts.map((ctx, idx) => (
                                 <div key={idx} className="group/ctx relative aspect-square rounded-xl overflow-hidden bg-neutral-50 dark:bg-neutral-950 border border-neutral-200 dark:border-neutral-800 shadow-sm transition-all hover:scale-110 hover:shadow-xl hover:z-10 hover:border-blue-500/50">
                                   <img 
@@ -287,7 +285,7 @@ export function DraftsTab({
                       {task.videoContexts && task.videoContexts.length > 0 && (
                         <div className="space-y-3">
                           <label className="text-[9px] font-black uppercase tracking-[0.2em] text-violet-300/70">Reference Videos</label>
-                          <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+                          <div className="grid grid-cols-1 @2xl/pane:grid-cols-2 gap-3">
                             {task.videoContexts.map((ctx, idx) => (
                               <video key={idx} src={imageDisplayUrl(ctx)} controls className="w-full rounded-lg border border-neutral-200 dark:border-neutral-800 bg-black" />
                             ))}

--- a/src/components/ProjectViewer/JobListItem.tsx
+++ b/src/components/ProjectViewer/JobListItem.tsx
@@ -74,7 +74,7 @@ export function JobListItem({
   return (
     <div className="flex flex-col gap-0 animate-in fade-in slide-in-from-top-2 duration-300 border-b border-neutral-200/50 dark:border-neutral-800/50">
       <div
-        className={`bg-white/10 dark:bg-black/10 backdrop-blur-sm flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between transition-ui cursor-pointer group/task p-3 lg:py-2.5 rounded-none border-0 ${headerClassName}`}
+        className={`bg-white/10 dark:bg-black/10 backdrop-blur-sm flex flex-col gap-3 @lg/pane:flex-row @lg/pane:items-center @lg/pane:justify-between transition-ui cursor-pointer group/task p-3 @lg/pane:py-2.5 rounded-none border-0 ${headerClassName}`}
         onClick={() => onToggleExpand(job.id)}
       >
         <div className="flex items-center gap-3 flex-1 min-w-0">
@@ -97,10 +97,10 @@ export function JobListItem({
           </span>
         </div>
 
-        <div className="flex flex-col gap-2 pl-10 sm:pl-0 lg:pl-0 lg:items-end lg:flex-shrink-0">
+        <div className="flex flex-col gap-2 pl-10 @lg/pane:pl-0 @lg/pane:items-end @lg/pane:flex-shrink-0">
           {(providerName || modelName) && (
-            <div className="flex items-center lg:hidden">
-              <InfoChip className="max-w-[9rem] sm:max-w-none gap-1">
+            <div className="flex items-center @lg/pane:hidden">
+              <InfoChip className="max-w-[9rem] @md/pane:max-w-none gap-1">
                 {providerName && (
                   <span className="truncate leading-none text-neutral-500 dark:text-neutral-500">
                     {providerName}
@@ -116,9 +116,9 @@ export function JobListItem({
             </div>
           )}
 
-          <div className="flex items-center gap-2 lg:flex-wrap lg:justify-end">
+          <div className="flex items-center gap-2 @lg/pane:flex-wrap @lg/pane:justify-end">
             {(providerName || modelName) && (
-              <div className="hidden lg:flex items-center">
+              <div className="hidden @lg/pane:flex items-center">
                 <InfoChip className="max-w-none gap-1">
                   {providerName && (
                     <span className="truncate leading-none text-neutral-500 dark:text-neutral-500">

--- a/src/components/ProjectViewer/PaginationBar.tsx
+++ b/src/components/ProjectViewer/PaginationBar.tsx
@@ -33,7 +33,7 @@ export function PaginationBar({
   const endIndex = Math.min(total, safePage * pageSize);
 
   return (
-    <div className="flex flex-col items-center gap-3 border-t border-neutral-200 dark:border-neutral-800 bg-white/40 dark:bg-neutral-950/40 px-3 py-3 sm:flex-row sm:flex-wrap sm:items-center sm:justify-between sm:px-4">
+    <div className="flex flex-col items-center gap-3 border-t border-neutral-200 dark:border-neutral-800 bg-white/40 dark:bg-neutral-950/40 px-3 py-3 @xl/pane:flex-row @xl/pane:flex-wrap @xl/pane:items-center @xl/pane:justify-between @xl/pane:px-4">
       <div className="flex items-center gap-2 text-[10px] font-black uppercase tracking-widest text-neutral-500 dark:text-neutral-500">
         <span>{t('pagination.range', { start: startIndex, end: endIndex, total })}</span>
       </div>
@@ -47,7 +47,7 @@ export function PaginationBar({
               const v = e.target.value;
               onPageSizeChange(v === 'all' ? 'all' : Number(v));
             }}
-            className="rounded-lg border border-neutral-300 dark:border-neutral-700 bg-white/60 dark:bg-neutral-900/60 px-2 py-1.5 sm:py-1 text-[10px] font-black text-neutral-700 dark:text-neutral-200 focus:outline-none focus:border-blue-500"
+            className="rounded-lg border border-neutral-300 dark:border-neutral-700 bg-white/60 dark:bg-neutral-900/60 px-2 py-1.5 @xl/pane:py-1 text-[10px] font-black text-neutral-700 dark:text-neutral-200 focus:outline-none focus:border-blue-500"
           >
             {PAGE_SIZE_OPTIONS.map((opt) => (
               <option key={String(opt)} value={String(opt)}>

--- a/src/components/ProjectViewer/QueueTab.tsx
+++ b/src/components/ProjectViewer/QueueTab.tsx
@@ -59,8 +59,6 @@ export function QueueTab({
               totalCount={queueJobs.length}
               selectedCount={selectedQueueIds.size}
               onToggleSelectAll={toggleSelectAllQueue}
-              mobileSingleLine
-              mobileActionsRight
               rightActions={
                 <>
                 {selectedQueueIds.size > 0 && (
@@ -69,10 +67,10 @@ export function QueueTab({
                     disabled={isRetryingQueue}
                     title={t('projectViewer.common.delete')}
                     aria-label={t('projectViewer.common.delete')}
-                    className="flex items-center justify-center gap-1.5 min-h-8 min-w-8 px-2 sm:px-3 py-1.5 bg-red-500/10 hover:bg-red-500/20 text-red-500 text-[9px] font-black uppercase tracking-widest rounded-lg border border-red-500/20 transition-all"
+                    className="flex items-center justify-center gap-1.5 min-h-8 min-w-8 px-2 @min-[56rem]/pane:px-3 py-1.5 bg-red-500/10 hover:bg-red-500/20 text-red-500 text-[9px] font-black uppercase tracking-widest rounded-lg border border-red-500/20 transition-all"
                   >
                     <Trash2 className="w-3 h-3" />
-                    <span className="hidden sm:inline">{t('projectViewer.common.delete')}</span>
+                    <span className="hidden @min-[56rem]/pane:inline">{t('projectViewer.common.delete')}</span>
                   </button>
                 )}
                 {queueJobs.some(j => selectedQueueIds.has(j.id) && j.status === 'failed') && (
@@ -81,12 +79,12 @@ export function QueueTab({
                     disabled={isRetryingQueue}
                     title={t('projectViewer.queue.retry')}
                     aria-label={t('projectViewer.queue.retry')}
-                    className="flex items-center justify-center gap-1.5 min-h-8 min-w-8 px-2 sm:px-3 py-1.5 bg-blue-500/10 hover:bg-blue-500/20 text-blue-500 text-[9px] font-black uppercase tracking-widest rounded-lg border border-blue-500/20 transition-all"
+                    className="flex items-center justify-center gap-1.5 min-h-8 min-w-8 px-2 @min-[56rem]/pane:px-3 py-1.5 bg-blue-500/10 hover:bg-blue-500/20 text-blue-500 text-[9px] font-black uppercase tracking-widest rounded-lg border border-blue-500/20 transition-all"
                   >
                     {isRetryingQueueBatch
                       ? <Loader2 className="w-3 h-3 animate-spin" />
                       : <Play className="w-3 h-3 fill-current" />}
-                    <span className="hidden sm:inline">
+                    <span className="hidden @min-[56rem]/pane:inline">
                       {isRetryingQueueBatch
                         ? t('projectViewer.queue.retrying')
                         : t('projectViewer.queue.retry')}
@@ -99,7 +97,7 @@ export function QueueTab({
                     disabled={isRetryingQueue}
                     title={t('projectViewer.queue.clearAllFailed')}
                     aria-label={t('projectViewer.queue.clearAllFailed')}
-                    className="flex items-center justify-center gap-1.5 min-h-8 min-w-8 px-2 sm:px-3 py-1.5 bg-red-500/10 hover:bg-red-500/20 text-red-400 text-[9px] font-black uppercase tracking-widest rounded-lg border border-red-500/20 transition-all"
+                    className="flex items-center justify-center gap-1.5 min-h-8 min-w-8 px-2 @min-[56rem]/pane:px-3 py-1.5 bg-red-500/10 hover:bg-red-500/20 text-red-400 text-[9px] font-black uppercase tracking-widest rounded-lg border border-red-500/20 transition-all"
                   >
                     <BrushCleaning className="w-3 h-3" />
                     <span>{t('projectViewer.queue.clearAllFailed')}</span>
@@ -208,7 +206,7 @@ export function QueueTab({
                       {task.imageContexts && task.imageContexts.length > 0 && (
                         <div className="space-y-3">
                             <label className="text-[9px] font-black uppercase tracking-[0.1em] text-neutral-600 px-1">{t('projectViewer.queue.visualContexts')}</label>
-                            <div className="grid grid-cols-4 sm:grid-cols-6 md:grid-cols-8 gap-3">
+                            <div className="grid grid-cols-3 @md/pane:grid-cols-4 @2xl/pane:grid-cols-6 @4xl/pane:grid-cols-8 gap-3">
                               {task.imageContexts.map((ctx, idx) => (
                                 <div key={idx} className="group/ctx relative aspect-square rounded-xl overflow-hidden bg-neutral-50 dark:bg-neutral-950 border border-neutral-200 dark:border-neutral-800 shadow-sm transition-all hover:scale-110 hover:shadow-xl hover:z-10 hover:border-blue-500/50">
                                   <img 
@@ -232,7 +230,7 @@ export function QueueTab({
                       {task.videoContexts && task.videoContexts.length > 0 && (
                         <div className="space-y-3">
                           <label className="text-[9px] font-black uppercase tracking-[0.1em] text-violet-300/70 px-1">Reference Videos</label>
-                          <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+                          <div className="grid grid-cols-1 @2xl/pane:grid-cols-2 gap-3">
                             {task.videoContexts.map((ctx, idx) => (
                               <video key={idx} src={imageDisplayUrl(ctx)} controls className="w-full rounded-lg border border-neutral-200 dark:border-neutral-800 bg-black" />
                             ))}

--- a/src/components/ProjectViewer/SelectionToolbar.tsx
+++ b/src/components/ProjectViewer/SelectionToolbar.tsx
@@ -31,15 +31,11 @@ interface SelectionToolbarProps {
    * separated by a vertical divider (e.g. AlbumTab's item count + MB display).
    */
   prefix?: React.ReactNode;
-  /** Keep the mobile toolbar on a single row for compact icon-first action sets. */
-  mobileSingleLine?: boolean;
-  /** Push mobile action buttons to the right edge while keeping desktop layout unchanged. */
-  mobileActionsRight?: boolean;
 }
 
-/** A thin vertical divider — hidden on small screens so it never orphans on a wrapped line. */
+/** A thin vertical divider — only shown once the pane is wide enough for labelled buttons. */
 function Divider() {
-  return <div className="hidden lg:block h-4 w-px bg-neutral-200 dark:bg-neutral-800 flex-shrink-0" />;
+  return <div className="hidden @min-[56rem]/pane:block h-4 w-px bg-neutral-200 dark:bg-neutral-800 flex-shrink-0" />;
 }
 
 export function SelectionToolbar({
@@ -51,8 +47,6 @@ export function SelectionToolbar({
   zeroSelectionActions,
   rightActions,
   prefix,
-  mobileSingleLine = false,
-  mobileActionsRight = false,
 }: SelectionToolbarProps) {
   const { t } = useTranslation();
 
@@ -60,18 +54,13 @@ export function SelectionToolbar({
     accentColor === 'emerald' ? 'text-emerald-500' : 'text-blue-500';
 
   return (
-    <div
-      className={`sticky top-0 z-20 flex justify-between bg-white/40 dark:bg-black/40 backdrop-blur-2xl border border-neutral-200/50 dark:border-white/5 gap-2 sm:gap-3 shadow-lg shadow-black/5 dark:shadow-black/20 p-3 rounded-none border-x-0 border-t-0 ${
-        mobileSingleLine ? 'flex-row items-center' : 'flex-col lg:flex-row lg:items-center'
-      }`}
-    >
-      <div
-        className={`flex items-center min-w-0 gap-1.5 sm:gap-x-3 sm:gap-y-2 ${
-          mobileSingleLine ? 'flex-nowrap min-w-0' : 'flex-wrap'
-        }`}
-      >
+    // Everything here wraps. Buttons keep their intrinsic width (flex-shrink-0), so a
+    // no-wrap row would let the two groups slide over each other once the pane got
+    // narrow; wrapping makes an overflow impossible at any width.
+    <div className="sticky top-0 z-20 flex flex-wrap items-center justify-between bg-white/40 dark:bg-black/40 backdrop-blur-2xl border border-neutral-200/50 dark:border-white/5 gap-x-2 gap-y-2 @min-[56rem]/pane:gap-x-3 shadow-lg shadow-black/5 dark:shadow-black/20 p-2 @min-[56rem]/pane:p-3 rounded-none border-x-0 border-t-0">
+      <div className="flex flex-wrap items-center min-w-0 gap-1.5 @min-[56rem]/pane:gap-x-3 @min-[56rem]/pane:gap-y-2">
         {prefix && (
-          <div className="hidden sm:flex items-center gap-2 flex-shrink-0">
+          <div className="hidden @xl/pane:flex items-center gap-2 flex-shrink-0">
             {prefix}
             <Divider />
           </div>
@@ -81,31 +70,28 @@ export function SelectionToolbar({
           onClick={onToggleSelectAll}
           title={t('projectViewer.common.selectAll')}
           aria-label={t('projectViewer.common.selectAll')}
-          className="flex items-center justify-start gap-3 min-h-8 p-1 rounded-lg text-[10px] font-bold text-neutral-600 dark:text-neutral-400 hover:text-white uppercase tracking-widest transition-colors flex-shrink-0"
+          className="flex items-center justify-start gap-2 @min-[56rem]/pane:gap-3 min-h-8 p-1 rounded-lg text-[10px] font-bold text-neutral-600 dark:text-neutral-400 hover:text-white uppercase tracking-widest transition-colors flex-shrink-0"
         >
           {selectedCount === totalCount && totalCount > 0 ? (
-            <CheckSquare className={`w-4 h-4 sm:w-4 sm:h-4 ${checkIconClass}`} />
+            <CheckSquare className={`w-4 h-4 ${checkIconClass}`} />
           ) : (
-            <Square className="w-4 h-4 sm:w-4 sm:h-4" />
+            <Square className="w-4 h-4" />
           )}
-          <span className="hidden sm:inline whitespace-nowrap">{t('projectViewer.common.selectAll')}</span>
+          <span className="hidden @min-[56rem]/pane:inline whitespace-nowrap">{t('projectViewer.common.selectAll')}</span>
         </button>
 
-        <span className="text-[10px] font-bold text-neutral-500 dark:text-neutral-500 uppercase tracking-widest whitespace-nowrap flex-shrink-0 sm:hidden">
+        {/* Compact stand-in for the "N selected" label while the pane is too narrow for it. */}
+        <span className="text-[10px] font-bold text-neutral-500 dark:text-neutral-500 uppercase tracking-widest whitespace-nowrap flex-shrink-0 @min-[56rem]/pane:hidden">
           {selectedCount > 0 ? `${selectedCount}/${totalCount}` : `${totalCount}`}
         </span>
 
         {selectedCount > 0 && (
           <>
             <Divider />
-            <span className="hidden sm:inline text-[10px] font-bold text-neutral-500 dark:text-neutral-500 uppercase tracking-widest flex-shrink-0 whitespace-nowrap">
+            <span className="hidden @min-[56rem]/pane:inline text-[10px] font-bold text-neutral-500 dark:text-neutral-500 uppercase tracking-widest flex-shrink-0 whitespace-nowrap">
               {t('projectViewer.common.selectedCount', { count: selectedCount })}
             </span>
-            <div
-              className={`flex items-center gap-1.5 sm:gap-2 flex-shrink-0 ${
-                mobileActionsRight ? 'ml-auto sm:ml-0' : ''
-              }`}
-            >
+            <div className="flex flex-wrap items-center gap-1.5 @min-[56rem]/pane:gap-2 min-w-0">
               {selectionActions}
             </div>
           </>
@@ -114,11 +100,7 @@ export function SelectionToolbar({
         {selectedCount === 0 && zeroSelectionActions && (
           <>
             <Divider />
-            <div
-              className={`flex items-center gap-1.5 sm:gap-2 flex-shrink-0 ${
-                mobileActionsRight ? 'ml-auto sm:ml-0' : ''
-              }`}
-            >
+            <div className="flex flex-wrap items-center gap-1.5 @min-[56rem]/pane:gap-2 min-w-0">
               {zeroSelectionActions}
             </div>
           </>
@@ -127,13 +109,7 @@ export function SelectionToolbar({
 
       {/* Right group */}
       {rightActions && (
-        <div
-          className={`flex items-center gap-1.5 sm:gap-2 flex-shrink-0 ${
-            mobileSingleLine
-              ? 'ml-auto flex-nowrap'
-              : 'ml-auto flex-wrap w-full pt-2 border-t border-neutral-200/50 dark:border-neutral-800/50 lg:w-auto lg:pt-0 lg:border-none'
-          }`}
-        >
+        <div className="flex flex-wrap items-center justify-end gap-1.5 @min-[56rem]/pane:gap-2 ml-auto min-w-0">
           {rightActions}
         </div>
       )}

--- a/src/components/ProjectViewer/SettingsPanel.tsx
+++ b/src/components/ProjectViewer/SettingsPanel.tsx
@@ -452,7 +452,7 @@ export function SettingsPanel({
                   </div>
 
                   {audioConfig.mode === 'multi' && (
-                    <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+                    <div className="grid grid-cols-1 @lg/panel:grid-cols-2 gap-3">
                       <div className="space-y-2.5">
                         <label className="text-[9px] font-black uppercase tracking-widest text-neutral-600 block px-1">
                           {t('projectViewer.settings.speakerOneName')}
@@ -496,7 +496,7 @@ export function SettingsPanel({
                     </div>
                   )}
 
-                  <div className={`grid grid-cols-1 gap-3 ${audioConfig.mode === 'multi' ? 'md:grid-cols-2' : ''}`}>
+                  <div className={`grid grid-cols-1 gap-3 ${audioConfig.mode === 'multi' ? '@lg/panel:grid-cols-2' : ''}`}>
                     <div className="space-y-2.5">
                       <label className="text-[9px] font-black uppercase tracking-widest text-neutral-600 block px-1">
                         {audioConfig.mode === 'multi' ? t('projectViewer.settings.speakerOneVoice') : t('projectViewer.settings.voice')}

--- a/src/components/ProjectViewer/WorkflowPanel.tsx
+++ b/src/components/ProjectViewer/WorkflowPanel.tsx
@@ -214,7 +214,7 @@ export function WorkflowPanel({
 
   return (
     <div
-      className={`w-full ${isExpanded ? 'lg:flex-1 lg:w-auto lg:min-w-0' : 'lg:w-96'} lg:h-full min-h-0 overflow-hidden border-b lg:border-b-0 lg:border-r border-neutral-200/50 dark:border-white/5 bg-white/30 dark:bg-black/30 backdrop-blur-3xl flex-col flex-shrink-0 relative ${mobileView === 'workflow' ? 'flex h-full' : 'hidden lg:flex'}`}
+      className={`@container/panel w-full ${isExpanded ? 'lg:flex-1 lg:w-auto lg:min-w-0' : 'lg:w-96'} lg:h-full min-h-0 overflow-hidden border-b lg:border-b-0 lg:border-r border-neutral-200/50 dark:border-white/5 bg-white/30 dark:bg-black/30 backdrop-blur-3xl flex-col flex-shrink-0 relative ${mobileView === 'workflow' ? 'flex h-full' : 'hidden lg:flex'}`}
       onDragOver={handlePanelDragOver}
       onDragLeave={handlePanelDragLeave}
       onDrop={handlePanelDrop}


### PR DESCRIPTION
## Summary
Migrated the ProjectViewer and related components from viewport-based (`sm:`, `md:`, `lg:`) Tailwind breakpoints to container queries (`@min-[]/pane:`, `@xl/pane:`, `@container/card:`, etc.). This enables UI elements to respond to their container&#39;s width rather than the window width, providing better responsiveness in the narrow side panel layout where the pane is only ~30% of the viewport on desktop.

## Key Changes

- **Container Query Setup**: Added `@container/pane` to the main jobs panel div in `ProjectViewer.tsx` to establish it as a query container, allowing all child components to use pane-relative breakpoints
- **Toolbar Responsiveness**: Updated `SelectionToolbar.tsx` to use container queries and removed `mobileSingleLine` and `mobileActionsRight` props that are no longer needed with flexible wrapping layouts
- **Album Grid**: Converted grid column counts from viewport-based (`sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4`) to container-relative (`@min-[26rem]/pane:grid-cols-2 @min-[44rem]/pane:grid-cols-3` etc.), with each breakpoint maintaining ~200px minimum card width
- **Card-Level Queries**: Added `@container/card` to individual album cards to enable responsive sizing of overlays, buttons, and icons within each card
- **Button &amp; Icon Scaling**: Updated button padding and icon sizes to scale with container width (e.g., `px-2 @min-[56rem]/pane:px-3`, `w-6 h-6 @min-[16rem]/card:w-7 @min-[16rem]/card:h-7`)
- **Text Visibility**: Replaced `hidden sm:inline` patterns with `hidden @min-[56rem]/pane:inline` to show/hide button labels based on pane width
- **Consistent Updates**: Applied the same container query pattern across all tabs (AlbumTab, DraftsTab, QueueTab, CompletedTab) and supporting components (JobListItem, PaginationBar, SettingsPanel, WorkflowPanel)

## Implementation Details

- Container queries use pane-relative breakpoints (e.g., `@min-[56rem]/pane:`) for most UI elements, with a few using `@xl/pane:` for larger breakpoints
- The grid layout now scales from 1 column at narrow widths up to 6 columns at very wide panes, with each step maintaining usable card dimensions
- Removed hardcoded mobile-specific behavior props in favor of responsive classes that naturally adapt to available space
- All spacing, padding, and sizing adjustments are now relative to the container rather than the viewport, ensuring consistent proportions regardless of window size
