### PR TITLE
feat(mcp): add project and album export tools

### DIFF
--- a/docs-site/integrations/mcp.md
+++ b/docs-site/integrations/mcp.md
@@ -15,10 +15,21 @@ Available MCP capabilities include:
 - **Inspect** storage usage, albums, libraries, library items, and usable model/provider pairings.
 - **Browse** the items inside a project album with `get_album_items`, including each item's prompt, format, aspect ratio, size, and storage keys.
 - **Download** stored files with `get_file_urls`, which converts internal storage keys into temporary presigned URLs (optionally as save-as download links).
+- **Export** a project album as a .zip with `export_project_album`, or a whole project as a portable bundle with `export_project`.
 - **Create and update** workflow-backed projects.
 - **Stage and run generation**: `draft_jobs` builds draft jobs from a project's workflow, `start_jobs` queues all of them or a chosen number, and `get_project_job_counts` reports drafts, queue depth, completed runs, and album totals.
 
 Write and destructive tools are **confirmation-gated**. Prompt deletion is scoped to one item in a text library and requires an explicit confirmed tool call.
+
+### Exports
+
+`export_project_album` archives the media saved in a project's album — the **entire album by default**, or just the ids passed in `item_ids`. `export_project` archives a whole project (settings, workflow, album metadata, and every media file they reference) as a bundle another Remix Studio installation can import.
+
+Both are queued in the background, exactly like an export started from the web interface:
+
+- The call waits up to `wait_seconds` (default 120, max 600) and returns `downloadUrl` once the archive is ready — a temporary link valid for about 24 hours.
+- If the archive is still building when the wait runs out, the response carries `status`, `filesArchived`/`filesTotal`, and a `taskId`. Re-call the same tool with `task_id` to keep waiting; do not start a second export.
+- Finished archives appear in the user's exports list and count against their storage quota, so an export can be refused with a storage-limit error.
 
 ### File access
 
@@ -78,7 +89,7 @@ The exact schemas are returned by MCP tool discovery. At the current source vers
 | Area | Read tools | Write/destructive tools |
 | :--- | :--- | :--- |
 | Libraries | `list_libraries`, `get_library_items`, `search_library_items` | `create_library`, `update_library`, `create_prompt`, `batch_create_prompts`, `update_prompt`, `update_library_item`, `batch_update_library_items`, `delete_prompt` |
-| Projects | `get_project`, `list_albums`, `get_album_items`, `list_available_models`, `get_storage_usage` | `create_project_with_workflow`, `update_project` |
+| Projects | `get_project`, `list_albums`, `get_album_items`, `list_available_models`, `get_storage_usage` | `create_project_with_workflow`, `update_project`, `export_project`, `export_project_album` |
 | Jobs | `get_project_job_counts` | `draft_jobs`, `start_jobs` |
 | Files | `get_file_urls` | — |
 | Campaigns | `list_social_accounts`, `list_campaigns` | `create_campaign`, `update_campaign` |
@@ -91,6 +102,7 @@ Important boundaries:
 - `update_project` replaces the entire workflow when `workflowItems` is supplied. Call `get_project` immediately beforehand and carry forward every step that should remain.
 - `draft_jobs` takes its prompts, provider, model, and generation settings from the project itself — set them with `update_project` first. It creates at most 200 drafts per call; call it again for larger batches.
 - `start_jobs` consumes drafts oldest first and runs generation against the user's provider, which costs credits. Omit `count` to start every draft.
+- Export tools are confirmation-gated writes because the archive they produce consumes the user's storage quota. Polling with `task_id` goes through the same protocol.
 - Media added to a post must be an internal storage key already owned by the authenticated user and valid for that campaign.
 - Scheduling requires a valid time, an active channel on the campaign, and ready media.
 

--- a/server.ts
+++ b/server.ts
@@ -253,6 +253,7 @@ async function startServer() {
     providerRepository,
     storage,
     exportStorage,
+    exportManager,
     queueManager,
     projectEvents: projectLiveHub,
   };

