### PR TITLE
Fix album grid layout on mobile portrait orientation

### DIFF
--- a/src/components/ProjectViewer/AlbumTab.tsx
+++ b/src/components/ProjectViewer/AlbumTab.tsx
@@ -670,8 +670,11 @@ export function AlbumTab({
         ) : (
           // Column count follows the pane's width, not the window's. Each step keeps
           // cards at ~200px or wider — below that the overlay controls and the
-          // metadata rows stop fitting.
-          <div className="grid grid-cols-1 @min-[26rem]/pane:grid-cols-2 @min-[44rem]/pane:grid-cols-3 @min-[60rem]/pane:grid-cols-4 @min-[76rem]/pane:grid-cols-5 @min-[92rem]/pane:grid-cols-6 gap-3 @xl/pane:gap-4 p-3 @xl/pane:p-4">
+          // metadata rows stop fitting. Every step is also gated on `sm:` so phones
+          // in portrait stay one card per row: there the pane spans the whole
+          // viewport, which is wide enough to trip the 26rem step but far too narrow
+          // to read two cards side by side.
+          <div className="grid grid-cols-1 sm:@min-[26rem]/pane:grid-cols-2 sm:@min-[44rem]/pane:grid-cols-3 sm:@min-[60rem]/pane:grid-cols-4 sm:@min-[76rem]/pane:grid-cols-5 sm:@min-[92rem]/pane:grid-cols-6 gap-3 @xl/pane:gap-4 p-3 @xl/pane:p-4">
             {displayItems.map((item, index) => {
               const isSelected = selectedAlbumIds.has(item.id);
               const aspectRatioStr = getCssAspectRatio(item.aspectRatio);


### PR DESCRIPTION
## Summary
Fixed the album grid layout to prevent unreadable multi-column layouts on mobile devices in portrait orientation.

## Key Changes
- Added `sm:` breakpoint prefix to all container query breakpoints (`@min-[*]/pane:grid-cols-*`) in the album grid
- This ensures that on small screens (phones in portrait), the grid stays at a single column regardless of pane width
- Updated the comment to explain the rationale: the pane spans the full viewport width on mobile, which can trigger multi-column breakpoints despite being too narrow for readable multi-column layouts

## Implementation Details
The fix uses Tailwind&#39;s `sm:` breakpoint to gate the container query-based column changes. This prevents the grid from expanding to multiple columns on portrait phones where the pane width equals the viewport width, while maintaining the responsive multi-column behavior on larger screens and landscape orientations.
