### PR TITLE
Add shareable URLs to tool responses for libraries, projects, and campaigns

### DIFF
--- a/docs-site/integrations/mcp.md
+++ b/docs-site/integrations/mcp.md
@@ -27,6 +27,15 @@ Read tools return **storage keys**, not links. To fetch, view, or download a fil
 - Signs a key only when it is still referenced by media the authenticated user owns — library items, album items, job outputs, or campaign post media. Everything else is returned under `denied` with a reason, and values that are already absolute URLs are rejected as needing no signing.
 - Returned URLs are temporary; request new ones rather than reusing expired links. When the deployment sets `S3_PUBLIC_CUSTOM_DOMAIN`, storage returns a direct public URL instead of a signed one.
 
+### Record links
+
+Tools return absolute Remix Studio links next to the raw ids, so a client can show the user where a record lives instead of quoting an id:
+
+- `url` — the library, project, campaign, or post the call is about (`list_libraries` entries, `get_project`, `create_campaign`, `get_post`, …).
+- `libraryUrl` / `projectUrl` / `campaignUrl` — the parent record when it is context for something else (`search_library_items` results, `get_album_items`, post tools).
+
+The origin comes from `APP_URL` when it is configured; otherwise the server falls back to the origin of the incoming MCP request (honoring `X-Forwarded-Proto` / `X-Forwarded-Host`). Set `APP_URL` to the browser-visible origin of your deployment so the links are shareable.
+
 ## Authentication
 
 MCP requests require a bearer token obtained through either:

--- a/server/assistant/system-prompt.ts
+++ b/server/assistant/system-prompt.ts
@@ -60,6 +60,7 @@ You do NOT:
 
 - Prefer reading before writing. Discover via \`list_libraries\` / \`search_library_items\` / \`get_library_items\` / \`list_albums\` / \`get_album_items\` / \`list_available_models\` / \`get_storage_usage\` before proposing changes.
 - Storage keys returned by read tools (\`storageKey\`, \`thumbnailKey\`, \`optimizedKey\`, post media \`sourceUrl\`) are internal references, not links. To view, fetch, or hand the user a downloadable file, call \`get_file_urls\` with those keys — it returns short-lived presigned URLs (pass \`download: true\` for a save-as link). Never invent a media URL, and mint a fresh one instead of reusing an expired URL.
+- Tools return absolute Remix Studio links for the records they touch: \`url\` for the library/project/campaign/post the call is about, and \`libraryUrl\` / \`projectUrl\` / \`campaignUrl\` when that record is context for something else. When you mention one of these in your reply, include its link so the user can open it. Use the link exactly as returned — never assemble one from an id.
 - Paginated read tools return \`hasMore\` and \`nextPage\`. Only page further when the user's question genuinely needs more results — don't preemptively fetch everything.
 - When searching by keyword or title, use \`search_library_items\` (cross-library keyword match) or \`get_library_items\` with a \`query\` (single library, substring match).
 - When the user asks what's available before a mutation (e.g. "show me my image libraries"), read and summarize first; do not mutate.

--- a/server/mcp/app-urls.ts
+++ b/server/mcp/app-urls.ts
@@ -1,0 +1,39 @@
+/**
+ * Builders for browser-facing Remix Studio links returned by tools.
+ *
+ * Tools hand back these absolute URLs alongside the raw ids so an MCP client
+ * (or the in-app assistant) can show the user a clickable link to the library,
+ * project, campaign, or post it just read or wrote.
+ *
+ * The public origin comes from `APP_URL` when configured — it is the documented
+ * browser-visible origin — otherwise from the incoming request (MCP transport)
+ * and finally from the local dev default.
+ */
+
+const DEFAULT_APP_URL = 'http://localhost:3000';
+
+export function resolveAppBaseUrl(requestOrigin?: string | null): string {
+  const raw = process.env.APP_URL?.trim() || requestOrigin?.trim() || DEFAULT_APP_URL;
+  return raw.replace(/\/+$/, '');
+}
+
+export interface AppUrlBuilder {
+  /** Normalized public origin, without a trailing slash. */
+  base: string;
+  library(libraryId: string): string;
+  project(projectId: string): string;
+  campaign(campaignId: string): string;
+  campaignPost(campaignId: string, postId: string): string;
+}
+
+export function createAppUrlBuilder(requestOrigin?: string | null): AppUrlBuilder {
+  const base = resolveAppBaseUrl(requestOrigin);
+  const seg = (value: string) => encodeURIComponent(value);
+  return {
+    base,
+    library: (libraryId) => `${base}/library/${seg(libraryId)}`,
+    project: (projectId) => `${base}/project/${seg(projectId)}`,
+    campaign: (campaignId) => `${base}/campaigns/${seg(campaignId)}`,
+    campaignPost: (campaignId, postId) => `${base}/campaigns/${seg(campaignId)}/posts/${seg(postId)}`,
+  };
+}

--- a/server/mcp/mcp-server.ts
+++ b/server/mcp/mcp-server.ts
@@ -96,13 +96,14 @@ function createMcpServerInstance(
   providerRepository: ProviderRepository,
   storage: IStorage,
   userId: string,
+  appBaseUrl: string,
 ) {
   const server = new McpServer({
     name: 'remix-studio',
     version: '1.0.0',
   });
 
-  const tools = createAssistantToolDefinitions({ repository, userRepository, prisma, providerRepository, storage });
+  const tools = createAssistantToolDefinitions({ repository, userRepository, prisma, providerRepository, storage, appBaseUrl });
   for (const tool of tools) {
     registerToolOnServer(server, tool, userId);
   }
@@ -135,7 +136,15 @@ export function createMcpRouter(
 
   router.all('/mcp', async (c) => {
     const userId = c.get('mcpUserId');
-    const server = createMcpServerInstance(repository, userRepository, prisma, providerRepository, storage, userId);
+    const server = createMcpServerInstance(
+      repository,
+      userRepository,
+      prisma,
+      providerRepository,
+      storage,
+      userId,
+      getBaseUrl(c.req.raw),
+    );
 
     const transport = new WebStandardStreamableHTTPServerTransport();
 

--- a/server/mcp/tool-definitions.ts
+++ b/server/mcp/tool-definitions.ts
@@ -5,6 +5,7 @@ import type { IRepository } from '../db/repository';
 import type { UserRepository } from '../auth/user-repository';
 import type { ProviderRepository } from '../db/provider-repository';
 import type { IStorage } from '../storage/storage';
+import { createAppUrlBuilder } from './app-urls';
 import { PROVIDER_MODELS_MAP } from '../../src/types';
 
 const MODEL_CATEGORY_VALUES = ['text', 'image', 'audio', 'video'] as const;
@@ -88,6 +89,11 @@ export interface ToolDependencies {
   providerRepository: ProviderRepository;
   /** Media bucket, used to mint presigned download URLs for owned storage keys. */
   storage: IStorage;
+  /**
+   * Public origin used to build browser links (library/project/campaign URLs)
+   * returned by tools. Only consulted when `APP_URL` is not configured.
+   */
+  appBaseUrl?: string;
 }
 
 const MAX_CONTENT_PREVIEW_CHARS = 4096;
@@ -372,6 +378,7 @@ function toToolWorkflowItem(item: {
 
 export function createAssistantToolDefinitions(deps: ToolDependencies): AssistantToolDefinition[] {
   const { repository, userRepository, prisma, providerRepository, storage } = deps;
+  const appUrls = createAppUrlBuilder(deps.appBaseUrl);
 
   const tools: AssistantToolDefinition[] = [];
 
@@ -379,7 +386,7 @@ export function createAssistantToolDefinitions(deps: ToolDependencies): Assistan
   tools.push({
     name: 'create_library',
     title: 'Create Library',
-    description: 'Create a new library of a specific type (text, image, audio, video). Description is optional and should explain what the library contains or when to use it.',
+    description: 'Create a new library of a specific type (text, image, audio, video). Description is optional and should explain what the library contains or when to use it. Returns the library "url" — share it with the user so they can open the new library.',
     inputSchema: {
       name: z.string().min(1).max(256).describe('Library name'),
       description: z.string().max(2000).optional().describe('Optional library description explaining what it contains or how it should be used'),
@@ -393,7 +400,7 @@ export function createAssistantToolDefinitions(deps: ToolDependencies): Assistan
       const nextDescription = description?.trim() || undefined;
       await repository.createLibrary(userId, { id, name, description: nextDescription, type });
       return {
-        text: JSON.stringify({ id, name, description: nextDescription ?? null, type, message: 'Library created successfully' }),
+        text: JSON.stringify({ id, name, description: nextDescription ?? null, type, url: appUrls.library(id), message: 'Library created successfully' }),
       };
     },
   });
@@ -402,7 +409,7 @@ export function createAssistantToolDefinitions(deps: ToolDependencies): Assistan
   tools.push({
     name: 'update_library',
     title: 'Update Library',
-    description: 'Update an existing library name and/or description. Only provided fields are changed.',
+    description: 'Update an existing library name and/or description. Only provided fields are changed. Returns the library "url" so it can be linked back to the user.',
     inputSchema: {
       library_id: z.string().describe('The library ID to update'),
       name: z.string().min(1).max(256).optional().describe('New library name'),
@@ -430,6 +437,7 @@ export function createAssistantToolDefinitions(deps: ToolDependencies): Assistan
       return {
         text: JSON.stringify({
           library_id,
+          url: appUrls.library(library_id),
           name: nextName ?? library.name,
           description: hasDescription ? (description.trim() || null) : (library.description ?? null),
           previousName: library.name,
@@ -467,7 +475,7 @@ export function createAssistantToolDefinitions(deps: ToolDependencies): Assistan
       const id = crypto.randomUUID();
       await repository.createLibraryItem(userId, library_id, { id, content, title, tags });
       return {
-        text: JSON.stringify({ id, library_id, name: library.name, title, tags, message: 'Prompt created successfully' }),
+        text: JSON.stringify({ id, library_id, libraryUrl: appUrls.library(library_id), name: library.name, title, tags, message: 'Prompt created successfully' }),
       };
     },
   });
@@ -509,6 +517,7 @@ export function createAssistantToolDefinitions(deps: ToolDependencies): Assistan
       return {
         text: JSON.stringify({
           library_id,
+          libraryUrl: appUrls.library(library_id),
           name: library.name,
           created: libraryItems.map((item) => ({ id: item.id, title: item.title })),
           count: libraryItems.length,
@@ -570,6 +579,7 @@ export function createAssistantToolDefinitions(deps: ToolDependencies): Assistan
           text: JSON.stringify({
             item_id,
             library_id,
+            libraryUrl: appUrls.library(library_id),
             libraryName: library.name,
             title: title ?? existingItem.title ?? null,
             updatedFields: Object.keys(updates),
@@ -618,6 +628,7 @@ export function createAssistantToolDefinitions(deps: ToolDependencies): Assistan
           text: JSON.stringify({
             item_id,
             library_id,
+            libraryUrl: appUrls.library(library_id),
             libraryName: library.name,
             title: existingItem.title ?? null,
             message: 'Prompt deleted successfully.',
@@ -633,7 +644,7 @@ export function createAssistantToolDefinitions(deps: ToolDependencies): Assistan
   tools.push({
     name: 'search_library_items',
     title: 'Search Library Items',
-    description: 'Search library items by keyword (matches content and title) and/or tags. Returns matching items with their library context. Long content is truncated in the preview.',
+    description: 'Search library items by keyword (matches content and title) and/or tags. Returns matching items with their library context, including the owning library\'s "libraryUrl" so results can be linked back to the app. Long content is truncated in the preview.',
     inputSchema: {
       query: z.string().optional().describe('Optional search keyword to match against item content and title'),
       library_id: z.string().optional().describe('Optional: limit search to a specific library'),
@@ -662,6 +673,7 @@ export function createAssistantToolDefinitions(deps: ToolDependencies): Assistan
         return {
           id: item.id,
           libraryId: item.libraryId,
+          libraryUrl: appUrls.library(item.libraryId),
           libraryName: item.libraryName,
           libraryDescription: item.libraryDescription ?? null,
           content: preview.text,
@@ -725,7 +737,7 @@ export function createAssistantToolDefinitions(deps: ToolDependencies): Assistan
   tools.push({
     name: 'list_albums',
     title: 'List Albums',
-    description: 'List project albums for the authenticated user, with project descriptions, album item count, and total album size per project. Defaults to active projects only — pass status="archived" or "all" to include archived.',
+    description: 'List project albums for the authenticated user, with project descriptions, album item count, total album size, and the "projectUrl" that opens each project in Remix Studio. Defaults to active projects only — pass status="archived" or "all" to include archived.',
     inputSchema: {
       status: z.enum(['active', 'archived', 'all']).default('active').describe('Project status filter (default "active")'),
       page: z.number().int().min(1).default(1).describe('Page number (default 1)'),
@@ -747,6 +759,7 @@ export function createAssistantToolDefinitions(deps: ToolDependencies): Assistan
         const stats = statsByProject[project.id] ?? { itemCount: 0, totalSize: 0 };
         return {
           projectId: project.id,
+          projectUrl: appUrls.project(project.id),
           projectName: project.name,
           projectDescription: project.description ?? null,
           projectStatus: project.status,
@@ -828,6 +841,7 @@ Storage keys are internal references, not fetchable URLs — pass them to get_fi
 
       const response = {
         projectId: project.id,
+        projectUrl: appUrls.project(project.id),
         projectName: project.name,
         projectType: project.type,
         items,
@@ -1100,7 +1114,7 @@ Set download=true to get a URL that saves as a file (Content-Disposition: attach
   tools.push({
     name: 'list_libraries',
     title: 'List Libraries',
-    description: 'List libraries (text, image, audio, video) for the authenticated user. Returns library id, name, description, type, and item count. Use the library id as libraryId when composing workflow items of type *_from_library or *_library.',
+    description: 'List libraries (text, image, audio, video) for the authenticated user. Returns library id, name, description, type, item count, and a "url" that opens the library in Remix Studio — show that url when presenting a library to the user. Use the library id as libraryId when composing workflow items of type *_from_library or *_library.',
     inputSchema: {
       query: z.string().optional().describe('Optional: search libraries by name (case-insensitive)'),
       type: z.enum(['text', 'image', 'audio', 'video']).optional().describe('Optional: filter by library type'),
@@ -1119,6 +1133,7 @@ Set download=true to get a URL that saves as a file (Content-Disposition: attach
       const result = await repository.getUserLibraries(userId, page, limit, query, false, type as any);
       const libraries = result.items.map((lib) => ({
         id: lib.id,
+        url: appUrls.library(lib.id),
         name: lib.name,
         description: lib.description ?? null,
         type: lib.type,
@@ -1146,7 +1161,7 @@ Field semantics:
 - Text libraries: use item.text as the "value" of a "text" workflow item.
 - Image/audio/video libraries: use item.storageKey as the "value" of the matching workflow item type to pin a specific file.
 
-Use this tool to find an item by name/title before composing a workflow. Combine with list_libraries to first discover the libraryId.`,
+Use this tool to find an item by name/title before composing a workflow. Combine with list_libraries to first discover the libraryId. The response also carries "libraryUrl", the link that opens this library in Remix Studio — surface it when telling the user about the library.`,
     inputSchema: {
       library_id: z.string().describe('The library ID to browse (from list_libraries)'),
       query: z.string().optional().describe('Optional: filter items by title/name (case-insensitive substring match)'),
@@ -1199,6 +1214,7 @@ Use this tool to find an item by name/title before composing a workflow. Combine
 
       const response = {
         libraryId: library_id,
+        libraryUrl: appUrls.library(library_id),
         libraryName: library.name,
         libraryDescription: library.description ?? null,
         libraryType: library.type,
@@ -1222,7 +1238,7 @@ Use this tool to find an item by name/title before composing a workflow. Combine
   tools.push({
     name: 'get_project',
     title: 'Get Project',
-    description: 'Read one project, including its current workflow. Always call this to fetch the latest workflow immediately before update_project when changing workflowItems — even if you read the project earlier in the conversation — so unchanged workflow items can be carried forward from the current state and not from a stale copy.',
+    description: 'Read one project, including its current workflow and the "url" that opens it in Remix Studio (show that url when presenting the project). Always call this to fetch the latest workflow immediately before update_project when changing workflowItems — even if you read the project earlier in the conversation — so unchanged workflow items can be carried forward from the current state and not from a stale copy.',
     inputSchema: {
       projectId: z.string().describe('The project ID to inspect'),
     },
@@ -1246,6 +1262,7 @@ Use this tool to find an item by name/title before composing a workflow. Combine
       const workflowItems = workflow.map(toToolWorkflowItem);
       const response = {
         projectId: project.id,
+        url: appUrls.project(project.id),
         name: project.name,
         description: project.description ?? null,
         type: project.type,
@@ -1285,7 +1302,7 @@ Use this tool to find an item by name/title before composing a workflow. Combine
   tools.push({
     name: 'create_project_with_workflow',
     title: 'Create Project with Workflow',
-    description: `Create a new project with a preset workflow.
+    description: `Create a new project with a preset workflow. The result carries the project "url" — show it to the user so they can open the new project.
 
 Workflow item types:
 - "text": static prompt text. Requires "value" with the text content. To use a specific item from a text library, first call get_library_items and pass the returned item.text as "value".
@@ -1507,11 +1524,12 @@ Recommended workflow:
       return {
         text: JSON.stringify({
           projectId,
+          url: appUrls.project(projectId),
           name,
           description: description?.trim() || null,
           type,
           workflowItemCount: workflow.length,
-          message: 'Project created successfully. Open it in Remix Studio to review the workflow and run generation.',
+          message: 'Project created successfully. Share the url so the user can open it in Remix Studio to review the workflow and run generation.',
         }),
       };
     },
@@ -1521,7 +1539,7 @@ Recommended workflow:
   tools.push({
     name: 'update_project',
     title: 'Update Project',
-    description: `Update an existing project's metadata, settings, or workflow. Only provided non-workflow fields will be updated.
+    description: `Update an existing project's metadata, settings, or workflow. Only provided non-workflow fields will be updated. The result carries the project "url" so the change can be linked back to the user.
 
 Important workflow behavior:
 - If workflowItems is omitted, the existing workflow is unchanged.
@@ -1751,6 +1769,7 @@ Important workflow behavior:
       return {
         text: JSON.stringify({
           projectId,
+          url: appUrls.project(projectId),
           name: updatedName,
           description: description !== undefined ? (description.trim() || null) : (existingProject.description ?? null),
           updatedFields: Object.keys(updates),
@@ -1803,6 +1822,7 @@ Important workflow behavior:
           text: JSON.stringify({
             item_id,
             library_id,
+            libraryUrl: appUrls.library(library_id),
             updatedFields: Object.keys(updates),
             message: 'Library item updated successfully.',
           }),
@@ -1867,6 +1887,7 @@ Important workflow behavior:
       return {
         text: JSON.stringify({
           library_id,
+          libraryUrl: appUrls.library(library_id),
           libraryName: library.name,
           results,
           successCount,
@@ -1902,7 +1923,7 @@ Important workflow behavior:
   tools.push({
     name: 'create_campaign',
     title: 'Create Campaign',
-    description: 'Creates a new social media campaign.',
+    description: 'Creates a new social media campaign. Returns the campaign "url" — show it so the user can open the new campaign.',
     inputSchema: {
       name: z.string().min(1).max(200).describe('Name of the campaign'),
       description: z.string().max(5000).optional(),
@@ -1924,24 +1945,26 @@ Important workflow behavior:
         },
         include: { socialAccounts: { select: SAFE_SOCIAL_ACCOUNT_SELECT } }
       });
-      return { text: JSON.stringify(campaign), structuredContent: campaign };
+      const payload = { ...campaign, url: appUrls.campaign(campaign.id) };
+      return { text: JSON.stringify(payload), structuredContent: payload };
     }
   });
 
   tools.push({
     name: 'list_campaigns',
     title: 'List Campaigns',
-    description: 'Returns the users social media campaigns.',
+    description: 'Returns the users social media campaigns, each with a "url" that opens it in Remix Studio — show that url when presenting a campaign to the user.',
     inputSchema: {
       status: z.enum(CAMPAIGN_STATUS_VALUES).optional().describe('Filter by status'),
     },
     annotations: { readOnlyHint: true, destructiveHint: false },
     category: 'read',
     handler: async (userId, { status }) => {
-      const campaigns = await prisma.campaign.findMany({
+      const rows = await prisma.campaign.findMany({
         where: { userId, ...(status ? { status } : {}) },
         include: { socialAccounts: { select: SAFE_SOCIAL_ACCOUNT_SELECT }, _count: { select: { posts: true } } }
       });
+      const campaigns = rows.map((campaign) => ({ ...campaign, url: appUrls.campaign(campaign.id) }));
       return { text: JSON.stringify(campaigns), structuredContent: { campaigns } };
     }
   });
@@ -1949,7 +1972,7 @@ Important workflow behavior:
   tools.push({
     name: 'update_campaign',
     title: 'Update Campaign',
-    description: 'Updates a social media campaign.',
+    description: 'Updates a social media campaign. Returns the campaign "url" so the change can be linked back to the user.',
     inputSchema: {
       campaignId: z.string().min(1),
       name: z.string().min(1).max(200).optional(),
@@ -1976,14 +1999,15 @@ Important workflow behavior:
         },
         include: { socialAccounts: { select: SAFE_SOCIAL_ACCOUNT_SELECT } }
       });
-      return { text: JSON.stringify(updated), structuredContent: updated };
+      const payload = { ...updated, url: appUrls.campaign(updated.id) };
+      return { text: JSON.stringify(payload), structuredContent: payload };
     }
   });
 
   tools.push({
     name: 'create_post',
     title: 'Create Post',
-    description: 'Creates a new post in a campaign.',
+    description: 'Creates a new post in a campaign. Returns the post "url" (and its "campaignUrl") — show the post url so the user can open it.',
     inputSchema: {
       campaignId: z.string().min(1),
       textContent: z.string().max(28000).optional(),
@@ -2011,14 +2035,19 @@ Important workflow behavior:
           status: nextStatus,
         }
       });
-      return { text: JSON.stringify(post), structuredContent: post };
+      const payload = {
+        ...post,
+        url: appUrls.campaignPost(post.campaignId, post.id),
+        campaignUrl: appUrls.campaign(post.campaignId),
+      };
+      return { text: JSON.stringify(payload), structuredContent: payload };
     }
   });
 
   tools.push({
     name: 'get_post',
     title: 'Get Post',
-    description: 'Get details of a specific post.',
+    description: 'Get details of a specific post, including the post "url" and its "campaignUrl" for linking back to Remix Studio.',
     inputSchema: {
       postId: z.string().min(1),
     },
@@ -2030,7 +2059,12 @@ Important workflow behavior:
         include: { media: { orderBy: { position: 'asc' } }, executions: true }
       });
       if (!post) throw new Error("Post not found");
-      return { text: JSON.stringify(post), structuredContent: post };
+      const payload = {
+        ...post,
+        url: appUrls.campaignPost(post.campaignId, post.id),
+        campaignUrl: appUrls.campaign(post.campaignId),
+      };
+      return { text: JSON.stringify(payload), structuredContent: payload };
     }
   });
 
@@ -2060,7 +2094,9 @@ Important workflow behavior:
       if (!post) throw new Error("Post not found");
       const payload = {
         postId: post.id,
+        url: appUrls.campaignPost(post.campaignId, post.id),
         campaignId: post.campaignId,
+        campaignUrl: appUrls.campaign(post.campaignId),
         campaignName: post.campaign?.name ?? null,
         textContent: post.textContent ?? '',
         textLength: (post.textContent ?? '').length,
@@ -2106,7 +2142,12 @@ Important workflow behavior:
           ...(status !== undefined && { status })
         }
       });
-      return { text: JSON.stringify(updated), structuredContent: updated };
+      const payload = {
+        ...updated,
+        url: appUrls.campaignPost(updated.campaignId, updated.id),
+        campaignUrl: appUrls.campaign(updated.campaignId),
+      };
+      return { text: JSON.stringify(payload), structuredContent: payload };
     }
   });
 
@@ -2140,7 +2181,9 @@ Important workflow behavior:
       });
       const payload = {
         postId: updated.id,
+        url: appUrls.campaignPost(updated.campaignId, updated.id),
         campaignId: updated.campaignId,
+        campaignUrl: appUrls.campaign(updated.campaignId),
         campaignName: updated.campaign?.name ?? null,
         textContent: updated.textContent ?? '',
         textLength: (updated.textContent ?? '').length,
@@ -2184,10 +2227,13 @@ Important workflow behavior:
           status: 'pending'
         }
       });
-      return {
-        text: JSON.stringify({ ...media, campaignId: post.campaignId }),
-        structuredContent: { ...media, campaignId: post.campaignId },
+      const payload = {
+        ...media,
+        campaignId: post.campaignId,
+        postUrl: appUrls.campaignPost(post.campaignId, post.id),
+        campaignUrl: appUrls.campaign(post.campaignId),
       };
+      return { text: JSON.stringify(payload), structuredContent: payload };
     }
   });
 
@@ -2217,7 +2263,12 @@ Important workflow behavior:
           status: 'scheduled'
         }
       });
-      return { text: JSON.stringify(updated), structuredContent: updated };
+      const payload = {
+        ...updated,
+        url: appUrls.campaignPost(updated.campaignId, updated.id),
+        campaignUrl: appUrls.campaign(updated.campaignId),
+      };
+      return { text: JSON.stringify(payload), structuredContent: payload };
     }
   });
 


### PR DESCRIPTION
## Summary

Tools now return absolute Remix Studio URLs alongside resource IDs, enabling MCP clients to present clickable links to users instead of raw identifiers. This improves the user experience by making it easy to navigate to created or modified resources.

## Key Changes

- **New `app-urls.ts` module**: Provides `AppUrlBuilder` interface and `createAppUrlBuilder()` function to generate browser-facing links for libraries, projects, campaigns, and posts. Supports configurable origin via `APP_URL` environment variable, with fallback to request origin and local dev default.

- **Updated tool responses**: All tools that create, read, or modify libraries, projects, campaigns, and posts now include:
  - `url` field for the primary resource (e.g., `url` in `create_library`, `get_project`, `create_campaign`)
  - `libraryUrl` / `projectUrl` / `campaignUrl` fields when returning child resources or search results
  - `postUrl` for campaign post operations

- **Tool descriptions enhanced**: Updated descriptions to document that URLs are returned and should be shown to users for navigation.

- **MCP server integration**: Modified `mcp-server.ts` to pass request origin to tool definitions, enabling URL builder to resolve the correct public origin.

- **Documentation**: Added &#34;Record links&#34; section to MCP integration docs explaining URL behavior and configuration via `APP_URL`.

- **System prompt update**: Updated assistant instructions to reference the new URL fields in tool responses.

## Implementation Details

- URL builder uses `encodeURIComponent()` for safe path segments
- Origin resolution order: `APP_URL` env var → request origin (with `X-Forwarded-Proto`/`X-Forwarded-Host` support) → `http://localhost:3000`
- All URLs are normalized without trailing slashes
- Backward compatible: existing ID fields remain unchanged; URLs are additive