--- a/server/assistant/system-prompt.ts
+++ b/server/assistant/system-prompt.ts
@@ -68,6 +68,7 @@ You do NOT:
 - When the user asks what's available before a mutation (e.g. "show me my image libraries"), read and summarize first; do not mutate.
 - Before changing an existing project's workflow, ALWAYS call \`get_project\` to fetch the latest workflow immediately before the update — even if you read the project earlier in the conversation, since it may have changed since. The \`update_project\` tool replaces the entire workflow whenever \`workflowItems\` is provided, so start from the freshly returned \`workflowItems\` (never a stale copy) and carry forward every existing item the user did not explicitly ask to remove.
 - To reach a specific post, go \`list_campaigns\` → \`list_posts\` (the campaign's posts, with their ids) → \`get_post_text\` or \`get_post\`. \`list_campaigns\` only reports a post count, so never guess a postId.
+- To hand the user a whole album as one download, call \`export_project_album\` (the entire album unless they named specific items); to back up or move a project between installations, call \`export_project\`. Both build the archive in the background — when a call comes back still building, re-call the same tool with the returned \`task_id\` instead of starting a second export. For one or two files, \`get_file_urls\` is enough.
 - Before revising existing post copy, call \`get_post_text\` and use \`update_post_text\` for text-only edits. Use \`update_post\` only when scheduling/status fields also need to change.
 - For generation runs: \`draft_jobs\` stages drafts from the project's own workflow, \`start_jobs\` queues them (all of them, or the number the user asked for), and \`get_project_job_counts\` reports drafts, queue, completed, and album totals. Drafting is reversible and free; starting spends the user's provider credits, so always state how many jobs will run before proposing it, and never start more than the user asked for.
 
@@ -94,6 +95,7 @@ Use this pattern for:
 - \`create_post\` / \`update_post\` / \`update_post_text\`
 - \`add_media_to_post\`
 - \`schedule_post\`
+- \`export_project\` / \`export_project_album\`
 
 Only wait for another user turn when information is missing, the target is ambiguous, or the user is still deciding.
 

--- a/server/mcp/tool-confirmation.ts
+++ b/server/mcp/tool-confirmation.ts
@@ -109,6 +109,18 @@ export function summarizeToolEffect(
         ? `Start every draft job on project ${getLabel(objectArgs.projectId, 'project')}. This runs generation and spends provider credits.`
         : `Start ${count} draft job${count === 1 ? '' : 's'} on project ${getLabel(objectArgs.projectId, 'project')}. This runs generation and spends provider credits.`;
     }
+    case 'export_project':
+      return typeof objectArgs.task_id === 'string' && objectArgs.task_id
+        ? `Check on export ${String(objectArgs.task_id)}.`
+        : `Export project ${getLabel(objectArgs.project_id, 'project')} as a portable .zip bundle.`;
+    case 'export_project_album': {
+      if (typeof objectArgs.task_id === 'string' && objectArgs.task_id) {
+        return `Check on export ${String(objectArgs.task_id)}.`;
+      }
+      const itemIds = Array.isArray(objectArgs.item_ids) ? objectArgs.item_ids : null;
+      const scope = itemIds ? `${itemIds.length} selected item${itemIds.length === 1 ? '' : 's'}` : 'every item';
+      return `Export ${scope} from the album of project ${getLabel(objectArgs.project_id, 'project')} as a .zip.`;
+    }
     case 'create_campaign':
       return `Create campaign named "${String(objectArgs.name ?? '')}".`;
     case 'update_campaign': {

--- a/server/mcp/tool-definitions.ts
+++ b/server/mcp/tool-definitions.ts
@@ -4,11 +4,18 @@ import { PrismaClient } from '@prisma/client';
 import type { IRepository } from '../db/repository';
 import type { UserRepository } from '../auth/user-repository';
 import type { ProviderRepository } from '../db/provider-repository';
-import type { IStorage } from '../storage/storage';
+import type { S3Storage } from '../storage/s3-storage';
 import type { QueueManager } from '../queue/queue-manager';
+import type { ExportManager, ExportTask } from '../queue/export-manager';
 import type { ProjectEventPublisher } from '../live/project-live-hub';
 import { checkStorageLimit } from '../utils/storage-check';
-import { createAppUrlBuilder } from './app-urls';
+import {
+  ProjectExportError,
+  startProjectAlbumExport,
+  startProjectBundleExport,
+  type StartedProjectExport,
+} from '../services/project-export';
+import { createAppUrlBuilder, type AppUrlBuilder } from './app-urls';
 import { generateJobs } from '../../src/lib/remixEngine';
 import {
   DEFAULT_AUDIO_PROJECT_CONFIG,
@@ -100,11 +107,13 @@ export interface ToolDependencies {
   prisma: PrismaClient;
   providerRepository: ProviderRepository;
   /** Media bucket, used to mint presigned download URLs for owned storage keys. */
-  storage: IStorage;
-  /** Archive bucket, needed alongside `storage` for storage-quota checks. */
-  exportStorage: IStorage;
+  storage: S3Storage;
+  /** Archive bucket: storage-quota checks, and where finished exports land. */
+  exportStorage: S3Storage;
   /** Generation queue, used to enqueue jobs the tools move to 'pending'. */
   queueManager: QueueManager;
+  /** Queue that builds export archives in the background. */
+  exportManager: ExportManager;
   /** Optional live-update hub so open project views refresh after job changes. */
   projectEvents?: ProjectEventPublisher;
   /**
@@ -442,6 +451,57 @@ function buildJobSettings(project: Project, model: ModelConfig | undefined): Par
   return { ...common, format: (project.format || 'png') as Job['format'] };
 }
 
+const EXPORT_POLL_INTERVAL_MS = 2000;
+const DEFAULT_EXPORT_WAIT_SECONDS = 120;
+const MAX_EXPORT_WAIT_SECONDS = 600;
+
+/**
+ * Archives are built by a background worker, so a tool call waits on the task
+ * rather than owning the work. Returns as soon as the task settles, or when the
+ * caller's wait budget runs out — whichever comes first.
+ */
+async function waitForExportTask(
+  exportManager: ExportManager,
+  userId: string,
+  taskId: string,
+  waitSeconds: number,
+): Promise<ExportTask | undefined> {
+  const deadline = Date.now() + waitSeconds * 1000;
+  let task = await exportManager.getTask(userId, taskId);
+
+  while (task && (task.status === 'pending' || task.status === 'processing')) {
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) break;
+    await new Promise((resolve) => setTimeout(resolve, Math.min(EXPORT_POLL_INTERVAL_MS, remaining)));
+    task = await exportManager.getTask(userId, taskId);
+  }
+
+  return task;
+}
+
+function describeExportTask(task: ExportTask, toolName: string, appUrls: AppUrlBuilder) {
+  const settled = task.status === 'completed' || task.status === 'failed';
+  return {
+    taskId: task.id,
+    status: task.status,
+    projectId: task.projectId ?? null,
+    projectUrl: task.projectId ? appUrls.project(task.projectId) : null,
+    projectName: task.projectName,
+    packageName: task.packageName ?? null,
+    filesArchived: task.current,
+    filesTotal: task.total,
+    size: task.size ?? null,
+    sizeFormatted: task.size ? formatSize(task.size) : null,
+    downloadUrl: task.downloadUrl ?? null,
+    error: task.error ?? null,
+    hint: task.status === 'completed'
+      ? 'downloadUrl is a temporary link (valid ~24h). The archive also stays in the user\'s exports list.'
+      : settled
+        ? 'The export did not produce an archive. Read "error" before retrying.'
+        : `Still building. Call ${toolName} again with task_id="${task.id}" to keep waiting — do not start a second export.`,
+  };
+}
+
 function toToolWorkflowItem(item: {
   id?: string;
   type: string;
@@ -465,7 +525,8 @@ function toToolWorkflowItem(item: {
 }
 
 export function createAssistantToolDefinitions(deps: ToolDependencies): AssistantToolDefinition[] {
-  const { repository, userRepository, prisma, providerRepository, storage, exportStorage, queueManager, projectEvents } = deps;
+  const { repository, userRepository, prisma, providerRepository, storage, exportStorage, exportManager, queueManager, projectEvents } = deps;
+  const exportDeps = { repository, userRepository, storage, exportStorage, exportManager };
   const appUrls = createAppUrlBuilder(deps.appBaseUrl);
 
   const tools: AssistantToolDefinition[] = [];
@@ -996,6 +1057,136 @@ Storage keys are internal references, not fetchable URLs — pass them to get_fi
         text: JSON.stringify(response, null, 2),
         structuredContent: response,
       };
+    },
+  });
+
+  // ─── export_project ───
+  tools.push({
+    name: 'export_project',
+    title: 'Export Project',
+    description: `Package one whole project into a portable .zip bundle: its settings, workflow, album metadata, and every media file those reference. The bundle can be imported into another Remix Studio installation, so this is the tool for backing up or moving a project — not for handing the user plain image files (use export_project_album for that).
+
+The archive is built in the background. The call waits up to wait_seconds for it to finish and returns a temporary download URL when it does; if it is still building, re-call with the returned task_id to keep waiting instead of starting a second export. Finished archives also appear in the user's exports list and count against their storage quota.`,
+    inputSchema: {
+      project_id: z.string().min(1).optional().describe('The project ID to export (from list_albums). Required unless task_id is given.'),
+      package_name: z.string().min(1).max(200).optional().describe('Optional archive filename (default "<project name>_Project.zip")'),
+      task_id: z.string().min(1).optional().describe('Resume waiting on an export already started by this tool. When set, no new export is started and project_id is ignored.'),
+      wait_seconds: z
+        .number()
+        .int()
+        .min(0)
+        .max(MAX_EXPORT_WAIT_SECONDS)
+        .default(DEFAULT_EXPORT_WAIT_SECONDS)
+        .describe(`How long to wait for the archive before returning progress (default ${DEFAULT_EXPORT_WAIT_SECONDS}s, max ${MAX_EXPORT_WAIT_SECONDS}s)`),
+    },
+    annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: false },
+    category: 'mutate',
+    handler: async (userId, input) => {
+      const { project_id, package_name, task_id, wait_seconds } = input as {
+        project_id?: string;
+        package_name?: string;
+        task_id?: string;
+        wait_seconds: number;
+      };
+
+      let taskId = task_id?.trim();
+      if (!taskId) {
+        if (!project_id?.trim()) {
+          return { text: JSON.stringify({ error: 'project_id is required unless task_id is provided.' }), isError: true };
+        }
+        try {
+          const started: StartedProjectExport = await startProjectBundleExport(exportDeps, userId, {
+            projectId: project_id.trim(),
+            packageName: package_name,
+          });
+          taskId = started.taskId;
+        } catch (e) {
+          if (e instanceof ProjectExportError) {
+            return { text: JSON.stringify({ error: e.message }), isError: true };
+          }
+          throw e;
+        }
+      }
+
+      const task = await waitForExportTask(exportManager, userId, taskId, wait_seconds);
+      if (!task) {
+        return { text: JSON.stringify({ error: `Export task "${taskId}" not found.` }), isError: true };
+      }
+
+      const response = describeExportTask(task, 'export_project', appUrls);
+      return { text: JSON.stringify(response, null, 2), structuredContent: response };
+    },
+  });
+
+  // ─── export_project_album ───
+  tools.push({
+    name: 'export_project_album',
+    title: 'Export Project Album',
+    description: `Package the media files saved in one project's album into a .zip the user can download. Exports the entire album by default — pass item_ids only when the user asked for a specific subset (ids come from get_album_items).
+
+The archive is built in the background. The call waits up to wait_seconds for it to finish and returns a temporary download URL when it does; if it is still building, re-call with the returned task_id to keep waiting instead of starting a second export. Finished archives also appear in the user's exports list and count against their storage quota.
+
+For a single file, get_file_urls is cheaper — it needs no archive. To move a project between installations, use export_project instead.`,
+    inputSchema: {
+      project_id: z.string().min(1).optional().describe('The project ID whose album to export (from list_albums). Required unless task_id is given.'),
+      item_ids: z
+        .array(z.string().min(1))
+        .optional()
+        .describe('Optional album item IDs to export. Omit to export the whole album (the default).'),
+      export_version: z
+        .enum(['raw', 'optimized'])
+        .default('raw')
+        .describe('Which asset variant to archive: "raw" originals (default) or "optimized" smaller variants where available'),
+      package_name: z.string().min(1).max(200).optional().describe('Optional archive filename (default "<project name>_Album.zip")'),
+      task_id: z.string().min(1).optional().describe('Resume waiting on an export already started by this tool. When set, no new export is started and the other inputs are ignored.'),
+      wait_seconds: z
+        .number()
+        .int()
+        .min(0)
+        .max(MAX_EXPORT_WAIT_SECONDS)
+        .default(DEFAULT_EXPORT_WAIT_SECONDS)
+        .describe(`How long to wait for the archive before returning progress (default ${DEFAULT_EXPORT_WAIT_SECONDS}s, max ${MAX_EXPORT_WAIT_SECONDS}s)`),
+    },
+    annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: false },
+    category: 'mutate',
+    handler: async (userId, input) => {
+      const { project_id, item_ids, export_version, package_name, task_id, wait_seconds } = input as {
+        project_id?: string;
+        item_ids?: string[];
+        export_version: 'raw' | 'optimized';
+        package_name?: string;
+        task_id?: string;
+        wait_seconds: number;
+      };
+
+      let taskId = task_id?.trim();
+      if (!taskId) {
+        if (!project_id?.trim()) {
+          return { text: JSON.stringify({ error: 'project_id is required unless task_id is provided.' }), isError: true };
+        }
+        try {
+          const started: StartedProjectExport = await startProjectAlbumExport(exportDeps, userId, {
+            projectId: project_id.trim(),
+            itemIds: item_ids?.length ? item_ids : undefined,
+            packageName: package_name,
+            exportVersion: export_version,
+          });
+          taskId = started.taskId;
+        } catch (e) {
+          if (e instanceof ProjectExportError) {
+            return { text: JSON.stringify({ error: e.message }), isError: true };
+          }
+          throw e;
+        }
+      }
+
+      const task = await waitForExportTask(exportManager, userId, taskId, wait_seconds);
+      if (!task) {
+        return { text: JSON.stringify({ error: `Export task "${taskId}" not found.` }), isError: true };
+      }
+
+      const response = describeExportTask(task, 'export_project_album', appUrls);
+      return { text: JSON.stringify(response, null, 2), structuredContent: response };
     },
   });
 

