### PR TITLE
chore: dependency major upgrade + flatten PWA share destinations

### DIFF
--- a/src/pages/ExtensionImport.tsx
+++ b/src/pages/ExtensionImport.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { useNavigate, Link } from 'react-router-dom';
+import { useNavigate, useSearchParams, Link } from 'react-router-dom';
 import { fetchLibraries, fetchProjects, fetchProjectWorkflow, updateProject, createLibraryItem, saveImage, createLibrary, createProject } from '../api';
 import { Library, Project } from '../types';
 import { useTranslation } from 'react-i18next';
@@ -142,9 +142,12 @@ function CreateProjectModal({ isOpen, onClose, type, onSuccess }: { isOpen: bool
 export default function ExtensionImport() {
   const { t } = useTranslation();
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const destinationParam = searchParams.get('destination');
+  const requestedDestination = destinationParam === 'project' || destinationParam === 'library' ? destinationParam : null;
   const [importData, setImportData] = useState<ImportData | null>(null);
-  
-  const [destinationType, setDestinationType] = useState<'library' | 'project'>('library');
+
+  const [destinationType, setDestinationType] = useState<'library' | 'project'>(requestedDestination ?? 'library');
 
   const handleDestinationChange = (type: 'library' | 'project') => {
     setDestinationType(type);
@@ -179,7 +182,7 @@ export default function ExtensionImport() {
     const applyPayload = (payload: ImportData) => {
       setImportData(payload);
 
-      if (payload?.type) {
+      if (payload?.type && !requestedDestination) {
         const saved = localStorage.getItem(`remix_studio_import_destination_${payload.type}`);
         if (saved === 'project' || saved === 'library') {
           setDestinationType(saved);

--- a/src/pages/SharePage.tsx
+++ b/src/pages/SharePage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
-import { Image as ImageIcon, Type, FolderPlus, MessageCircle, Loader2, AlertTriangle } from 'lucide-react';
+import { Image as ImageIcon, Type, Layers, Folder, MessageCircle, Loader2, AlertTriangle } from 'lucide-react';
 import { toast } from 'sonner';
 import { PageHeader } from '../components/PageHeader';
 import { stashPwaShareHandoff, type PwaShareHandoff } from '../lib/pwa-share';
@@ -120,13 +120,13 @@ export default function SharePage() {
     return true;
   };
 
-  const handleSendToImport = () => {
+  const handleSendToImport = (destination: 'library' | 'project') => {
     const payload = buildHandoff();
     if (share && share.images.length > 1) {
       toast.warning(`Only the first of ${share.images.length} images will be saved`);
     }
     if (!handoffOrNotify(payload)) return;
-    navigate('/import');
+    navigate(`/import?destination=${destination}`);
   };
 
   const handleSendToChat = () => {
@@ -208,13 +208,20 @@ export default function SharePage() {
           )}
         </div>
 
-        <div className="grid gap-3 sm:grid-cols-2">
+        <div className="grid gap-3 sm:grid-cols-3">
           <button
-            onClick={handleSendToImport}
+            onClick={() => handleSendToImport('library')}
             className="flex items-center justify-center gap-3 rounded-xl border border-neutral-200 bg-white px-5 py-4 text-sm font-bold text-neutral-900 shadow-sm transition-all hover:bg-neutral-50 active:scale-[0.98] dark:border-white/10 dark:bg-neutral-900 dark:text-white dark:hover:bg-neutral-800"
           >
-            <FolderPlus className="h-5 w-5 text-blue-500" />
-            Save to Library or Project
+            <Layers className="h-5 w-5 text-blue-500" />
+            Save to Library
+          </button>
+          <button
+            onClick={() => handleSendToImport('project')}
+            className="flex items-center justify-center gap-3 rounded-xl border border-neutral-200 bg-white px-5 py-4 text-sm font-bold text-neutral-900 shadow-sm transition-all hover:bg-neutral-50 active:scale-[0.98] dark:border-white/10 dark:bg-neutral-900 dark:text-white dark:hover:bg-neutral-800"
+          >
+            <Folder className="h-5 w-5 text-blue-500" />
+            Save to Project
           </button>
           <button
             onClick={handleSendToChat}


### PR DESCRIPTION
## What changed

Two independent changes carried on this branch:

**1. Dependency upgrade** (`a9591b4`) — all dependencies bumped to latest, including major versions.

**2. PWA share sheet: one-level destination choice** (`a974901`)

The Android PWA share target previously showed two buttons — "Save to Library or Project" and "Start a Chat" — where the first led to a *second* destination selection on the import page. That's two levels of choice for what is conceptually one decision.

The share sheet now offers three flat options:

1. **Save to Library** → `/import?destination=library`
2. **Save to Project** → `/import?destination=project`
3. **Start a Chat** → `/assistant` (unchanged)

- `src/pages/SharePage.tsx` — split the combined button in two; `handleSendToImport` now takes the destination and encodes it in the navigation.
- `src/pages/ExtensionImport.tsx` — seeds `destinationType` from the `destination` query param, and skips the remembered-destination lookup in `localStorage` when the param is present (otherwise the saved value would immediately override the user's pick).

## Reviewer notes

- The Library/Project toggle on the import page is unchanged and still switchable — the query param only sets the initial value.
- The Chrome extension flow passes no `destination` param, so its behavior (including the `localStorage` destination memory) is untouched.
- The share buttons are now `sm:grid-cols-3`, so they stack vertically on narrow phones.
- `tsc --noEmit` passes. The share flow itself was not exercised on a device.
- The dependency upgrade and the share change are unrelated; happy to split them into separate PRs if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)