### PR TITLE
Add batch set text action for campaigns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Remix Studio are documented here by version number.
 
+## [Unreleased]
+
+### Added
+
+- **Batch Set Post Text**: Campaign Batch Actions could only fill post text through the model — useful when each post needs its own wording, wasteful when they should all carry the same caption. A **Set Text** action next to AI Generate takes one block of text and writes it to every selected post in a single request, with no provider, prompt, or background task involved. Existing text on those posts is replaced, and posts that no longer exist are reported as skipped the way the other batch operations report them.
+
 ## [1.20.0] - 2026-08-08
 
 ### Added

--- a/docs-site/concepts/campaigns.md
+++ b/docs-site/concepts/campaigns.md
@@ -63,6 +63,7 @@ The campaign Batch Actions view supports searchable, paginated post selection an
 - Batch unschedule, which returns scheduled posts to draft.
 - Batch Send Now for an active campaign.
 - Batch AI text generation.
+- Batch set text, which writes one identical text to every selected post.
 - Creating one new draft post per selected/uploaded media item.
 
 Batch operations report skipped items individually—for example, already completed posts, invalid dates, or media that is still processing.
@@ -76,6 +77,10 @@ Optional per-user watermark settings are applied to image media during processin
 ### Batch AI Text Generation
 
 Select posts, then choose an assistant-capable provider/model and a reusable prompt from a text library or enter instructions directly. The task can optionally include each post's images as model context.
+
+### Batch Set Text
+
+When every selected post should carry the same caption, **Set Text** writes it directly—no model, no queue. Enter the text, apply it, and the posts are updated in one request; any text those posts already had is replaced.
 
 The server processes the selected post IDs asynchronously and reports per-post success/failure. Generated text replaces the targeted post's text; it does not automatically schedule or send the post.
 

--- a/docs/feature_mindmap.mm.md
+++ b/docs/feature_mindmap.mm.md
@@ -101,6 +101,7 @@
       - Batch Schedule / Unschedule posts
       - Batch Send immediately
       - Batch AI Text Generation (Generate text for multiple posts simultaneously with background polling)
+      - Batch Set Text (Apply one identical text to every selected post)
     - **Social Integrations**
       - Connect/Disconnect social accounts (Supported: X/Twitter, Instagram, LinkedIn, Facebook)
       - View scheduled posts calendar/counts

--- a/server/routes/posts.ts
+++ b/server/routes/posts.ts
@@ -1722,6 +1722,41 @@ export function createPostsRouter(
     }
   });
 