--- a/server/routes/projects.ts
+++ b/server/routes/projects.ts
@@ -9,8 +9,13 @@ import { QueueManager } from '../queue/queue-manager';
 import { ExportManager } from '../queue/export-manager';
 import { DeliveryManager } from '../queue/delivery-manager';
 import { ProjectImportManager } from '../queue/project-import-manager';
-import { buildProjectBundleManifest } from '../services/project-bundle';
+import {
+  ProjectExportError,
+  startProjectAlbumExport,
+  startProjectBundleExport,
+} from '../services/project-export';
 import { checkStorageLimit } from '../utils/storage-check';
+import { normalizeWorkflowForStorage, stripToKey } from '../utils/storage-keys';
 import { UserRepository } from '../auth/user-repository';
 import type { WorkflowItem, Job, Project, LibraryItem, QueueMonitorView, AlbumItem } from '../../src/types';
 import type { ProjectEventPublisher, ProjectLiveEventReason } from '../live/project-live-hub';
@@ -30,40 +35,6 @@ async function presignIfKey(value: string, storage: S3Storage): Promise<string> 
     return storage.getPresignedUrl(key);
   }
   return value;
-}
-
-/** Extract bare S3 key from a presigned URL, or return the value as-is if already a key */
-function stripToKey(value: string | undefined, bucket: string): string | undefined {
-  if (!value || !value.startsWith('http')) return value;
-  try {
-    const url = new URL(value);
-    // Path-style: /bucket/key (used by MinIO/LocalStack)
-    const prefix = `/${bucket}/`;
-    if (url.pathname.startsWith(prefix)) {
-      return decodeURIComponent(url.pathname.slice(prefix.length));
-    }
-    // Virtual-hosted style: bucket.host/key (used by AWS S3)
-    if (url.hostname.startsWith(`${bucket}.`)) {
-      return decodeURIComponent(url.pathname.slice(1));
-    }
-    return value;
-  } catch {
-    return value;
-  }
-}
-
-function normalizeWorkflowForStorage(workflow: WorkflowItem[], bucket: string): WorkflowItem[] {
-  return workflow.map((item) => {
-    if (item.type === 'image' || item.type === 'video' || item.type === 'audio') {
-      return {
-        ...item,
-        value: stripToKey(item.value, bucket) || item.value,
-        thumbnailUrl: stripToKey(item.thumbnailUrl, bucket),
-        optimizedUrl: stripToKey(item.optimizedUrl, bucket),
-      };
-    }
-    return item;
-  });
 }
 
 /**
@@ -241,6 +212,8 @@ export async function signWorkflowItems(workflow: WorkflowItem[], storage: S3Sto
 
 export function createProjectRouter(repository: IRepository, userRepository: UserRepository, storage: S3Storage, exportStorage: S3Storage, queueManager: QueueManager, exportManager: ExportManager, deliveryManager: DeliveryManager, projectImportManager: ProjectImportManager, prisma: PrismaClient, projectEvents?: ProjectEventPublisher) {
   const router = new Hono<{ Variables: Variables }>();
+
+  const exportDeps = { repository, userRepository, storage, exportStorage, exportManager };
 
   // NOTE: /rename must be registered before /:id to avoid route shadowing
   router.post('/api/projects/rename', authMiddleware, async (c) => {
@@ -1326,54 +1299,16 @@ export function createProjectRouter(repository: IRepository, userRepository: Use
         ? normalizePostWatermarkPayload(postWatermarkSettingSchema.parse(body.watermarkSettings))
         : undefined;
 
-      const project = await repository.getProject(user.userId, projectId);
-      if (!project) return c.json({ error: 'Project not found' }, 404);
-      if (watermarkSettings?.enabled && project.type !== 'image') {
-        return c.json({ error: 'Watermark export is only available for image projects' }, 400);
-      }
-
-      const albumPage = await repository.getProjectAlbum(user.userId, projectId, { limit: 999999 });
-      const albumItems = albumPage.items;
-      const itemsToExport = itemIds
-        ? albumItems.filter((item) => itemIds.includes(item.id))
-        : albumItems;
-
-      if (itemsToExport.length === 0) return c.json({ error: 'No items to export' }, 400);
-
-      // Estimate the ZIP size using the selected asset version. Media files are already
-      // compressed, so the ZIP will be roughly the sum of source sizes.
-      const estimatedZipSize = (
-        await Promise.all(
-          itemsToExport.map(async (item) => {
-            const key = exportVersion === 'optimized' && item.optimizedUrl ? item.optimizedUrl : item.imageUrl;
-            const knownSize = exportVersion === 'optimized' && item.optimizedUrl
-              ? item.optimizedSize || item.size
-              : item.size;
-            return knownSize || (await storage.getSize(key).catch(() => undefined)) || 5 * 1024 * 1024;
-          })
-        )
-      ).reduce((acc, size) => acc + size, 0);
-      const { allowed, currentUsage, limit } = await checkStorageLimit(
-        user.userId,
-        estimatedZipSize,
-        userRepository,
-        storage,
-        exportStorage,
-        repository
-      );
-
-      if (!allowed) {
-        return c.json({ 
-          error: `Storage limit exceeded. Cannot export album. Remaining: ${((limit - currentUsage) / (1024 * 1024)).toFixed(1)}MB. Required: ~${(estimatedZipSize / (1024 * 1024)).toFixed(1)}MB.` 
-        }, 403);
-      }
-
-      const taskId = await exportManager.startExport(user.userId, projectId, project.name, itemsToExport, packageName, {
+      const { taskId } = await startProjectAlbumExport(exportDeps, user.userId, {
+        projectId,
+        itemIds,
+        packageName,
         exportVersion,
-        ...(watermarkSettings ? { watermarkSettings } : {}),
+        watermarkSettings,
       });
       return c.json({ taskId });
     } catch (e) {
+      if (e instanceof ProjectExportError) return c.json({ error: e.message }, e.status);
       console.error('[POST /api/projects/:id/export]', e);
       return c.json({ error: 'Failed to start export' }, 500);
     }
@@ -1396,87 +1331,10 @@ export function createProjectRouter(repository: IRepository, userRepository: Use
       const body = await c.req.json().catch(() => ({}));
       const packageName = typeof body?.packageName === 'string' ? body.packageName : undefined;
 
-      const project = await repository.getProject(user.userId, projectId);
-      if (!project) return c.json({ error: 'Project not found' }, 404);
-
-      const bucket = storage.getBucketName();
-      const [workflow, albumPage] = await Promise.all([
-        repository.getProjectWorkflow(user.userId, projectId),
-        repository.getProjectAlbum(user.userId, projectId, { limit: 999999 }),
-      ]);
-
-      // The manifest has to carry bare storage keys to resolve them to files,
-      // so anything stored as a presigned URL is stripped back down first.
-      const manifest = buildProjectBundleManifest({
-        project: { ...project, id: projectId },
-        workflow: normalizeWorkflowForStorage(workflow, bucket),
-        album: albumPage.items.map((item) => ({
-          ...item,
-          imageUrl: stripToKey(item.imageUrl, bucket) || item.imageUrl,
-          thumbnailUrl: stripToKey(item.thumbnailUrl, bucket),
-          optimizedUrl: stripToKey(item.optimizedUrl, bucket),
-          imageContexts: item.imageContexts?.map((v) => stripToKey(v, bucket) || v),
-          videoContexts: item.videoContexts?.map((v) => stripToKey(v, bucket) || v),
-          audioContexts: item.audioContexts?.map((v) => stripToKey(v, bucket) || v),
-        })),
-      });
-
-      // Resolve real sizes for the quota estimate, and drop entries whose file
-      // has gone missing so the archiver never stalls on a dead key.
-      const mediaItems: Array<AlbumItem & { exportName?: string }> = [];
-      let estimatedSize = 0;
-      for (const entry of manifest.media) {
-        if (!entry.sourceKey) continue;
-        const size = entry.size ?? (await storage.getSize(entry.sourceKey).catch(() => undefined));
-        if (size == null && !(await storage.exists(entry.sourceKey).catch(() => false))) {
-          console.warn(`[POST /api/projects/:id/export-bundle] Skipping missing file ${entry.sourceKey}`);
-          continue;
-        }
-        entry.size = size;
-        estimatedSize += size ?? 5 * 1024 * 1024;
-        mediaItems.push({
-          id: entry.path,
-          jobId: '',
-          prompt: '',
-          imageUrl: entry.sourceKey,
-          size,
-          createdAt: Date.now(),
-          exportName: entry.path,
-        });
-      }
-
-      // Keep the manifest honest about what the archive actually contains.
-      const packedPaths = new Set(mediaItems.map((item) => item.exportName));
-      manifest.media = manifest.media.filter((entry) => packedPaths.has(entry.path));
-
-      const { allowed, currentUsage, limit } = await checkStorageLimit(
-        user.userId,
-        estimatedSize,
-        userRepository,
-        storage,
-        exportStorage,
-        repository
-      );
-      if (!allowed) {
-        return c.json({
-          error: `Storage limit exceeded. Cannot export project. Remaining: ${((limit - currentUsage) / (1024 * 1024)).toFixed(1)}MB. Required: ~${(estimatedSize / (1024 * 1024)).toFixed(1)}MB.`,
-        }, 403);
-      }
-
-      const taskId = await exportManager.startExport(
-        user.userId,
-        projectId,
-        project.name,
-        mediaItems,
-        packageName || `${project.name}_Project`,
-        {
-          sourceType: 'project-bundle',
-          bundleManifest: manifest,
-        }
-      );
-
+      const { taskId } = await startProjectBundleExport(exportDeps, user.userId, { projectId, packageName });
       return c.json({ taskId });
     } catch (e) {
+      if (e instanceof ProjectExportError) return c.json({ error: e.message }, e.status);
       console.error('[POST /api/projects/:id/export-bundle]', e);
       return c.json({ error: 'Failed to start project export' }, 500);
     }

--- a/server/services/project-export.ts
+++ b/server/services/project-export.ts
@@ -1,0 +1,214 @@
+/**
+ * Project export entry points shared by the HTTP routes and the MCP/assistant
+ * tools. Both surfaces queue the exact same archive jobs, so a bundle exported
+ * by an agent is byte-for-byte the one the UI would have produced.
+ */
+
+import type { AlbumItem } from '../../src/types';
+import type { IRepository } from '../db/repository';
+import type { UserRepository } from '../auth/user-repository';
+import type { S3Storage } from '../storage/s3-storage';
+import type { ExportManager, ExportItem } from '../queue/export-manager';
+import { buildProjectBundleManifest } from './project-bundle';
+import { checkStorageLimit } from '../utils/storage-check';
+import { normalizeWorkflowForStorage, stripToKey } from '../utils/storage-keys';
+import type { PostWatermarkConfig } from '../utils/watermark';
+
+export type ExportAssetVersion = 'raw' | 'optimized';
+
+export interface ProjectExportDeps {
+  repository: IRepository;
+  userRepository: UserRepository;
+  /** Media bucket the album/bundle files are read from. */
+  storage: S3Storage;
+  /** Bucket the finished archives are written to. */
+  exportStorage: S3Storage;
+  exportManager: ExportManager;
+}
+
+/** Carries the HTTP status the route layer should answer with. */
+export class ProjectExportError extends Error {
+  constructor(message: string, readonly status: 400 | 403 | 404) {
+    super(message);
+    this.name = 'ProjectExportError';
+  }
+}
+
+export interface StartedProjectExport {
+  taskId: string;
+  projectId: string;
+  projectName: string;
+  /** Files queued into the archive. */
+  itemCount: number;
+  estimatedSize: number;
+}
+
+/** Everything in one project's album is exported unless `itemIds` narrows it. */
+export async function startProjectAlbumExport(
+  deps: ProjectExportDeps,
+  userId: string,
+  params: {
+    projectId: string;
+    itemIds?: string[];
+    packageName?: string;
+    exportVersion?: ExportAssetVersion;
+    watermarkSettings?: PostWatermarkConfig;
+  }
+): Promise<StartedProjectExport> {
+  const { repository, userRepository, storage, exportStorage, exportManager } = deps;
+  const { projectId, itemIds, packageName, watermarkSettings } = params;
+  const exportVersion: ExportAssetVersion = params.exportVersion === 'optimized' ? 'optimized' : 'raw';
+
+  const project = await repository.getProject(userId, projectId);
+  if (!project) throw new ProjectExportError(`Project "${projectId}" not found`, 404);
+  if (watermarkSettings?.enabled && project.type !== 'image') {
+    throw new ProjectExportError('Watermark export is only available for image projects', 400);
+  }
+
+  const albumPage = await repository.getProjectAlbum(userId, projectId, { limit: 999999 });
+  const itemsToExport = itemIds ? albumPage.items.filter((item) => itemIds.includes(item.id)) : albumPage.items;
+  if (itemsToExport.length === 0) throw new ProjectExportError('No items to export', 400);
+
+  // Estimate the ZIP size using the selected asset version. Media files are already
+  // compressed, so the ZIP will be roughly the sum of source sizes.
+  const estimatedSize = (
+    await Promise.all(
+      itemsToExport.map(async (item) => {
+        const key = exportVersion === 'optimized' && item.optimizedUrl ? item.optimizedUrl : item.imageUrl;
+        const knownSize = exportVersion === 'optimized' && item.optimizedUrl
+          ? item.optimizedSize || item.size
+          : item.size;
+        return knownSize || (await storage.getSize(key).catch(() => undefined)) || 5 * 1024 * 1024;
+      })
+    )
+  ).reduce((acc, size) => acc + size, 0);
+
+  const { allowed, currentUsage, limit } = await checkStorageLimit(
+    userId,
+    estimatedSize,
+    userRepository,
+    storage,
+    exportStorage,
+    repository
+  );
+  if (!allowed) {
+    throw new ProjectExportError(
+      `Storage limit exceeded. Cannot export album. Remaining: ${((limit - currentUsage) / (1024 * 1024)).toFixed(1)}MB. Required: ~${(estimatedSize / (1024 * 1024)).toFixed(1)}MB.`,
+      403
+    );
+  }
+
+  const taskId = await exportManager.startExport(userId, projectId, project.name, itemsToExport, packageName, {
+    exportVersion,
+    ...(watermarkSettings ? { watermarkSettings } : {}),
+  });
+
+  return {
+    taskId,
+    projectId,
+    projectName: project.name,
+    itemCount: itemsToExport.length,
+    estimatedSize,
+  };
+}
+
+/**
+ * Package a whole project — settings, workflow, album and every media file they
+ * reference — into one portable .zip that another installation can import.
+ */
+export async function startProjectBundleExport(
+  deps: ProjectExportDeps,
+  userId: string,
+  params: { projectId: string; packageName?: string }
+): Promise<StartedProjectExport> {
+  const { repository, userRepository, storage, exportStorage, exportManager } = deps;
+  const { projectId, packageName } = params;
+
+  const project = await repository.getProject(userId, projectId);
+  if (!project) throw new ProjectExportError(`Project "${projectId}" not found`, 404);
+
+  const bucket = storage.getBucketName();
+  const [workflow, albumPage] = await Promise.all([
+    repository.getProjectWorkflow(userId, projectId),
+    repository.getProjectAlbum(userId, projectId, { limit: 999999 }),
+  ]);
+
+  // The manifest has to carry bare storage keys to resolve them to files,
+  // so anything stored as a presigned URL is stripped back down first.
+  const manifest = buildProjectBundleManifest({
+    project: { ...project, id: projectId },
+    workflow: normalizeWorkflowForStorage(workflow, bucket),
+    album: albumPage.items.map((item) => ({
+      ...item,
+      imageUrl: stripToKey(item.imageUrl, bucket) || item.imageUrl,
+      thumbnailUrl: stripToKey(item.thumbnailUrl, bucket),
+      optimizedUrl: stripToKey(item.optimizedUrl, bucket),
+      imageContexts: item.imageContexts?.map((v) => stripToKey(v, bucket) || v),
+      videoContexts: item.videoContexts?.map((v) => stripToKey(v, bucket) || v),
+      audioContexts: item.audioContexts?.map((v) => stripToKey(v, bucket) || v),
+    })),
+  });
+
+  // Resolve real sizes for the quota estimate, and drop entries whose file
+  // has gone missing so the archiver never stalls on a dead key.
+  const mediaItems: ExportItem[] = [];
+  let estimatedSize = 0;
+  for (const entry of manifest.media) {
+    if (!entry.sourceKey) continue;
+    const size = entry.size ?? (await storage.getSize(entry.sourceKey).catch(() => undefined));
+    if (size == null && !(await storage.exists(entry.sourceKey).catch(() => false))) {
+      console.warn(`[ProjectExport] Skipping missing file ${entry.sourceKey}`);
+      continue;
+    }
+    entry.size = size;
+    estimatedSize += size ?? 5 * 1024 * 1024;
+    mediaItems.push({
+      id: entry.path,
+      jobId: '',
+      prompt: '',
+      imageUrl: entry.sourceKey,
+      size,
+      createdAt: Date.now(),
+      exportName: entry.path,
+    } as AlbumItem & { exportName: string });
+  }
+
+  // Keep the manifest honest about what the archive actually contains.
+  const packedPaths = new Set(mediaItems.map((item) => item.exportName));
+  manifest.media = manifest.media.filter((entry) => packedPaths.has(entry.path));
+
+  const { allowed, currentUsage, limit } = await checkStorageLimit(
+    userId,
+    estimatedSize,
+    userRepository,
+    storage,
+    exportStorage,
+    repository
+  );
+  if (!allowed) {
+    throw new ProjectExportError(
+      `Storage limit exceeded. Cannot export project. Remaining: ${((limit - currentUsage) / (1024 * 1024)).toFixed(1)}MB. Required: ~${(estimatedSize / (1024 * 1024)).toFixed(1)}MB.`,
+      403
+    );
+  }
+
+  const taskId = await exportManager.startExport(
+    userId,
+    projectId,
+    project.name,
+    mediaItems,
+    packageName || `${project.name}_Project`,
+    {
+      sourceType: 'project-bundle',
+      bundleManifest: manifest,
+    }
+  );
+
+  return {
+    taskId,
+    projectId,
+    projectName: project.name,
+    itemCount: mediaItems.length,
+    estimatedSize,
+  };
+}

