### PR TITLE
Add posting trend chart visualization to campaign history

### DIFF
--- a/server/routes/campaigns.ts
+++ b/server/routes/campaigns.ts
@@ -77,6 +77,59 @@ export function createCampaignsRouter(prisma: PrismaClient, storage: S3Storage) 
     }
   });
 
+  // Daily delivery counts for the posting-trend chart.
+  // Buckets executions by the user's local date so the chart lines up with the
+  // day boundaries they see everywhere else in the UI.
+  campaignsRouter.get('/api/campaigns/posted-counts', authMiddleware, async (c) => {
+    const user = c.get('user') as JwtPayload;
+    const from = c.req.query('from');
+    const to = c.req.query('to');
+    const timezoneOffsetMinutes = Number(c.req.query('timezoneOffsetMinutes') || 0);
+
+    if (!from || !to) {
+      return c.json({ error: 'Missing from or to parameters' }, 400);
+    }
+
+    const fromDate = new Date(from);
+    const toDate = new Date(to);
+    if (Number.isNaN(fromDate.getTime()) || Number.isNaN(toDate.getTime())) {
+      return c.json({ error: 'Invalid from or to parameters' }, 400);
+    }
+
+    try {
+      const executions = await prisma.postExecution.findMany({
+        where: {
+          post: { userId: user.userId },
+          OR: [
+            { status: 'posted', publishedAt: { gte: fromDate, lte: toDate } },
+            { status: 'failed', updatedAt: { gte: fromDate, lte: toDate } },
+          ],
+        },
+        select: { status: true, publishedAt: true, updatedAt: true },
+      });
+
+      const offsetMinutes = Number.isFinite(timezoneOffsetMinutes) ? timezoneOffsetMinutes : 0;
+      const counts: Record<string, { date: string; posted: number; failed: number }> = {};
+
+      executions.forEach((execution) => {
+        const at = execution.status === 'posted'
+          ? (execution.publishedAt ?? execution.updatedAt)
+          : execution.updatedAt;
+        if (!at) return;
+
+        const dateKey = new Date(at.getTime() - offsetMinutes * 60000).toISOString().split('T')[0];
+        if (!counts[dateKey]) counts[dateKey] = { date: dateKey, posted: 0, failed: 0 };
+        if (execution.status === 'posted') counts[dateKey].posted++;
+        else counts[dateKey].failed++;
+      });
+
+      return c.json(Object.values(counts).sort((a, b) => a.date.localeCompare(b.date)));
+    } catch (error) {
+      console.error('Failed to get posted counts:', error);
+      return c.json({ error: 'Failed to fetch posted counts' }, 500);
+    }
+  });
+
   campaignsRouter.get('/api/campaigns/history', authMiddleware, async (c) => {
     console.log('[DEBUG] GET /api/campaigns/history called');
     const user = c.get('user') as JwtPayload;

--- a/src/api.ts
+++ b/src/api.ts
@@ -1691,6 +1691,18 @@ export async function fetchRecentPosts(limit = 20): Promise<any[]> {
   return handleResponse<any[]>(res, 'Failed to fetch recent posts');
 }
 
+export interface PostedCountBucket {
+  date: string;
+  posted: number;
+  failed: number;
+}
+
+export async function fetchPostedCounts(from: string, to: string, timezoneOffsetMinutes: number): Promise<PostedCountBucket[]> {
+  const params = new URLSearchParams({ from, to, timezoneOffsetMinutes: timezoneOffsetMinutes.toString() });
+  const res = await apiFetch(`/api/campaigns/posted-counts?${params.toString()}`, { headers: getHeaders(false) });
+  return handleResponse<PostedCountBucket[]>(res, 'Failed to fetch posted counts');
+}
+
 export async function fetchCampaignHistory(page = 1, pageSize = 25, startDate?: string, endDate?: string, q?: string): Promise<{ items: any[], total: number, page: number, pageSize: number, totalPages: number }> {
   const params = new URLSearchParams({ page: page.toString(), pageSize: pageSize.toString() });
   if (startDate) params.set('startDate', startDate);

--- a/src/components/PostingTrendChart.tsx
+++ b/src/components/PostingTrendChart.tsx
@@ -1,0 +1,437 @@
+import React, { useEffect, useId, useMemo, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { fetchPostedCounts } from '../api';
+import { cn } from '../lib/utils';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function startOfLocalDay(value: Date) {
+  const date = new Date(value);
+  date.setHours(0, 0, 0, 0);
+  return date;
+}
+
+function endOfLocalDay(value: Date) {
+  const date = new Date(value);
+  date.setHours(23, 59, 59, 999);
+  return date;
+}
+
+function localDateKey(value: Date) {
+  const month = `${value.getMonth() + 1}`.padStart(2, '0');
+  const day = `${value.getDate()}`.padStart(2, '0');
+  return `${value.getFullYear()}-${month}-${day}`;
+}
+
+/** Local-day range covering the last `days` days, today included. */
+export function lastNDaysRange(days: number) {
+  const to = endOfLocalDay(new Date());
+  const from = startOfLocalDay(new Date(to.getTime() - (days - 1) * DAY_MS));
+  return { from, to };
+}
+
+/** Integer axis ticks that comfortably cover `max`. */
+function axisTicks(max: number) {
+  const nice = [1, 2, 5, 10, 20, 25, 50, 100, 200, 250, 500, 1000];
+  const rawStep = Math.max(1, Math.ceil(Math.max(max, 1) / 4));
+  const step = nice.find((candidate) => candidate >= rawStep) ?? Math.ceil(rawStep / 1000) * 1000;
+  const top = Math.max(step, Math.ceil(max / step) * step);
+  const ticks: number[] = [];
+  for (let value = 0; value <= top; value += step) ticks.push(value);
+  return { top, ticks };
+}
+
+interface DayBucket {
+  date: Date;
+  key: string;
+  posted: number;
+  failed: number;
+}
+
+interface PostingTrendChartProps {
+  from: Date;
+  to: Date;
+  className?: string;
+  /** Plot height in px. Defaults to a width-aware value so phones get a shorter chart. */
+  height?: number;
+}
+
+export function PostingTrendChart({ from, to, className, height }: PostingTrendChartProps) {
+  const { t, i18n } = useTranslation();
+  const gradientId = useId();
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  const [width, setWidth] = useState(0);
+  const [buckets, setBuckets] = useState<DayBucket[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [hasError, setHasError] = useState(false);
+  const [activeIndex, setActiveIndex] = useState<number | null>(null);
+
+  const fromTime = startOfLocalDay(from).getTime();
+  const toTime = endOfLocalDay(to).getTime();
+
+  useEffect(() => {
+    const element = containerRef.current;
+    if (!element) return;
+
+    setWidth(element.clientWidth);
+    const observer = new ResizeObserver((entries) => {
+      for (const entry of entries) setWidth(entry.contentRect.width);
+    });
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    const rangeStart = new Date(fromTime);
+    const rangeEnd = new Date(toTime);
+
+    const emptyBuckets: DayBucket[] = [];
+    // Cap the bucket count so an extreme custom range can't blow up the render.
+    for (const cursor = new Date(rangeStart); cursor <= rangeEnd && emptyBuckets.length < 400; cursor.setDate(cursor.getDate() + 1)) {
+      const date = new Date(cursor);
+      emptyBuckets.push({ date, key: localDateKey(date), posted: 0, failed: 0 });
+    }
+
+    const load = async () => {
+      setIsLoading(true);
+      setHasError(false);
+      try {
+        const counts = await fetchPostedCounts(
+          rangeStart.toISOString(),
+          rangeEnd.toISOString(),
+          new Date().getTimezoneOffset(),
+        );
+        if (cancelled) return;
+        const byDate = new Map(counts.map((entry) => [entry.date, entry]));
+        setBuckets(emptyBuckets.map((bucket) => ({
+          ...bucket,
+          posted: byDate.get(bucket.key)?.posted ?? 0,
+          failed: byDate.get(bucket.key)?.failed ?? 0,
+        })));
+      } catch (error) {
+        if (cancelled) return;
+        console.error('Failed to load posting trend', error);
+        setBuckets(emptyBuckets);
+        setHasError(true);
+      } finally {
+        if (!cancelled) setIsLoading(false);
+      }
+    };
+
+    void load();
+    return () => {
+      cancelled = true;
+    };
+  }, [fromTime, toTime]);
+
+  const totals = useMemo(() => buckets.reduce(
+    (acc, bucket) => ({ posted: acc.posted + bucket.posted, failed: acc.failed + bucket.failed }),
+    { posted: 0, failed: 0 },
+  ), [buckets]);
+
+  const isCompact = width > 0 && width < 400;
+  const plotHeight = height ?? (isCompact ? 150 : 190);
+  const padding = { top: 18, right: 10, bottom: 22, left: isCompact ? 22 : 28 };
+  const innerWidth = Math.max(0, width - padding.left - padding.right);
+  const innerHeight = Math.max(0, plotHeight - padding.top - padding.bottom);
+
+  const showFailed = totals.failed > 0;
+  const maxValue = buckets.reduce(
+    (max, bucket) => Math.max(max, bucket.posted, showFailed ? bucket.failed : 0),
+    0,
+  );
+  const { top: axisTop, ticks } = axisTicks(maxValue);
+
+  const pointX = (index: number) => {
+    if (buckets.length <= 1) return padding.left + innerWidth / 2;
+    return padding.left + (index * innerWidth) / (buckets.length - 1);
+  };
+  const pointY = (value: number) => padding.top + innerHeight - (value / axisTop) * innerHeight;
+
+  const linePath = (pick: (bucket: DayBucket) => number) =>
+    buckets.map((bucket, index) => `${index === 0 ? 'M' : 'L'}${pointX(index).toFixed(2)},${pointY(pick(bucket)).toFixed(2)}`).join(' ');
+
+  const areaPath = () => {
+    if (buckets.length === 0) return '';
+    const baseline = padding.top + innerHeight;
+    return `${linePath((bucket) => bucket.posted)} L${pointX(buckets.length - 1).toFixed(2)},${baseline} L${pointX(0).toFixed(2)},${baseline} Z`;
+  };
+
+  const spansWeekOrLess = buckets.length <= 7;
+  const dateFormatter = useMemo(() => new Intl.DateTimeFormat(i18n.language, spansWeekOrLess
+    ? { weekday: 'short' }
+    : { month: 'numeric', day: 'numeric' }), [i18n.language, spansWeekOrLess]);
+  const tooltipFormatter = useMemo(() => new Intl.DateTimeFormat(i18n.language, {
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric',
+  }), [i18n.language]);
+
+  const labelIndices = useMemo(() => {
+    if (buckets.length === 0) return [];
+    const maxLabels = Math.max(2, Math.floor(Math.max(innerWidth, 1) / (spansWeekOrLess ? 38 : 44)));
+    const step = Math.max(1, Math.ceil(buckets.length / maxLabels));
+    const indices: number[] = [];
+    for (let index = 0; index < buckets.length; index += step) indices.push(index);
+
+    // Always label the last day, but drop the one before it if they would collide.
+    const last = buckets.length - 1;
+    if (indices[indices.length - 1] !== last) {
+      if (last - indices[indices.length - 1] < Math.ceil(step * 0.75)) indices.pop();
+      indices.push(last);
+    }
+    return indices;
+  }, [buckets.length, innerWidth, spansWeekOrLess]);
+
+  const peakIndex = useMemo(() => {
+    if (buckets.length === 0 || maxValue === 0) return -1;
+    return buckets.reduce((best, bucket, index) => (bucket.posted > buckets[best].posted ? index : best), 0);
+  }, [buckets, maxValue]);
+
+  const indexFromPointer = (event: React.PointerEvent<SVGRectElement>) => {
+    if (buckets.length === 0) return null;
+    const bounds = event.currentTarget.getBoundingClientRect();
+    const offsetX = event.clientX - bounds.left;
+    if (buckets.length === 1) return 0;
+    const ratio = offsetX / Math.max(1, bounds.width);
+    return Math.min(buckets.length - 1, Math.max(0, Math.round(ratio * (buckets.length - 1))));
+  };
+
+  const isEmpty = !isLoading && totals.posted === 0 && totals.failed === 0;
+  // Per-day dots turn into noise past a couple of weeks; the crosshair still
+  // exposes every day's exact value.
+  const showMarkers = !isEmpty && buckets.length <= 14;
+  const activeBucket = activeIndex != null ? buckets[activeIndex] : null;
+  const tooltipLeft = activeIndex != null
+    ? Math.min(Math.max(pointX(activeIndex), 72), Math.max(72, width - 72))
+    : 0;
+
+  return (
+    <div
+      className={cn(
+        'rounded-card border border-neutral-200/50 bg-white/70 p-4 shadow-sm backdrop-blur-xl dark:border-white/5 dark:bg-neutral-900/70 sm:p-6',
+        className,
+      )}
+    >
+      <div className="flex flex-wrap items-end justify-between gap-3">
+        <div className="min-w-0">
+          <div className="text-[10px] font-black uppercase tracking-[0.18em] text-neutral-400 dark:text-neutral-500">
+            {t('postingTrend.label')}
+          </div>
+          <div className="mt-1 flex items-baseline gap-2">
+            <span className="text-3xl font-semibold tabular-nums tracking-tight text-neutral-900 dark:text-white">
+              {isLoading ? '—' : totals.posted}
+            </span>
+            <span className="text-[13px] font-medium text-neutral-500">
+              {t('postingTrend.rangeSummary', { days: buckets.length })}
+            </span>
+          </div>
+        </div>
+
+        {showFailed && (
+          <div className="flex items-center gap-3 text-[11px] font-semibold text-neutral-500 dark:text-neutral-400">
+            <span className="flex items-center gap-1.5">
+              <span className="h-2 w-2 rounded-full bg-indigo-500" />
+              {t('postingTrend.posted')}
+            </span>
+            <span className="flex items-center gap-1.5">
+              <span className="h-2 w-2 rounded-full bg-red-500" />
+              {t('postingTrend.failed')}
+            </span>
+          </div>
+        )}
+      </div>
+
+      <div ref={containerRef} className="relative mt-4 w-full">
+        {width > 0 && (
+          <svg
+            width={width}
+            height={plotHeight}
+            viewBox={`0 0 ${width} ${plotHeight}`}
+            className="block text-indigo-500"
+            role="img"
+            aria-label={t('postingTrend.ariaLabel', { n: totals.posted })}
+          >
+            <defs>
+              <linearGradient id={`${gradientId}-area`} x1="0" y1="0" x2="0" y2="1">
+                <stop offset="0%" stopColor="currentColor" stopOpacity="0.22" />
+                <stop offset="100%" stopColor="currentColor" stopOpacity="0" />
+              </linearGradient>
+            </defs>
+
+            {/* Grid + y-axis */}
+            {ticks.map((tick) => (
+              <g key={tick}>
+                <line
+                  x1={padding.left}
+                  x2={width - padding.right}
+                  y1={pointY(tick)}
+                  y2={pointY(tick)}
+                  className="stroke-neutral-200 dark:stroke-white/10"
+                  strokeWidth={1}
+                  strokeDasharray={tick === 0 ? undefined : '3 4'}
+                />
+                <text
+                  x={padding.left - 6}
+                  y={pointY(tick) + 3}
+                  textAnchor="end"
+                  className="fill-neutral-400 text-[9px] tabular-nums dark:fill-neutral-500"
+                >
+                  {tick}
+                </text>
+              </g>
+            ))}
+
+            {/* X labels */}
+            {labelIndices.map((index) => (
+              <text
+                key={buckets[index].key}
+                x={pointX(index)}
+                y={plotHeight - 6}
+                textAnchor={index === 0 ? 'start' : index === buckets.length - 1 ? 'end' : 'middle'}
+                className="fill-neutral-400 text-[9px] dark:fill-neutral-500"
+              >
+                {dateFormatter.format(buckets[index].date)}
+              </text>
+            ))}
+
+            {!isLoading && buckets.length > 0 && (
+              <>
+                {!isEmpty && <path d={areaPath()} fill={`url(#${gradientId}-area)`} />}
+
+                {showFailed && (
+                  <g className="text-red-500">
+                    <path
+                      d={linePath((bucket) => bucket.failed)}
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth={2}
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeOpacity={0.85}
+                    />
+                  </g>
+                )}
+
+                <path
+                  d={linePath((bucket) => bucket.posted)}
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth={2}
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  className={cn(isEmpty && 'text-neutral-300 dark:text-neutral-700')}
+                />
+
+                {showMarkers && buckets.map((bucket, index) => (
+                  <circle
+                    key={bucket.key}
+                    cx={pointX(index)}
+                    cy={pointY(bucket.posted)}
+                    r={activeIndex === index ? 5 : 4}
+                    fill="currentColor"
+                    className="stroke-white dark:stroke-neutral-900"
+                    strokeWidth={2}
+                  />
+                ))}
+
+                {/* Dense ranges drop their dots, so the hovered day still gets one. */}
+                {!showMarkers && !isEmpty && activeIndex != null && (
+                  <circle
+                    cx={pointX(activeIndex)}
+                    cy={pointY(buckets[activeIndex].posted)}
+                    r={5}
+                    fill="currentColor"
+                    className="stroke-white dark:stroke-neutral-900"
+                    strokeWidth={2}
+                  />
+                )}
+
+                {/* Selective direct label: the peak day only */}
+                {peakIndex >= 0 && activeIndex == null && (
+                  <text
+                    x={pointX(peakIndex)}
+                    y={pointY(buckets[peakIndex].posted) - 10}
+                    textAnchor={peakIndex === 0 ? 'start' : peakIndex === buckets.length - 1 ? 'end' : 'middle'}
+                    className="fill-neutral-900 text-[10px] font-bold tabular-nums dark:fill-white"
+                  >
+                    {buckets[peakIndex].posted}
+                  </text>
+                )}
+
+                {activeIndex != null && (
+                  <line
+                    x1={pointX(activeIndex)}
+                    x2={pointX(activeIndex)}
+                    y1={padding.top}
+                    y2={padding.top + innerHeight}
+                    className="stroke-neutral-400 dark:stroke-neutral-500"
+                    strokeWidth={1}
+                    strokeDasharray="3 3"
+                  />
+                )}
+              </>
+            )}
+
+            <rect
+              x={padding.left}
+              y={padding.top}
+              width={Math.max(0, innerWidth)}
+              height={Math.max(0, innerHeight)}
+              fill="transparent"
+              onPointerMove={(event) => setActiveIndex(indexFromPointer(event))}
+              onPointerDown={(event) => setActiveIndex(indexFromPointer(event))}
+              onPointerLeave={() => setActiveIndex(null)}
+              onPointerCancel={() => setActiveIndex(null)}
+            />
+          </svg>
+        )}
+
+        {isLoading && (
+          <div className="absolute inset-0 flex items-center justify-center">
+            <div className="h-2 w-32 animate-pulse rounded-full bg-neutral-200 dark:bg-neutral-800" />
+          </div>
+        )}
+
+        {isEmpty && !hasError && (
+          <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
+            <span className="rounded-full bg-white/80 px-3 py-1 text-[11px] font-medium text-neutral-500 dark:bg-neutral-900/80">
+              {t('postingTrend.empty')}
+            </span>
+          </div>
+        )}
+
+        {!isLoading && hasError && (
+          <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
+            <span className="rounded-full bg-white/80 px-3 py-1 text-[11px] font-medium text-red-500 dark:bg-neutral-900/80">
+              {t('postingTrend.error')}
+            </span>
+          </div>
+        )}
+
+        {activeBucket && (
+          <div
+            className="pointer-events-none absolute top-0 z-10 -translate-x-1/2 rounded-xl border border-neutral-200 bg-white px-3 py-2 text-left shadow-lg dark:border-white/10 dark:bg-neutral-900"
+            style={{ left: tooltipLeft }}
+          >
+            <div className="text-[10px] font-bold uppercase tracking-wider text-neutral-400 dark:text-neutral-500">
+              {tooltipFormatter.format(activeBucket.date)}
+            </div>
+            <div className="mt-1 flex items-center gap-1.5 text-[12px] font-semibold text-neutral-900 dark:text-white">
+              <span className="h-2 w-2 shrink-0 rounded-full bg-indigo-500" />
+              {t('postingTrend.postedCount', { n: activeBucket.posted })}
+            </div>
+            {activeBucket.failed > 0 && (
+              <div className="mt-0.5 flex items-center gap-1.5 text-[12px] font-semibold text-neutral-900 dark:text-white">
+                <span className="h-2 w-2 shrink-0 rounded-full bg-red-500" />
+                {t('postingTrend.failedCount', { n: activeBucket.failed })}
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/locales/en/campaigns.json
+++ b/src/locales/en/campaigns.json
@@ -12,6 +12,21 @@
   "viewAllHistory": "View All History",
   "viewAllScheduled": "View All Scheduled",
   "openCalendar": "Open Calendar",
+  "postingTrend": {
+    "title": "Posting Trend",
+    "label": "Delivered",
+    "rangeSummary": "posts over the last {{days}} days",
+    "posted": "Posted",
+    "failed": "Failed",
+    "postedCount": "{{n}} posted",
+    "failedCount": "{{n}} failed",
+    "empty": "No posts delivered in this period",
+    "error": "Couldn't load the chart",
+    "ariaLabel": "Daily posting trend, {{n}} posts delivered in this period",
+    "listView": "List",
+    "chartView": "Chart",
+    "lastNDays": "Last {{days}} days"
+  },
   "status": {
     "active": "Active Campaign",
     "paused": "Paused",

--- a/src/locales/fr/campaigns.json
+++ b/src/locales/fr/campaigns.json
@@ -12,6 +12,21 @@
   "viewAllHistory": "Voir tout l'historique",
   "viewAllScheduled": "Voir tout ce qui est programmé",
   "openCalendar": "Ouvrir le calendrier",
+  "postingTrend": {
+    "title": "Tendance des publications",
+    "label": "Publiés",
+    "rangeSummary": "publications sur les {{days}} derniers jours",
+    "posted": "Publié",
+    "failed": "Échec",
+    "postedCount": "{{n}} publié(s)",
+    "failedCount": "{{n}} en échec",
+    "empty": "Aucune publication sur cette période",
+    "error": "Impossible de charger le graphique",
+    "ariaLabel": "Tendance quotidienne des publications, {{n}} publications sur cette période",
+    "listView": "Liste",
+    "chartView": "Graphique",
+    "lastNDays": "{{days}} derniers jours"
+  },
   "status": {
     "active": "Campagne active",
     "paused": "En pause",

--- a/src/locales/ja/campaigns.json
+++ b/src/locales/ja/campaigns.json
@@ -12,6 +12,21 @@
   "viewAllHistory": "すべての履歴を表示",
   "viewAllScheduled": "すべての予約を表示",
   "openCalendar": "カレンダーを開く",
+  "postingTrend": {
+    "title": "投稿トレンド",
+    "label": "配信済み",
+    "rangeSummary": "件 · 直近 {{days}} 日間",
+    "posted": "成功",
+    "failed": "失敗",
+    "postedCount": "成功 {{n}} 件",
+    "failedCount": "失敗 {{n}} 件",
+    "empty": "この期間に配信された投稿はありません",
+    "error": "グラフを読み込めませんでした",
+    "ariaLabel": "日別の投稿トレンド、この期間に {{n}} 件配信",
+    "listView": "リスト",
+    "chartView": "グラフ",
+    "lastNDays": "直近 {{days}} 日間"
+  },
   "status": {
     "active": "実行中",
     "paused": "一時停止中",

--- a/src/locales/ko/campaigns.json
+++ b/src/locales/ko/campaigns.json
@@ -12,6 +12,21 @@
   "viewAllHistory": "모든 기록 보기",
   "viewAllScheduled": "모든 예약 보기",
   "openCalendar": "캘린더 열기",
+  "postingTrend": {
+    "title": "게시 추이",
+    "label": "전송됨",
+    "rangeSummary": "건 · 최근 {{days}}일",
+    "posted": "성공",
+    "failed": "실패",
+    "postedCount": "성공 {{n}}건",
+    "failedCount": "실패 {{n}}건",
+    "empty": "이 기간에 전송된 게시물이 없습니다",
+    "error": "차트를 불러오지 못했습니다",
+    "ariaLabel": "일별 게시 추이, 이 기간에 {{n}}건 전송",
+    "listView": "목록",
+    "chartView": "차트",
+    "lastNDays": "최근 {{days}}일"
+  },
   "status": {
     "active": "활성 캠페인",
     "paused": "일시 정지됨",

--- a/src/locales/zh-CN/campaigns.json
+++ b/src/locales/zh-CN/campaigns.json
@@ -12,6 +12,21 @@
   "viewAllHistory": "查看所有历史",
   "viewAllScheduled": "查看所有定时",
   "openCalendar": "打开日历",
+  "postingTrend": {
+    "title": "投送趋势",
+    "label": "已投送",
+    "rangeSummary": "条 · 最近 {{days}} 天",
+    "posted": "成功",
+    "failed": "失败",
+    "postedCount": "成功 {{n}} 条",
+    "failedCount": "失败 {{n}} 条",
+    "empty": "该时间段内没有投送记录",
+    "error": "图表加载失败",
+    "ariaLabel": "每日投送趋势，该时间段共投送 {{n}} 条",
+    "listView": "列表",
+    "chartView": "图表",
+    "lastNDays": "最近 {{days}} 天"
+  },
   "status": {
     "active": "正在进行",
     "paused": "已暂停",

--- a/src/locales/zh-TW/campaigns.json
+++ b/src/locales/zh-TW/campaigns.json
@@ -12,6 +12,21 @@
   "viewAllHistory": "查看所有歷史",
   "viewAllScheduled": "查看所有定時",
   "openCalendar": "打開日曆",
+  "postingTrend": {
+    "title": "投送趨勢",
+    "label": "已投送",
+    "rangeSummary": "則 · 最近 {{days}} 天",
+    "posted": "成功",
+    "failed": "失敗",
+    "postedCount": "成功 {{n}} 則",
+    "failedCount": "失敗 {{n}} 則",
+    "empty": "該時間範圍內沒有投送紀錄",
+    "error": "圖表載入失敗",
+    "ariaLabel": "每日投送趨勢，此期間共投送 {{n}} 則",
+    "listView": "列表",
+    "chartView": "圖表",
+    "lastNDays": "最近 {{days}} 天"
+  },
   "status": {
     "active": "正在進行",
     "paused": "已暫停",

--- a/src/pages/CampaignHistory.tsx
+++ b/src/pages/CampaignHistory.tsx
@@ -1,5 +1,6 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
 import {
   ArrowRight,
   Calendar,
@@ -8,6 +9,8 @@ import {
   ExternalLink,
   Filter,
   History,
+  LineChart,
+  List,
   Loader2,
   Megaphone,
   Search,
@@ -20,8 +23,12 @@ import { cn } from '../lib/utils';
 import { applyAvatarFallback, defaultAvatar } from '../lib/avatar';
 import { getPlatformIcon, fallbackExternalUrl } from '../lib/platform';
 import { PageNav } from '../components/PageNav';
+import { PostingTrendChart, lastNDaysRange } from '../components/PostingTrendChart';
+
+const TREND_RANGE_OPTIONS = [7, 14, 30] as const;
 
 export function CampaignHistory() {
+  const { t } = useTranslation();
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
   const [history, setHistory] = useState<any[]>([]);
@@ -39,6 +46,31 @@ export function CampaignHistory() {
   const [endDate, setEndDate] = useState(endDateParam);
   const [searchQuery, setSearchQuery] = useState(qParam);
 
+  const view = searchParams.get('view') === 'chart' ? 'chart' : 'list';
+  const [trendDays, setTrendDays] = useState<number>(30);
+
+  // The chart follows the page's date filter when one is set; otherwise it uses
+  // the quick range picker.
+  const explicitTrendRange = useMemo(() => {
+    if (!startDateParam || !endDateParam) return null;
+    const from = new Date(`${startDateParam}T00:00:00`);
+    const to = new Date(`${endDateParam}T23:59:59`);
+    if (Number.isNaN(from.getTime()) || Number.isNaN(to.getTime()) || from > to) return null;
+    return { from, to };
+  }, [startDateParam, endDateParam]);
+
+  const trendRange = useMemo(
+    () => explicitTrendRange ?? lastNDaysRange(trendDays),
+    [explicitTrendRange, trendDays],
+  );
+
+  const setView = (nextView: 'list' | 'chart') => {
+    const params = new URLSearchParams(searchParams);
+    if (nextView === 'chart') params.set('view', 'chart');
+    else params.delete('view');
+    setSearchParams(params, { replace: true });
+  };
+
   const loadHistory = async () => {
     setIsLoading(true);
     try {
@@ -55,11 +87,12 @@ export function CampaignHistory() {
   };
 
   useEffect(() => {
-    void loadHistory();
+    // The chart pulls its own aggregates, so skip the list request while it is shown.
+    if (view === 'list') void loadHistory();
     setStartDate(startDateParam);
     setEndDate(endDateParam);
     setSearchQuery(qParam);
-  }, [page, pageSize, startDateParam, endDateParam, qParam]);
+  }, [page, pageSize, startDateParam, endDateParam, qParam, view]);
 
   const applyFilters = () => {
     const params = new URLSearchParams(searchParams);
@@ -105,9 +138,39 @@ export function CampaignHistory() {
           className="mb-0 md:mb-4"
         />
 
-        <div className="flex flex-col sm:flex-row sm:items-center gap-3 mb-2">
+        <div className="flex flex-col sm:flex-row sm:flex-wrap sm:items-center gap-3 mb-2">
+          {/* View switcher */}
+          <div className="flex w-full items-center gap-1 rounded-card border border-neutral-200 bg-white p-1 shadow-sm dark:border-white/10 dark:bg-neutral-900 sm:w-auto">
+            <button
+              onClick={() => setView('list')}
+              className={cn(
+                'flex h-8 flex-1 items-center justify-center gap-1.5 rounded-[10px] px-3 text-xs font-bold transition-colors sm:flex-none',
+                view === 'list'
+                  ? 'bg-indigo-600 text-white shadow-sm'
+                  : 'text-neutral-500 hover:bg-neutral-100 dark:text-neutral-400 dark:hover:bg-white/5',
+              )}
+              aria-pressed={view === 'list'}
+            >
+              <List className="h-3.5 w-3.5" />
+              {t('postingTrend.listView')}
+            </button>
+            <button
+              onClick={() => setView('chart')}
+              className={cn(
+                'flex h-8 flex-1 items-center justify-center gap-1.5 rounded-[10px] px-3 text-xs font-bold transition-colors sm:flex-none',
+                view === 'chart'
+                  ? 'bg-indigo-600 text-white shadow-sm'
+                  : 'text-neutral-500 hover:bg-neutral-100 dark:text-neutral-400 dark:hover:bg-white/5',
+              )}
+              aria-pressed={view === 'chart'}
+            >
+              <LineChart className="h-3.5 w-3.5" />
+              {t('postingTrend.chartView')}
+            </button>
+          </div>
+
           {/* Search bar */}
-          <div className="relative w-full sm:w-80">
+          <div className={cn('relative w-full sm:w-80', view === 'chart' && 'hidden')}>
             <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-neutral-400" />
             <input
               type="text"
@@ -160,6 +223,31 @@ export function CampaignHistory() {
           </div>
         </div>
 
+        {view === 'chart' ? (
+          <div className="flex flex-col gap-3">
+            {!explicitTrendRange && (
+              <div className="flex items-center gap-1.5 overflow-x-auto pb-0.5">
+                {TREND_RANGE_OPTIONS.map((days) => (
+                  <button
+                    key={days}
+                    onClick={() => setTrendDays(days)}
+                    className={cn(
+                      'h-8 shrink-0 rounded-full border px-3.5 text-xs font-bold transition-colors',
+                      trendDays === days
+                        ? 'border-indigo-600 bg-indigo-600 text-white shadow-sm'
+                        : 'border-neutral-200 bg-white text-neutral-500 hover:text-neutral-900 dark:border-white/10 dark:bg-neutral-900 dark:text-neutral-400 dark:hover:text-white',
+                    )}
+                    aria-pressed={trendDays === days}
+                  >
+                    {t('postingTrend.lastNDays', { days })}
+                  </button>
+                ))}
+              </div>
+            )}
+
+            <PostingTrendChart from={trendRange.from} to={trendRange.to} height={280} />
+          </div>
+        ) : (
         <div className="overflow-hidden rounded-card border border-neutral-200/50 bg-white shadow-sm dark:border-white/5 dark:bg-neutral-900/50">
           {/* Header Row */}
           <div className="hidden lg:grid lg:grid-cols-[240px_1fr_1fr_160px_100px] items-center gap-4 px-6 py-3 bg-neutral-50 dark:bg-white/5 border-b border-neutral-200/50 dark:border-white/5 text-[11px] font-semibold uppercase tracking-wider text-neutral-500">
@@ -303,6 +391,7 @@ export function CampaignHistory() {
             </div>
           )}
         </div>
+        )}
       </div>
     </div>
   );

--- a/src/pages/Campaigns.tsx
+++ b/src/pages/Campaigns.tsx
@@ -13,6 +13,7 @@ import {
   Plus,
   Search,
   Share2,
+  TrendingUp,
 } from 'lucide-react';
 // lucide-react 1.x dropped its brand icons; react-icons still carries them.
 import { FaInstagram, FaLinkedin, FaFacebook } from 'react-icons/fa6';
@@ -23,6 +24,7 @@ import { ConfirmDialog } from '../components/ConfirmDialog';
 import { PageHeader } from '../components/PageHeader';
 import { cn } from '../lib/utils';
 import { applyAvatarFallback, defaultAvatar } from '../lib/avatar';
+import { PostingTrendChart, lastNDaysRange } from '../components/PostingTrendChart';
 
 type CampaignStatus = 'Active' | 'Inactive';
 
@@ -137,6 +139,7 @@ export function Campaigns() {
   const [recentPostsLoading, setRecentPostsLoading] = useState(true);
   const [scheduledPosts, setScheduledPosts] = useState<any[]>([]);
   const [scheduledPostsLoading, setScheduledPostsLoading] = useState(true);
+  const trendRange = useMemo(() => lastNDaysRange(7), []);
 
   const loadData = async () => {
     setIsLoading(true);
@@ -403,8 +406,19 @@ export function Campaigns() {
             )}
           </section>
 
-          {/* Right Column: Recently Posted & Scheduled */}
+          {/* Right Column: Posting Trend, Recently Posted & Scheduled */}
           <aside className="lg:col-span-1 space-y-8">
+            <div className="space-y-6">
+              <div className="flex h-10 items-center justify-between">
+                <h3 className="flex items-center gap-2 text-xl font-semibold text-neutral-900 dark:text-white">
+                  <TrendingUp className="h-5 w-5 text-indigo-500" />
+                  {t('postingTrend.title')}
+                </h3>
+              </div>
+
+              <PostingTrendChart from={trendRange.from} to={trendRange.to} />
+            </div>
+
             <div className="space-y-6">
               <div className="flex h-10 items-center justify-between">
                 <h3 className="flex items-center gap-2 text-xl font-semibold text-neutral-900 dark:text-white">


### PR DESCRIPTION
## Summary
This PR adds a new posting trend chart component that visualizes daily post delivery metrics over time. Users can now toggle between a list view and a chart view in the campaign history page, with the ability to select different time ranges (7, 14, or 30 days).

## Key Changes

- **New `PostingTrendChart` component** (`src/components/PostingTrendChart.tsx`):
  - Interactive SVG-based chart showing daily posted and failed post counts
  - Responsive design with adaptive layout for mobile/desktop
  - Hover tooltips displaying exact counts for each day
  - Peak day highlighting when not hovering
  - Gradient-filled area chart with optional failed posts line overlay
  - Automatic axis scaling with intelligent tick generation
  - Accessibility features including ARIA labels and semantic HTML

- **Backend API endpoint** (`server/routes/campaigns.ts`):
  - New `/api/campaigns/posted-counts` endpoint that aggregates daily execution counts
  - Respects user's local timezone for date bucketing
  - Filters posts by `publishedAt` (for posted) and `updatedAt` (for failed)
  - Returns sorted date-keyed buckets with posted/failed counts

- **Campaign History page enhancements** (`src/pages/CampaignHistory.tsx`):
  - View switcher toggle between list and chart modes
  - Quick range selector (7/14/30 days) for chart view
  - Chart respects existing date filters when set
  - Skips list data loading when chart view is active

- **Dashboard integration** (`src/pages/Campaigns.tsx`):
  - Embedded 7-day posting trend chart on main dashboard
  - Uses new `lastNDaysRange` utility for consistent date handling

- **Internationalization**:
  - Added `postingTrend` translation keys to all 6 supported languages (EN, FR, JA, KO, ZH-CN, ZH-TW)
  - Includes labels for chart elements, empty states, and view toggles

- **API client** (`src/api.ts`):
  - New `fetchPostedCounts` function with `PostedCountBucket` interface

## Notable Implementation Details

- **Date handling**: Uses local day boundaries (00:00:00 to 23:59:59) consistently across frontend and backend, with timezone offset support
- **Responsive rendering**: Chart height and label density adapt based on viewport width and date range span
- **Performance**: Caps bucket count at 400 to prevent rendering issues with extreme date ranges
- **Graceful degradation**: Shows loading skeleton, empty state, or error message as appropriate
- **Accessibility**: Includes proper ARIA labels, semantic SVG structure, and keyboard-friendly interactions

https://claude.ai/code/session_01Ko6MSrKv9UfN4efrViFkBZ