### PR TITLE
Add batch selection and deletion for exports

### DIFF
--- a/src/locales/en/workspace.json
+++ b/src/locales/en/workspace.json
@@ -50,10 +50,23 @@
     },
     "pagination": "Page {{current}} of {{total}}",
     "loadMore": "Load More Exports",
+    "selection": {
+      "selectAll": "Select page",
+      "deselectAll": "Clear selection",
+      "selected": "{{count}} selected",
+      "selectItem": "Select export",
+      "deselectItem": "Deselect export",
+      "deleteSelected": "Delete selected",
+      "deleteSuccess": "Deleted {{count}} exports.",
+      "deleteFailed": "Failed to delete {{count}} exports."
+    },
     "deleteDialog": {
       "title": "Delete Export Record",
       "message": "Are you sure you want to delete this export record? This action cannot be undone.",
-      "confirm": "Delete Record"
+      "confirm": "Delete Record",
+      "batchTitle": "Delete Selected Exports",
+      "batchMessage": "Are you sure you want to delete {{count}} export records? This action cannot be undone.",
+      "batchConfirm": "Delete Exports"
     }
   },
   "projectImports": {

--- a/src/locales/fr/workspace.json
+++ b/src/locales/fr/workspace.json
@@ -50,10 +50,23 @@
     },
     "pagination": "Page {{current}} sur {{total}}",
     "loadMore": "Charger plus d'exports",
+    "selection": {
+      "selectAll": "Sélectionner la page",
+      "deselectAll": "Effacer la sélection",
+      "selected": "{{count}} sélectionné(s)",
+      "selectItem": "Sélectionner l'export",
+      "deselectItem": "Désélectionner l'export",
+      "deleteSelected": "Supprimer la sélection",
+      "deleteSuccess": "{{count}} exports supprimés.",
+      "deleteFailed": "Échec de la suppression de {{count}} exports."
+    },
     "deleteDialog": {
       "title": "Supprimer l'enregistrement d'exportation",
       "message": "Êtes-vous sûr de vouloir supprimer cet enregistrement d'exportation ? Cette action ne peut pas être annulée.",
-      "confirm": "Supprimer l'enregistrement"
+      "confirm": "Supprimer l'enregistrement",
+      "batchTitle": "Supprimer les exports sélectionnés",
+      "batchMessage": "Voulez-vous vraiment supprimer {{count}} enregistrements d'exportation ? Cette action est irréversible.",
+      "batchConfirm": "Supprimer les exports"
     }
   },
   "projectImports": {

--- a/src/locales/ja/workspace.json
+++ b/src/locales/ja/workspace.json
@@ -50,10 +50,23 @@
     },
     "pagination": "{{total}} ページ中 {{current}} ページ",
     "loadMore": "さらにエクスポートを読み込む",
+    "selection": {
+      "selectAll": "このページを選択",
+      "deselectAll": "選択を解除",
+      "selected": "{{count}} 件選択中",
+      "selectItem": "エクスポートを選択",
+      "deselectItem": "エクスポートの選択を解除",
+      "deleteSelected": "選択項目を削除",
+      "deleteSuccess": "{{count}} 件のエクスポートを削除しました。",
+      "deleteFailed": "{{count}} 件のエクスポートを削除できませんでした。"
+    },
     "deleteDialog": {
       "title": "エクスポートレコードの削除",
       "message": "このエクスポートレコードを削除してもよろしいですか？この操作は取り消せません。",
-      "confirm": "レコードを削除"
+      "confirm": "レコードを削除",
+      "batchTitle": "選択したエクスポートを削除",
+      "batchMessage": "{{count}} 件のエクスポートレコードを削除してもよろしいですか？この操作は取り消せません。",
+      "batchConfirm": "エクスポートを削除"
     }
   },
   "projectImports": {

--- a/src/locales/ko/workspace.json
+++ b/src/locales/ko/workspace.json
@@ -50,10 +50,23 @@
     },
     "pagination": "{{total}}페이지 중 {{current}}페이지",
     "loadMore": "내보내기 더 불러오기",