--- a/server/utils/storage-keys.ts
+++ b/server/utils/storage-keys.ts
@@ -1,0 +1,35 @@
+import type { WorkflowItem } from '../../src/types';
+
+/** Extract bare S3 key from a presigned URL, or return the value as-is if already a key */
+export function stripToKey(value: string | undefined, bucket: string): string | undefined {
+  if (!value || !value.startsWith('http')) return value;
+  try {
+    const url = new URL(value);
+    // Path-style: /bucket/key (used by MinIO/LocalStack)
+    const prefix = `/${bucket}/`;
+    if (url.pathname.startsWith(prefix)) {
+      return decodeURIComponent(url.pathname.slice(prefix.length));
+    }
+    // Virtual-hosted style: bucket.host/key (used by AWS S3)
+    if (url.hostname.startsWith(`${bucket}.`)) {
+      return decodeURIComponent(url.pathname.slice(1));
+    }
+    return value;
+  } catch {
+    return value;
+  }
+}
+
+export function normalizeWorkflowForStorage(workflow: WorkflowItem[], bucket: string): WorkflowItem[] {
+  return workflow.map((item) => {
+    if (item.type === 'image' || item.type === 'video' || item.type === 'audio') {
+      return {
+        ...item,
+        value: stripToKey(item.value, bucket) || item.value,
+        thumbnailUrl: stripToKey(item.thumbnailUrl, bucket),
+        optimizedUrl: stripToKey(item.optimizedUrl, bucket),
+      };
+    }
+    return item;
+  });
+}