+  const batchSetTextSchema = z.object({
+    postIds: z.array(z.string().min(1)).min(1),
+    textContent: z.string(),
+  });
+
+  postsRouter.post('/api/posts/batch-set-text', authMiddleware, async (c) => {
+    const user = c.get('user') as JwtPayload;
+    try {
+      const body = await c.req.json();
+      const data = batchSetTextSchema.parse(body);
+
+      const postIds = Array.from(new Set(data.postIds));
+      const owned = await prisma.post.findMany({
+        where: { id: { in: postIds }, userId: user.userId },
+        select: { id: true },
+      });
+      const ownedIds = new Set(owned.map((post) => post.id));
+      const skipped = postIds
+        .filter((postId) => !ownedIds.has(postId))
+        .map((postId) => ({ postId, reason: 'Not found' }));
+
+      const result = ownedIds.size > 0
+        ? await prisma.post.updateMany({
+          where: { id: { in: Array.from(ownedIds) }, userId: user.userId },
+          data: { textContent: data.textContent },
+        })
+        : { count: 0 };
+
+      return c.json({ updated: result.count, skipped });
+    } catch (error) {
+      console.error('Failed to batch-set post text:', error);
+      return c.json({ error: 'Failed to batch-set post text' }, 400);
+    }
+  });
+
   postsRouter.post('/api/posts/:id/send', authMiddleware, async (c) => {
     const user = c.get('user') as JwtPayload;
     const id = c.req.param('id');

--- a/src/api.ts
+++ b/src/api.ts
@@ -1969,6 +1969,15 @@ export async function batchUnschedulePosts(postIds: string[]): Promise<BatchOpRe
   return handleResponse<BatchOpResult>(res, 'Failed to batch-unschedule posts');
 }
 
+export async function batchSetPostText(postIds: string[], textContent: string): Promise<BatchOpResult> {
+  const res = await apiFetch('/api/posts/batch-set-text', {
+    method: 'POST',
+    headers: getHeaders(),
+    body: JSON.stringify({ postIds, textContent }),
+  });
+  return handleResponse<BatchOpResult>(res, 'Failed to set post text');
+}
+
 export async function sendPostNow(postId: string): Promise<any> {
   const res = await apiFetch(`/api/posts/${postId}/send`, {
     method: 'POST',

--- a/src/components/BatchSetTextModal.tsx
+++ b/src/components/BatchSetTextModal.tsx
@@ -1,0 +1,101 @@
+import React, { useState } from 'react';
+import { Loader2, Type } from 'lucide-react';
+import { toast } from 'sonner';
+import { batchSetPostText } from '../api';
+
+interface Props {
+  postIds: string[];
+  onClose: () => void;
+  onComplete: () => void;
+}
+
+export function BatchSetTextModal({ postIds, onClose, onComplete }: Props) {
+  const [textContent, setTextContent] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!textContent.trim()) {
+      toast.error('Enter the text to apply');
+      return;
+    }
+
+    try {
+      setSubmitting(true);
+      const result = await batchSetPostText(postIds, textContent);
+      if (result.skipped.length > 0) {
+        toast.warning(`Updated ${result.updated}. Skipped ${result.skipped.length}: ${result.skipped[0].reason}${result.skipped.length > 1 ? '…' : ''}`);
+      } else {
+        toast.success(`Updated text for ${result.updated} post${result.updated === 1 ? '' : 's'}`);
+      }
+      onComplete();
+      onClose();
+    } catch (err: any) {
+      toast.error(err?.message || 'Failed to set post text');
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-[100] flex items-center justify-center p-4 sm:p-6 bg-black/80 backdrop-blur-md animate-in fade-in duration-300"
+      onClick={() => {
+        if (!submitting) onClose();
+      }}
+    >
+      <div
+        className="flex max-h-[95vh] w-full max-w-2xl flex-col overflow-hidden rounded-card border border-neutral-200/50 bg-white/90 shadow-2xl backdrop-blur-xl animate-in zoom-in-95 duration-300 dark:border-white/10 dark:bg-neutral-900/95"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex-1 overflow-y-auto p-8">
+          <h2 className="mb-2 flex items-center gap-2 text-xl font-bold tracking-tight text-neutral-900 dark:text-white">
+            <Type className="h-5 w-5 text-indigo-500" />
+            Set Post Text
+          </h2>
+          <p className="mb-6 text-xs font-medium text-neutral-500 dark:text-neutral-400">
+            Apply the same text to {postIds.length} selected post{postIds.length === 1 ? '' : 's'}. Existing text on those posts is replaced.
+          </p>
+
+          <form onSubmit={handleSubmit} className="space-y-6">
+            <div>
+              <label className="mb-3 block text-[10px] font-black uppercase tracking-widest text-neutral-500 dark:text-neutral-400">
+                Post Text
+              </label>
+              <textarea
+                value={textContent}
+                onChange={(e) => setTextContent(e.target.value)}
+                rows={6}
+                disabled={submitting}
+                className="min-h-40 w-full resize-y rounded-card border border-neutral-200 bg-neutral-50 px-5 py-4 text-sm font-medium text-neutral-900 shadow-inner outline-none ring-indigo-500/10 transition focus:border-indigo-500/50 focus:ring-4 dark:border-neutral-800 dark:bg-black/20 dark:text-neutral-100"
+                placeholder="e.g., New drop is live. Link in bio. #launch"
+                autoFocus
+              />
+              <p className="mt-2 text-right text-[10px] font-bold uppercase tracking-widest text-neutral-400">
+                {textContent.length} characters
+              </p>
+            </div>
+
+            <div className="flex justify-end gap-3 border-t border-neutral-200/50 pt-2 dark:border-white/5">
+              <button
+                type="button"
+                onClick={onClose}
+                disabled={submitting}
+                className="mt-4 rounded-xl px-4 py-2 text-sm font-bold text-neutral-600 transition hover:bg-neutral-100 hover:text-neutral-900 active:scale-95 dark:text-neutral-400 dark:hover:bg-white/10 dark:hover:text-white"
+              >
+                Cancel
+              </button>
+              <button
+                type="submit"
+                disabled={submitting || !textContent.trim()}
+                className="mt-4 flex items-center gap-2 rounded-xl border border-indigo-700 bg-indigo-600 px-5 py-2 text-sm font-bold text-white shadow-lg shadow-indigo-600/10 transition hover:bg-indigo-700 active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                {submitting && <Loader2 className="h-4 w-4 animate-spin" />}
+                {submitting ? 'Applying...' : 'Apply Text'}
+              </button>
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/CampaignBatchActions.tsx
+++ b/src/pages/CampaignBatchActions.tsx
@@ -9,6 +9,7 @@ import {
   Send,
   Sparkles,
   Trash2,
+  Type,
   X,
 } from 'lucide-react';
 import { toast } from 'sonner';
@@ -24,6 +25,7 @@ import {
 } from '../api';
 import { BatchAiGenerateModal } from '../components/BatchAiGenerateModal';
 import { BatchScheduleModal } from '../components/BatchScheduleModal';
+import { BatchSetTextModal } from '../components/BatchSetTextModal';
 import { PageHeader } from '../components/PageHeader';
 import { cn } from '../lib/utils';
 import { PageNav } from '../components/PageNav';
@@ -89,6 +91,7 @@ export function CampaignBatchActions() {
   const [deleting, setDeleting] = useState(false);
   const [aiOpen, setAiOpen] = useState(false);
   const [aiTask, setAiTask] = useState<BatchGenerateTextResult | null>(null);
+  const [setTextOpen, setSetTextOpen] = useState(false);
   const [scheduleOpen, setScheduleOpen] = useState(false);
   const [previewMedia, setPreviewMedia] = useState<string[] | null>(null);
 
@@ -363,6 +366,9 @@ export function CampaignBatchActions() {
             <button disabled={selectedPostIds.length === 0} className="inline-flex h-9 items-center gap-2 rounded-xl border border-neutral-200 px-3 text-sm font-bold text-neutral-700 transition hover:bg-neutral-100 disabled:opacity-40 dark:border-white/10 dark:text-neutral-200 dark:hover:bg-white/10" onClick={() => setAiOpen(true)}>
               <Sparkles className="h-4 w-4" /> AI Generate
             </button>
+            <button disabled={selectedPostIds.length === 0} className="inline-flex h-9 items-center gap-2 rounded-xl border border-neutral-200 px-3 text-sm font-bold text-neutral-700 transition hover:bg-neutral-100 disabled:opacity-40 dark:border-white/10 dark:text-neutral-200 dark:hover:bg-white/10" onClick={() => setSetTextOpen(true)}>
+              <Type className="h-4 w-4" /> Set Text
+            </button>
             <button disabled={selectedPostIds.length === 0} className="inline-flex h-9 items-center gap-2 rounded-xl border border-neutral-200 px-3 text-sm font-bold text-neutral-700 transition hover:bg-neutral-100 disabled:opacity-40 dark:border-white/10 dark:text-neutral-200 dark:hover:bg-white/10" onClick={() => setScheduleOpen(true)}>
               <Clock className="h-4 w-4" /> Schedule
             </button>
@@ -577,6 +583,13 @@ export function CampaignBatchActions() {
             setAiTask(task);
             setAiOpen(false);
           }}
+        />
+      )}
+      {setTextOpen && (
+        <BatchSetTextModal
+          postIds={selectedPostIds}
+          onClose={() => setSetTextOpen(false)}
+          onComplete={() => void loadData(true)}
         />
       )}
       {scheduleOpen && (


### PR DESCRIPTION
## Summary
Adds a new &#34;Set Text&#34; batch action to the Campaign Batch Actions view, allowing users to apply identical text to multiple selected posts in a single operation without requiring AI generation or background processing.

## Key Changes
- **New Modal Component** (`BatchSetTextModal.tsx`): A form-based modal that accepts text input and applies it to selected posts with real-time character count and loading states
- **Backend Endpoint** (`POST /api/posts/batch-set-text`): Server-side handler that validates ownership, updates post text content, and reports skipped items (posts not found or not owned)
- **API Client** (`batchSetPostText`): New function to call the batch set text endpoint with proper error handling
- **UI Integration**: Added &#34;Set Text&#34; button to the batch actions toolbar alongside existing AI Generate and Schedule actions
- **Documentation**: Updated CHANGELOG and campaign documentation to describe the new feature

## Implementation Details
- Uses Zod schema validation for request body (postIds array and textContent string)
- Deduplicates post IDs before processing
- Validates user ownership of posts before updating
- Returns count of updated posts and list of skipped items with reasons
- Replaces existing text on targeted posts (non-destructive for posts that don&#39;t exist)
- Integrates with existing toast notification system for user feedback
- Maintains consistent styling and UX patterns with other batch action modals