+    "selection": {
+      "selectAll": "현재 페이지 선택",
+      "deselectAll": "선택 해제",
+      "selected": "{{count}}개 선택됨",
+      "selectItem": "내보내기 선택",
+      "deselectItem": "내보내기 선택 해제",
+      "deleteSelected": "선택 항목 삭제",
+      "deleteSuccess": "내보내기 {{count}}개를 삭제했습니다.",
+      "deleteFailed": "내보내기 {{count}}개를 삭제하지 못했습니다."
+    },
     "deleteDialog": {
       "title": "내보내기 기록 삭제",
       "message": "이 내보내기 기록을 삭제하시겠습니까? 이 작업은 취소할 수 없습니다.",
-      "confirm": "기록 삭제"
+      "confirm": "기록 삭제",
+      "batchTitle": "선택한 내보내기 삭제",
+      "batchMessage": "내보내기 기록 {{count}}개를 삭제하시겠습니까? 이 작업은 취소할 수 없습니다.",
+      "batchConfirm": "내보내기 삭제"
     }
   },
   "projectImports": {

--- a/src/locales/zh-CN/workspace.json
+++ b/src/locales/zh-CN/workspace.json
@@ -50,10 +50,23 @@
     },
     "pagination": "第 {{current}} / {{total}} 页",
     "loadMore": "加载更多导出",
+    "selection": {
+      "selectAll": "选择本页",
+      "deselectAll": "取消全选",
+      "selected": "已选择 {{count}} 项",
+      "selectItem": "选择导出",
+      "deselectItem": "取消选择导出",
+      "deleteSelected": "删除所选",
+      "deleteSuccess": "已删除 {{count}} 个导出。",
+      "deleteFailed": "{{count}} 个导出删除失败。"
+    },
     "deleteDialog": {
       "title": "删除导出记录",
       "message": "确定要删除此导出记录吗？此操作无法撤销。",
-      "confirm": "删除记录"
+      "confirm": "删除记录",
+      "batchTitle": "删除所选导出",
+      "batchMessage": "确定要删除所选的 {{count}} 条导出记录吗？此操作无法撤销。",
+      "batchConfirm": "删除导出"
     }
   },
   "projectImports": {

--- a/src/locales/zh-TW/workspace.json
+++ b/src/locales/zh-TW/workspace.json
@@ -50,10 +50,23 @@
     },
     "pagination": "第 {{current}} / {{total}} 頁",
     "loadMore": "載入更多匯出",
