### PR TITLE
feat(media-picker): remember the last picked library or album

### DIFF
--- a/src/components/ProjectViewer.tsx
+++ b/src/components/ProjectViewer.tsx
@@ -250,6 +250,11 @@ export function ProjectViewer({ project, libraries, onUpdate: onUpdateProp, onDe
   const [isRefreshingLibraries, setIsRefreshingLibraries] = useState(false);
   const [libraryRefreshError, setLibraryRefreshError] = useState<string | null>(null);
 
+  const workflowPickerType: Exclude<WorkflowItemTypeKind, 'library'> = (() => {
+    const item = (localProject.workflow || []).find((workflowItem) => workflowItem.id === selectingLibraryForItemId);
+    return item && item.type !== 'library' ? item.type : 'text';
+  })();
+
   const [isLoadingWorkflow, setIsLoadingWorkflow] = useState(true);
   const [isLoadingJobs, setIsLoadingJobs] = useState(true);
   const [isLoadingAlbum, setIsLoadingAlbum] = useState(true);
@@ -2486,13 +2491,11 @@ export function ProjectViewer({ project, libraries, onUpdate: onUpdateProp, onDe
       <UniversalMediaPicker
         isOpen={!!selectingLibraryForItemId}
         title="Pick Workflow Item"
-        allowedTypes={(() => {
-          const item = (localProject.workflow || []).find((workflowItem) => workflowItem.id === selectingLibraryForItemId);
-          return item && item.type !== 'library' ? [item.type] : ['text'];
-        })()}
+        allowedTypes={[workflowPickerType]}
         defaultSourceKind="library"
         multiple={false}
         enableImageVersionSelection
+        memoryKey={`workflow-item:${workflowPickerType}`}
         onClose={() => setSelectingLibraryForItemId(null)}
         onConfirm={(items: UniversalPickedItem[]) => {
           const picked = items[0];

--- a/src/components/UniversalMediaPicker.tsx
+++ b/src/components/UniversalMediaPicker.tsx
@@ -22,6 +22,7 @@ import {
 import { fetchLibraries, fetchLibrary, fetchLibraryItems, fetchProject, fetchProjectAlbum, fetchProjects, imageDisplayUrl } from '../api';
 import { AlbumItem, AspectRatioCount, Library, LibraryItem, LibraryType, Project } from '../types';
 import { cn } from '../lib/utils';
+import { getLastMediaPickerSource, setLastMediaPickerSource } from '../lib/media-picker-memory';
 
 export type PickerSourceKind = 'library' | 'album';
 export type UniversalPickerSort = 'newest' | 'oldest' | 'name-asc' | 'name-desc';
@@ -70,6 +71,7 @@ interface UniversalMediaPickerProps {
   sourceKinds?: PickerSourceKind[];
   multiple?: boolean;
   enableImageVersionSelection?: boolean;
+  memoryKey?: string;
   onClose: () => void;
   onConfirm: (items: UniversalPickedItem[]) => void;
 }
@@ -181,6 +183,7 @@ export function UniversalMediaPicker({
   sourceKinds = DEFAULT_SOURCE_KINDS,
   multiple = true,
   enableImageVersionSelection = false,
+  memoryKey,
   onClose,
   onConfirm,
 }: UniversalMediaPickerProps) {
@@ -190,7 +193,17 @@ export function UniversalMediaPicker({
   const enabledTypeSet = useMemo(() => new Set(allowedTypes), [allowedTypeKey]);
   const enabledKinds = useMemo(() => sourceKinds.filter((kind) => DEFAULT_SOURCE_KINDS.includes(kind)), [sourceKindKey]);
   const enabledKindKey = enabledKinds.join('|');
-  const initialKind = enabledKinds.includes(defaultSourceKind) ? defaultSourceKind : (enabledKinds[0] || 'library');
+  const memoryEnabled = !!memoryKey && !fixedSourceId;
+  const rememberedSource = useMemo(
+    () => (memoryEnabled && isOpen ? getLastMediaPickerSource(memoryKey!) : null),
+    [memoryEnabled, memoryKey, isOpen],
+  );
+  const preferredKind = rememberedSource && enabledKinds.includes(rememberedSource.kind)
+    ? rememberedSource.kind
+    : defaultSourceKind;
+  const initialKind = enabledKinds.includes(preferredKind) ? preferredKind : (enabledKinds[0] || 'library');
+  const initialSourceId = fixedSourceId
+    || (rememberedSource && rememberedSource.kind === initialKind ? rememberedSource.sourceId : null);
 
   const [activeKind, setActiveKind] = useState<PickerSourceKind>(initialKind);
   const [selectedTypes, setSelectedTypes] = useState<Set<LibraryType>>(() => new Set(allowedTypes));
@@ -217,14 +230,14 @@ export function UniversalMediaPicker({
     setSelectedTypes(new Set(allowedTypes));
     setSourceQuery('');
     setItemQuery('');
-    setActiveSourceId(fixedSourceId || null);
+    setActiveSourceId(initialSourceId);
     setSelectedKeys(new Set());
     setSelectedItemMap({});
     setItems([]);
     setAspectRatioCounts([]);
     setSelectedAspectRatios([]);
     setImageVersion('optimized');
-  }, [allowedTypeKey, initialKind, isOpen, fixedSourceId]);
+  }, [allowedTypeKey, initialKind, initialSourceId, isOpen, fixedSourceId]);
 
   useEffect(() => {
     if (!isOpen) return;
@@ -331,6 +344,11 @@ export function UniversalMediaPicker({
     setSelectedAspectRatios([]);
     setAspectRatioCounts([]);
   }, [activeSource?.id, activeSource?.kind]);
+
+  useEffect(() => {
+    if (!isOpen || !memoryEnabled || !activeSource) return;
+    setLastMediaPickerSource(memoryKey!, { kind: activeSource.kind, sourceId: activeSource.id });
+  }, [isOpen, memoryEnabled, memoryKey, activeSource?.id, activeSource?.kind]);
 
   useEffect(() => {
     if (!isOpen || !activeSource) {

--- a/src/lib/media-picker-memory.ts
+++ b/src/lib/media-picker-memory.ts
@@ -1,0 +1,39 @@
+export type MediaPickerSourceKind = 'library' | 'album';
+
+export interface MediaPickerSourceMemory {
+  kind: MediaPickerSourceKind;
+  sourceId: string;
+}
+
+const STORAGE_PREFIX = 'media_picker_last_source:';
+
+function canUseStorage() {
+  return typeof window !== 'undefined' && typeof window.localStorage !== 'undefined';
+}
+
+function storageKey(scope: string) {
+  return `${STORAGE_PREFIX}${scope}`;
+}
+
+export function getLastMediaPickerSource(scope: string): MediaPickerSourceMemory | null {
+  if (!canUseStorage() || !scope) return null;
+  try {
+    const raw = window.localStorage.getItem(storageKey(scope));
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as Partial<MediaPickerSourceMemory>;
+    if (parsed?.kind !== 'library' && parsed?.kind !== 'album') return null;
+    if (typeof parsed.sourceId !== 'string' || !parsed.sourceId) return null;
+    return { kind: parsed.kind, sourceId: parsed.sourceId };
+  } catch {
+    return null;
+  }
+}
+
+export function setLastMediaPickerSource(scope: string, memory: MediaPickerSourceMemory) {
+  if (!canUseStorage() || !scope || !memory.sourceId) return;
+  try {
+    window.localStorage.setItem(storageKey(scope), JSON.stringify(memory));
+  } catch {
+    // Ignore quota or privacy-mode failures; remembering the source is best effort.
+  }
+}

--- a/src/pages/CampaignBatchCreate.tsx
+++ b/src/pages/CampaignBatchCreate.tsx
@@ -465,6 +465,7 @@ export function CampaignBatchCreate() {
         title="Media Picker"
         allowedTypes={['image', 'video']}
         defaultSourceKind={pickerMode || 'library'}
+        memoryKey={`campaign-media:${pickerMode || 'library'}`}
         multiple
         onClose={closePicker}
         onConfirm={addPickedItemsToQueue}


### PR DESCRIPTION
## What

The universal media picker now reopens on the source you used last time, instead of always landing on the first library in the list.

- New `src/lib/media-picker-memory.ts` — stores `{kind, sourceId}` in `localStorage` under `media_picker_last_source:<scope>`, with tolerant read/write (bad JSON, private mode, quota errors all degrade silently).
- `UniversalMediaPicker` takes an optional `memoryKey` prop. Memory is only active when the prop is set and no `fixedSourceId` is given. On open it restores the Library/Album tab and the source id; on every effective source change it writes the record back, which covers both the desktop sidebar and the mobile `<select>`.
- Restore is defensive: a remembered kind outside `sourceKinds` falls back to `defaultSourceKind`, the source id is only restored when its kind matches, and a source that was deleted or filtered out falls back to the first entry as before.

## Scoping

Records are keyed per feature, not per project, so the same picker shares one record across every project:

- `ProjectViewer` → `workflow-item:<type>`, one record per workflow item type (image / text / video / audio) so an image slot never restores a text library.
- `CampaignBatchCreate` → `campaign-media:<library|album>`. The entry kind is part of the key here because the user picks it explicitly via the "From Library" / "From Album" buttons — a shared record could open the Album button on the Library tab.
- `SellExport` is intentionally left out: it passes `fixedSourceId`, so there is no source choice to remember.

## Notes for the reviewer

- `ProjectViewer` also gets a small refactor: the inline IIFE that derived `allowedTypes` is now a `workflowPickerType` value reused by both `allowedTypes` and `memoryKey`.
- `npm run lint` (tsc) passes. Not exercised in a running app — worth a click-through of the workflow item picker across two projects to confirm it stops on the remembered library.

🤖 Generated with [Claude Code](https://claude.com/claude-code)