### PR DESCRIPTION
## What

Two new confirmation-gated tools in the shared MCP / in-app-assistant registry:

| Tool | Archives | Default |
| :-- | :-- | :-- |
| `export_project` | A whole project as a portable bundle — settings, workflow, album metadata and every media file they reference (importable by another Remix Studio installation) | full project |
| `export_project_album` | The media saved in a project's album | **the entire album**; `item_ids` narrows it, `export_version` picks raw/optimized |

Both queue the same `ExportManager` jobs the web UI queues, wait up to `wait_seconds` (default 120, max 600) for the archive, and return a presigned `downloadUrl` when it lands. If the archive is still building, the response carries `taskId` + progress and the caller re-invokes the same tool with `task_id` to keep waiting rather than starting a second export. Responses also carry `projectUrl`, matching the app-link convention the other tools follow. Storage-quota refusals surface the same message as the HTTP routes.

## Why

Agents could already browse album items (`get_album_items`) and sign individual files (`get_file_urls`), but there was no way to hand the user a whole album as one download, or to back up / move a project between installations — both of which the web interface has had for a while.

## How

`POST /api/projects/:id/export` and `POST /api/projects/:id/export-bundle` had their bodies lifted into `server/services/project-export.ts` (`startProjectAlbumExport` / `startProjectBundleExport`, plus a `ProjectExportError` carrying the HTTP status). The routes now call the service, so the tools and the UI produce byte-identical archives instead of two drifting copies of the manifest logic. `stripToKey` / `normalizeWorkflowForStorage` moved out of `routes/projects.ts` into `server/utils/storage-keys.ts` so the service can use them.

`ToolDependencies` gained `exportManager`, and `storage` / `exportStorage` are now typed `S3Storage` (what every caller already passed) because the bundle builder needs `getBucketName` / `exists`. `server.ts` adds `exportManager` to the shared `toolDeps` object.

## Reviewer notes

- Export tools are `category: 'mutate'`, so they go through the existing two-call confirmation protocol — including the `task_id` polling call. That is a little chatty; the alternative was a third read-only status tool, which the request didn't ask for.
- The 404 body for these two routes changed from `Project not found` to `Project "<id>" not found`. Status codes are unchanged.
- Watermarked album export stays route-only; the tool doesn't expose `watermarkSettings`.
- Docs and the assistant system prompt are updated.
- Rebased onto current `main`, so it sits on top of the app-link (#59) and job-drafting (#61) tool work rather than conflicting with it.

## Testing

- `tsc --noEmit` passes on the rebased tree.
- Smoke-tested tool registration with stub deps: 35 tools register, both new tools resolve their defaults (`export_project_album` defaults to the whole album), and the confirmation preview renders the expected summary.
- No real export was executed — that would have written an archive into the account's exports list and counted against its quota.

🤖 Generated with [Claude Code](https://claude.com/claude-code)