+    "selection": {
+      "selectAll": "選擇本頁",
+      "deselectAll": "取消全選",
+      "selected": "已選擇 {{count}} 項",
+      "selectItem": "選擇匯出",
+      "deselectItem": "取消選擇匯出",
+      "deleteSelected": "刪除所選",
+      "deleteSuccess": "已刪除 {{count}} 個匯出。",
+      "deleteFailed": "{{count}} 個匯出刪除失敗。"
+    },
     "deleteDialog": {
       "title": "刪除匯出紀錄",
       "message": "確定要刪除此匯出紀錄嗎？此操作無法撤銷。",
-      "confirm": "刪除紀錄"
+      "confirm": "刪除紀錄",
+      "batchTitle": "刪除所選匯出",
+      "batchMessage": "確定要刪除所選的 {{count}} 筆匯出紀錄嗎？此操作無法撤銷。",
+      "batchConfirm": "刪除匯出"
     }
   },
   "projectImports": {

--- a/src/pages/Exports.tsx
+++ b/src/pages/Exports.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
-import { Download, Loader2, CheckCircle2, XCircle, Trash2, Clock, ArrowRight, List, HardDrive, Cloud, Upload, Rocket, Tag, History as HistoryIcon } from 'lucide-react';
+import { Download, Loader2, CheckCircle2, XCircle, Trash2, Clock, ArrowRight, List, HardDrive, Cloud, Upload, Rocket, Tag, History as HistoryIcon, Square, CheckSquare } from 'lucide-react';
 import { Link, useSearchParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { ExportTask, DeliveryStatus } from '../types';
@@ -27,7 +27,8 @@ export function Exports() {
   const [total, setTotal] = useState(0);
   const [pages, setPages] = useState(1);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
-  const [taskToDelete, setTaskToDelete] = useState<string | null>(null);
+  const [taskIdsToDelete, setTaskIdsToDelete] = useState<string[]>([]);
+  const [selectedTaskIds, setSelectedTaskIds] = useState<Set<string>>(() => new Set());
   const [taskToUploadDrive, setTaskToUploadDrive] = useState<ExportTask | null>(null);
   const [selectedDriveId, setSelectedDriveId] = useState<string | null>(null);
 
@@ -182,6 +183,11 @@ export function Exports() {
       setExports(items);
       setTotal(nextTotal);
       setPages(nextPages);
+      setSelectedTaskIds(prev => {
+        const visibleIds = new Set(items.map(item => item.id));
+        const next = new Set([...prev].filter(id => visibleIds.has(id)));
+        return next.size === prev.size ? prev : next;
+      });
       setDeliveries(prev => {
         const next = { ...prev };
         for (const delivery of activeDeliveries) {
@@ -223,6 +229,7 @@ export function Exports() {
   }, [hasActiveExportTasks, loadExports, page]);
 
   const handlePageChange = (newPage: number) => {
+    setSelectedTaskIds(new Set());
     setSearchParams(prev => {
       const next = new URLSearchParams(prev);
       next.set('page', newPage.toString());
@@ -244,26 +251,67 @@ export function Exports() {
     };
   };
 
-  const handleDelete = async (taskId: string) => {
-    setTaskToDelete(taskId);
+  const handleDelete = (taskId: string) => {
+    setTaskIdsToDelete([taskId]);
+    setShowDeleteConfirm(true);
+  };
+
+  const toggleTaskSelection = (taskId: string) => {
+    setSelectedTaskIds(prev => {
+      const next = new Set(prev);
+      if (next.has(taskId)) {
+        next.delete(taskId);
+      } else {
+        next.add(taskId);
+      }
+      return next;
+    });
+  };
+
+  const toggleSelectAll = () => {
+    setSelectedTaskIds(prev => (
+      prev.size === exports.length
+        ? new Set()
+        : new Set(exports.map(task => task.id))
+    ));
+  };
+
+  const handleDeleteSelected = () => {
+    if (selectedTaskIds.size === 0) return;
+    setTaskIdsToDelete([...selectedTaskIds]);
     setShowDeleteConfirm(true);
   };
 
   const confirmDelete = async () => {
-    if (!taskToDelete) return;
-    try {
-      await deleteExport(taskToDelete);
-      if (exports.length <= 1 && page > 1) {
+    if (taskIdsToDelete.length === 0) return;
+
+    const results = await Promise.allSettled(taskIdsToDelete.map(taskId => deleteExport(taskId)));
+    const deletedIds = taskIdsToDelete.filter((_, index) => results[index].status === 'fulfilled');
+    const failedCount = taskIdsToDelete.length - deletedIds.length;
+
+    setSelectedTaskIds(prev => {
+      const next = new Set(prev);
+      deletedIds.forEach(taskId => next.delete(taskId));
+      return next.size === prev.size ? prev : next;
+    });
+
+    if (deletedIds.length > 0) {
+      if (taskIdsToDelete.length > 1) {
+        toast.success(t('exports.selection.deleteSuccess', { count: deletedIds.length }));
+      }
+      if (exports.length <= deletedIds.length && page > 1) {
         handlePageChange(page - 1);
       } else {
         await loadExports(page, { showLoading: false });
       }
-    } catch (err: any) {
-      toast.error(`Failed to delete export record: ${err.message}`);
-    } finally {
-      setTaskToDelete(null);
-      setShowDeleteConfirm(false);
     }
+
+    if (failedCount > 0) {
+      toast.error(t('exports.selection.deleteFailed', { count: failedCount }));
+    }
+
+    setTaskIdsToDelete([]);
+    setShowDeleteConfirm(false);
   };
 
   const handleUploadToDrive = (task: ExportTask) => {
@@ -373,8 +421,43 @@ export function Exports() {
         </div>
       ) : (
         <div className="space-y-3">
+          {exports.length > 0 && (
+            <div className="flex flex-col gap-3 rounded-card border border-neutral-200/50 bg-white/50 p-3 shadow-sm backdrop-blur-xl dark:border-white/5 dark:bg-neutral-900/50 sm:flex-row sm:items-center sm:justify-between">
+              <div className="flex items-center gap-3">
+                <button
+                  type="button"
+                  onClick={toggleSelectAll}
+                  className="inline-flex items-center gap-2 rounded-lg px-2 py-1.5 text-[10px] font-black uppercase tracking-widest text-neutral-600 transition hover:bg-neutral-100 hover:text-neutral-900 dark:text-neutral-400 dark:hover:bg-white/5 dark:hover:text-white"
+                >
+                  {selectedTaskIds.size === exports.length ? (
+                    <CheckSquare className="h-4 w-4 text-blue-500" />
+                  ) : (
+                    <Square className="h-4 w-4" />
+                  )}
+                  {selectedTaskIds.size === exports.length
+                    ? t('exports.selection.deselectAll')
+                    : t('exports.selection.selectAll')}
+                </button>
+                {selectedTaskIds.size > 0 && (
+                  <span className="text-[10px] font-black uppercase tracking-widest text-blue-500">
+                    {t('exports.selection.selected', { count: selectedTaskIds.size })}
+                  </span>
+                )}
+              </div>
+              <button
+                type="button"
+                onClick={handleDeleteSelected}
+                disabled={selectedTaskIds.size === 0}
+                className="inline-flex items-center justify-center gap-2 rounded-xl bg-red-600 px-4 py-2.5 text-[10px] font-black uppercase tracking-widest text-white shadow-lg shadow-red-600/20 transition hover:bg-red-500 active:scale-95 disabled:cursor-not-allowed disabled:opacity-40 disabled:shadow-none"
+              >
+                <Trash2 className="h-4 w-4" />
+                {t('exports.selection.deleteSelected')}
+              </button>
+            </div>
+          )}
           {exports.map((task) => {
             const taskTarget = getTaskTarget(task);
+            const isSelected = selectedTaskIds.has(task.id);
             const driveDelivery = getDriveDelivery(task.id);
             const isDriveUploading = driveDelivery && (driveDelivery.status === 'pending' || driveDelivery.status === 'processing');
             const driveProgress = driveDelivery && driveDelivery.totalBytes
@@ -389,9 +472,19 @@ export function Exports() {
             return (
               <div
                 key={task.id}
-                className={`bg-white/70 dark:bg-neutral-900/70 p-4 md:p-5 rounded-card border flex flex-col sm:flex-row sm:items-center justify-between gap-4 transition-ui group/task shadow-sm hover:shadow-xl backdrop-blur-xl duration-300 hover:-translate-y-0.5 ${task.status === 'failed' ? 'border-red-500/30' : 'border-neutral-200/50 dark:border-white/5 hover:border-blue-500/50'}`}
+                className={`bg-white/70 dark:bg-neutral-900/70 p-4 md:p-5 rounded-card border flex flex-col sm:flex-row sm:items-center justify-between gap-4 transition-ui group/task shadow-sm hover:shadow-xl backdrop-blur-xl duration-300 hover:-translate-y-0.5 ${isSelected ? 'border-blue-500 ring-2 ring-blue-500/10' : task.status === 'failed' ? 'border-red-500/30' : 'border-neutral-200/50 dark:border-white/5 hover:border-blue-500/50'}`}
               >
                 <div className="flex items-center gap-4 flex-1 min-w-0">
+                  <button
+                    type="button"
+                    onClick={() => toggleTaskSelection(task.id)}
+                    className={`flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-lg border transition active:scale-90 ${isSelected ? 'border-blue-500 bg-blue-500 text-white shadow-sm shadow-blue-500/20' : 'border-neutral-200 bg-white/70 text-neutral-400 hover:border-blue-400 hover:text-blue-500 dark:border-white/10 dark:bg-neutral-950/50'}`}
+                    aria-label={isSelected ? t('exports.selection.deselectItem') : t('exports.selection.selectItem')}
+                    aria-pressed={isSelected}
+                    title={isSelected ? t('exports.selection.deselectItem') : t('exports.selection.selectItem')}
+                  >
+                    {isSelected ? <CheckSquare className="h-4 w-4" /> : <Square className="h-4 w-4" />}
+                  </button>
                   {/* Status Indicator Bar */}
                   <div className={`w-1 h-10 sm:h-8 rounded-full flex-shrink-0 ${
                     task.status === 'completed' ? 'bg-emerald-500 shadow-[0_0_8px_rgba(16,185,129,0.5)]' :
@@ -573,12 +666,14 @@ export function Exports() {
         isOpen={showDeleteConfirm}
         onClose={() => {
           setShowDeleteConfirm(false);
-          setTaskToDelete(null);
+          setTaskIdsToDelete([]);
         }}
         onConfirm={confirmDelete}
-        title={t('exports.deleteDialog.title')}
-        message={t('exports.deleteDialog.message')}
-        confirmText={t('exports.deleteDialog.confirm')}
+        title={taskIdsToDelete.length > 1 ? t('exports.deleteDialog.batchTitle') : t('exports.deleteDialog.title')}
+        message={taskIdsToDelete.length > 1
+          ? t('exports.deleteDialog.batchMessage', { count: taskIdsToDelete.length })
+          : t('exports.deleteDialog.message')}
+        confirmText={taskIdsToDelete.length > 1 ? t('exports.deleteDialog.batchConfirm') : t('exports.deleteDialog.confirm')}
         type="danger"
       />
 


### PR DESCRIPTION
## Summary

- Add page-level and individual export selection controls.
- Support batch deletion with confirmation, success, and failure feedback.
- Preserve selection state safely across refreshes and pagination.
- Add localized selection and batch-delete strings for supported languages.

## Testing

- Not run (not requested)