### PR TITLE
fix(ui): repair light mode colors in model selector and related dialogs

### DIFF
--- a/src/components/CopyMoveItemsDialog.tsx
+++ b/src/components/CopyMoveItemsDialog.tsx
@@ -80,11 +80,11 @@ export function CopyMoveItemsDialog({
 
   return (
     <div
-      className="fixed inset-0 z-[300] flex items-center justify-center p-4 sm:p-6 bg-black/80 backdrop-blur-md animate-in fade-in duration-300"
+      className="fixed inset-0 z-[300] flex items-center justify-center p-4 sm:p-6 bg-black/60 dark:bg-black/80 backdrop-blur-md animate-in fade-in duration-300"
       onClick={() => !submitting && onClose()}
     >
       <div
-        className="bg-white/40 dark:bg-neutral-900/40 border border-neutral-200/50 dark:border-white/5 backdrop-blur-3xl rounded-card shadow-[0_50px_100px_rgba(0,0,0,0.8)] max-w-lg w-full max-h-[calc(100dvh-2rem)] overflow-y-auto overscroll-contain animate-in zoom-in-95 duration-300"
+        className="bg-white dark:bg-neutral-900/40 dark:backdrop-blur-3xl border border-neutral-200 dark:border-white/5 rounded-card shadow-2xl dark:shadow-[0_50px_100px_rgba(0,0,0,0.8)] max-w-lg w-full max-h-[calc(100dvh-2rem)] overflow-y-auto overscroll-contain animate-in zoom-in-95 duration-300"
         onClick={(e) => e.stopPropagation()}
       >
         <div className="p-5 sm:p-8">
@@ -140,7 +140,7 @@ export function CopyMoveItemsDialog({
         <div className="px-5 py-4 sm:px-8 sm:py-6 pb-[max(1rem,env(safe-area-inset-bottom))] bg-neutral-50/40 dark:bg-neutral-950/40 flex flex-wrap items-center justify-end gap-3 sm:gap-4 border-t border-neutral-200/50 dark:border-neutral-800/50">
           <button
             onClick={() => !submitting && onClose()}
-            className="px-4 sm:px-6 py-2.5 rounded-xl text-xs font-black uppercase tracking-widest text-neutral-500 dark:text-neutral-500 hover:text-neutral-900 dark:hover:text-neutral-200 hover:bg-neutral-200/50 dark:hover:bg-neutral-800/50 transition-all border border-transparent hover:border-neutral-800/80 active:scale-95"
+            className="px-4 sm:px-6 py-2.5 rounded-xl text-xs font-black uppercase tracking-widest text-neutral-500 dark:text-neutral-500 hover:text-neutral-900 dark:hover:text-neutral-200 hover:bg-neutral-200/50 dark:hover:bg-neutral-800/50 transition-all border border-transparent hover:border-neutral-300 dark:hover:border-neutral-800/80 active:scale-95"
             disabled={submitting}
           >
             {t('common.cancel', 'Cancel')}

--- a/src/components/DuplicateLibraryDialog.tsx
+++ b/src/components/DuplicateLibraryDialog.tsx
@@ -42,11 +42,11 @@ export function DuplicateLibraryDialog({
 
   return (
     <div
-      className="fixed inset-0 z-[300] flex items-center justify-center p-4 sm:p-6 bg-black/80 backdrop-blur-md animate-in fade-in duration-300"
+      className="fixed inset-0 z-[300] flex items-center justify-center p-4 sm:p-6 bg-black/60 dark:bg-black/80 backdrop-blur-md animate-in fade-in duration-300"
       onClick={() => !submitting && onClose()}
     >
       <div
-        className="bg-white/40 dark:bg-neutral-900/40 border border-neutral-200/50 dark:border-white/5 backdrop-blur-3xl rounded-card shadow-[0_50px_100px_rgba(0,0,0,0.8)] max-w-lg w-full max-h-[calc(100dvh-2rem)] overflow-y-auto overscroll-contain animate-in zoom-in-95 duration-300"
+        className="bg-white dark:bg-neutral-900/40 dark:backdrop-blur-3xl border border-neutral-200 dark:border-white/5 rounded-card shadow-2xl dark:shadow-[0_50px_100px_rgba(0,0,0,0.8)] max-w-lg w-full max-h-[calc(100dvh-2rem)] overflow-y-auto overscroll-contain animate-in zoom-in-95 duration-300"
         onClick={(e) => e.stopPropagation()}
       >
         <div className="p-5 sm:p-8">
@@ -93,7 +93,7 @@ export function DuplicateLibraryDialog({
         <div className="px-5 py-4 sm:px-8 sm:py-6 pb-[max(1rem,env(safe-area-inset-bottom))] bg-neutral-50/40 dark:bg-neutral-950/40 flex flex-wrap items-center justify-end gap-3 sm:gap-4 border-t border-neutral-200/50 dark:border-neutral-800/50">
           <button
             onClick={() => !submitting && onClose()}
-            className="px-4 sm:px-6 py-2.5 rounded-xl text-xs font-black uppercase tracking-widest text-neutral-500 dark:text-neutral-500 hover:text-neutral-900 dark:hover:text-neutral-200 hover:bg-neutral-200/50 dark:hover:bg-neutral-800/50 transition-all border border-transparent hover:border-neutral-800/80 active:scale-95"
+            className="px-4 sm:px-6 py-2.5 rounded-xl text-xs font-black uppercase tracking-widest text-neutral-500 dark:text-neutral-500 hover:text-neutral-900 dark:hover:text-neutral-200 hover:bg-neutral-200/50 dark:hover:bg-neutral-800/50 transition-all border border-transparent hover:border-neutral-300 dark:hover:border-neutral-800/80 active:scale-95"
             disabled={submitting}
           >
             {t('libraries.duplicateDialog.cancel')}

--- a/src/components/ExportFileNameModal.tsx
+++ b/src/components/ExportFileNameModal.tsx
@@ -35,11 +35,11 @@ export function ExportFileNameModal({
 
   return (
     <div
-      className="fixed inset-0 z-[350] flex items-center justify-center p-4 sm:p-6 bg-black/80 backdrop-blur-md animate-in fade-in duration-300"
+      className="fixed inset-0 z-[350] flex items-center justify-center p-4 sm:p-6 bg-black/60 dark:bg-black/80 backdrop-blur-md animate-in fade-in duration-300"
       onClick={() => !exporting && onClose()}
     >
       <div
-        className="bg-white/40 dark:bg-neutral-900/40 border border-neutral-200/50 dark:border-white/5 backdrop-blur-3xl rounded-card shadow-[0_50px_100px_rgba(0,0,0,0.8)] max-w-lg w-full max-h-[calc(100dvh-2rem)] overflow-y-auto overscroll-contain animate-in zoom-in-95 duration-300"
+        className="bg-white dark:bg-neutral-900/40 dark:backdrop-blur-3xl border border-neutral-200 dark:border-white/5 rounded-card shadow-2xl dark:shadow-[0_50px_100px_rgba(0,0,0,0.8)] max-w-lg w-full max-h-[calc(100dvh-2rem)] overflow-y-auto overscroll-contain animate-in zoom-in-95 duration-300"
         onClick={(e) => e.stopPropagation()}
       >
         <div className="p-5 sm:p-8">
@@ -87,7 +87,7 @@ export function ExportFileNameModal({
         <div className="px-5 py-4 sm:px-8 sm:py-6 pb-[max(1rem,env(safe-area-inset-bottom))] bg-neutral-50/40 dark:bg-neutral-950/40 flex flex-wrap items-center justify-end gap-3 sm:gap-4 border-t border-neutral-200/50 dark:border-neutral-800/50">
           <button
             onClick={() => !exporting && onClose()}
-            className="px-4 sm:px-6 py-2.5 rounded-xl text-xs font-black uppercase tracking-widest text-neutral-500 dark:text-neutral-500 hover:text-neutral-900 dark:hover:text-neutral-200 hover:bg-neutral-200/50 dark:hover:bg-neutral-800/50 transition-all border border-transparent hover:border-neutral-800/80 active:scale-95"
+            className="px-4 sm:px-6 py-2.5 rounded-xl text-xs font-black uppercase tracking-widest text-neutral-500 dark:text-neutral-500 hover:text-neutral-900 dark:hover:text-neutral-200 hover:bg-neutral-200/50 dark:hover:bg-neutral-800/50 transition-all border border-transparent hover:border-neutral-300 dark:hover:border-neutral-800/80 active:scale-95"
             disabled={exporting}
           >
             {t('libraryEditor.exportModal.cancel', 'Cancel')}

--- a/src/components/LibraryEditor.tsx
+++ b/src/components/LibraryEditor.tsx
@@ -510,7 +510,7 @@ export function LibraryEditor({ library, onUpdate, onDelete }: Props) {
 
               <button
                 onClick={handleStartAssistantChat}
-                className="p-2.5 text-neutral-600 dark:text-neutral-400 hover:text-neutral-900 dark:hover:text-white hover:bg-neutral-200/80 dark:hover:bg-neutral-800/80 rounded-xl transition-all border border-neutral-200/50 dark:border-neutral-800/50 hover:border-neutral-700 active:scale-95"
+                className="p-2.5 text-neutral-600 dark:text-neutral-400 hover:text-neutral-900 dark:hover:text-white hover:bg-neutral-200/80 dark:hover:bg-neutral-800/80 rounded-xl transition-all border border-neutral-200/50 dark:border-neutral-800/50 hover:border-neutral-300 dark:hover:border-neutral-700 active:scale-95"
                 title={t('libraryEditor.startAssistantChat', { defaultValue: 'Start assistant chat for this library' })}
                 aria-label={t('libraryEditor.startAssistantChat', { defaultValue: 'Start assistant chat for this library' })}
               >
@@ -527,7 +527,7 @@ export function LibraryEditor({ library, onUpdate, onDelete }: Props) {
 
               <button
                 onClick={() => navigate(`/library/${library.id}/edit`)}
-                className="p-2.5 text-neutral-600 dark:text-neutral-400 hover:text-neutral-900 dark:hover:text-white hover:bg-neutral-200/80 dark:hover:bg-neutral-800/80 rounded-xl transition-all border border-neutral-200/50 dark:border-neutral-800/50 hover:border-neutral-700 active:scale-95"
+                className="p-2.5 text-neutral-600 dark:text-neutral-400 hover:text-neutral-900 dark:hover:text-white hover:bg-neutral-200/80 dark:hover:bg-neutral-800/80 rounded-xl transition-all border border-neutral-200/50 dark:border-neutral-800/50 hover:border-neutral-300 dark:hover:border-neutral-700 active:scale-95"
                 title={t('libraryEditor.editLibrarySettings')}
               >
                 <Settings className="w-5 h-5" />
@@ -720,7 +720,7 @@ export function LibraryEditor({ library, onUpdate, onDelete }: Props) {
                 <div className="w-px h-4 bg-neutral-200/60 dark:bg-neutral-800/60 mx-1"></div>
                 <button
                   onClick={() => setSelectedItemIds(new Set())}
-                  className="p-1 text-neutral-500 dark:text-neutral-500 hover:text-white transition-colors"
+                  className="p-1 text-neutral-500 dark:text-neutral-500 hover:text-neutral-900 dark:hover:text-white transition-colors"
                 >
                   <X className="w-4 h-4" />
                 </button>
@@ -976,7 +976,7 @@ export function LibraryEditor({ library, onUpdate, onDelete }: Props) {
             <div className="px-8 py-6 bg-neutral-50/40 dark:bg-neutral-950/40 flex items-center justify-end gap-4 border-t border-neutral-200/50 dark:border-neutral-800/50">
               <button
                 onClick={() => setShowReferencesModal(false)}
-                className="px-6 py-2.5 rounded-xl text-xs font-black uppercase tracking-widest text-neutral-500 dark:text-neutral-500 hover:text-neutral-900 dark:hover:text-neutral-200 hover:bg-neutral-200/50 dark:hover:bg-neutral-800/50 transition-all border border-transparent hover:border-neutral-800/80 active:scale-95"
+                className="px-6 py-2.5 rounded-xl text-xs font-black uppercase tracking-widest text-neutral-500 dark:text-neutral-500 hover:text-neutral-900 dark:hover:text-neutral-200 hover:bg-neutral-200/50 dark:hover:bg-neutral-800/50 transition-all border border-transparent hover:border-neutral-300 dark:hover:border-neutral-800/80 active:scale-95"
               >
                 {t('confirmModal.cancel')}
               </button>

--- a/src/components/ProjectViewer/AlbumTab.tsx
+++ b/src/components/ProjectViewer/AlbumTab.tsx
@@ -606,7 +606,7 @@ export function AlbumTab({
                     <button
                       type="button"
                       onClick={() => toggleAudioExpand(item.id)}
-                      className="flex-shrink-0 p-1 text-neutral-500 dark:text-neutral-500 hover:text-white transition-colors"
+                      className="flex-shrink-0 p-1 text-neutral-500 dark:text-neutral-500 hover:text-neutral-900 dark:hover:text-white transition-colors"
                       title={isExpanded ? t('projectViewer.album.collapse') : t('projectViewer.album.expand')}
                       aria-label={isExpanded ? t('projectViewer.album.collapse') : t('projectViewer.album.expand')}
                     >
@@ -819,7 +819,7 @@ export function AlbumTab({
                       className="mb-3 @min-[16rem]/card:mb-4 block w-full text-left rounded-xl focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/60 h-10"
                       title={t('projectViewer.album.viewFullPrompt')}
                     >
-                      <p className="text-[11px] leading-relaxed text-neutral-600 dark:text-neutral-400 line-clamp-2 font-medium group-hover:text-neutral-200 transition-colors cursor-pointer hover:text-white">
+                      <p className="text-[11px] leading-relaxed text-neutral-600 dark:text-neutral-400 line-clamp-2 font-medium dark:group-hover:text-neutral-200 transition-colors cursor-pointer hover:text-neutral-900 dark:hover:text-white">
                         {item.prompt}
                       </p>
                     </button>

--- a/src/components/ProjectViewer/CopyToLibraryDialog.tsx
+++ b/src/components/ProjectViewer/CopyToLibraryDialog.tsx
@@ -265,7 +265,7 @@ export function CopyToLibraryDialog({
         <div className="flex flex-col-reverse sm:flex-row items-stretch sm:items-center justify-end gap-2 sm:gap-3 border-t border-neutral-200 dark:border-neutral-800 bg-neutral-50/40 dark:bg-neutral-950/40 p-4 sm:p-6">
           <button
             onClick={onClose}
-            className="w-full sm:w-auto px-6 py-3 sm:py-2.5 text-[10px] font-black uppercase tracking-widest text-neutral-600 dark:text-neutral-400 transition-all hover:text-white border border-neutral-200/80 dark:border-neutral-800/80 sm:border-transparent rounded-xl"
+            className="w-full sm:w-auto px-6 py-3 sm:py-2.5 text-[10px] font-black uppercase tracking-widest text-neutral-600 dark:text-neutral-400 transition-all hover:text-neutral-900 dark:hover:text-white border border-neutral-200/80 dark:border-neutral-800/80 sm:border-transparent rounded-xl"
             disabled={isSubmitting}
           >
             {t('projectViewer.common.cancel')}

--- a/src/components/ProjectViewer/EmptyState.tsx
+++ b/src/components/ProjectViewer/EmptyState.tsx
@@ -10,7 +10,7 @@ interface EmptyStateProps {
 
 export function EmptyState({ Icon, title, description, animateIcon = true }: EmptyStateProps) {
   return (
-    <div className="bg-white/40 dark:bg-neutral-900/40 border-2 border-dashed border-neutral-200/50 dark:border-white/5 rounded-card p-12 md:p-24 m-4 md:m-8 text-center text-neutral-500 dark:text-neutral-500 flex flex-col items-center gap-6 transition-colors hover:border-neutral-700 shadow-inner backdrop-blur-xl animate-in fade-in zoom-in duration-700">
+    <div className="bg-white/40 dark:bg-neutral-900/40 border-2 border-dashed border-neutral-200/50 dark:border-white/5 rounded-card p-12 md:p-24 m-4 md:m-8 text-center text-neutral-500 dark:text-neutral-500 flex flex-col items-center gap-6 transition-colors hover:border-neutral-300 dark:hover:border-neutral-700 shadow-inner backdrop-blur-xl animate-in fade-in zoom-in duration-700">
       <Icon className={`w-16 h-16 text-neutral-800 dark:text-neutral-700 ${animateIcon ? 'animate-pulse' : 'opacity-20'}`} />
       <div>
         <p className="text-sm font-bold text-neutral-600 dark:text-neutral-400 tracking-wider uppercase">

--- a/src/components/ProjectViewer/ExportPackageDialog.tsx
+++ b/src/components/ProjectViewer/ExportPackageDialog.tsx
@@ -131,7 +131,7 @@ export function ExportPackageDialog({
         <div className="flex flex-col-reverse sm:flex-row items-stretch sm:items-center justify-end gap-2 sm:gap-3 border-t border-neutral-200 dark:border-neutral-800 bg-neutral-50/40 dark:bg-neutral-950/40 p-4 sm:p-6">
           <button
             onClick={onClose}
-            className="w-full sm:w-auto px-6 py-3 sm:py-2.5 text-[10px] font-black uppercase tracking-widest text-neutral-600 dark:text-neutral-400 transition-all hover:text-white border border-neutral-200/80 dark:border-neutral-800/80 sm:border-transparent rounded-xl"
+            className="w-full sm:w-auto px-6 py-3 sm:py-2.5 text-[10px] font-black uppercase tracking-widest text-neutral-600 dark:text-neutral-400 transition-all hover:text-neutral-900 dark:hover:text-white border border-neutral-200/80 dark:border-neutral-800/80 sm:border-transparent rounded-xl"
             disabled={isSubmitting}
           >
             {t('projectViewer.common.cancel')}

--- a/src/components/ProjectViewer/JobListItem.tsx
+++ b/src/components/ProjectViewer/JobListItem.tsx
@@ -69,7 +69,7 @@ export function JobListItem({
     ? accentClasses[accentColor]
     : isExpanded
       ? expandedClasses[accentColor]
-      : `border-neutral-200 dark:border-neutral-800 hover:border-neutral-700 ${borderClassName}`.trim();
+      : `border-neutral-200 dark:border-neutral-800 hover:border-neutral-300 dark:hover:border-neutral-700 ${borderClassName}`.trim();
 
   return (
     <div className="flex flex-col gap-0 animate-in fade-in slide-in-from-top-2 duration-300 border-b border-neutral-200/50 dark:border-neutral-800/50">
@@ -83,7 +83,7 @@ export function JobListItem({
               e.stopPropagation();
               onToggleSelect(job.id, e.shiftKey);
             }}
-            className={`flex-shrink-0 p-1 rounded-lg transition-colors ${isSelected ? selectedTextClasses[accentColor] : 'text-neutral-500 dark:text-neutral-500 hover:text-white'}`}
+            className={`flex-shrink-0 p-1 rounded-lg transition-colors ${isSelected ? selectedTextClasses[accentColor] : 'text-neutral-500 dark:text-neutral-500 hover:text-neutral-900 dark:hover:text-white'}`}
           >
             {isSelected ? <CheckSquare className="w-4 h-4" /> : <Square className="w-4 h-4" />}
           </button>

--- a/src/components/ProjectViewer/LibraryPreviewModal.tsx
+++ b/src/components/ProjectViewer/LibraryPreviewModal.tsx
@@ -184,7 +184,7 @@ export function LibraryPreviewModal({
                   className={`shrink-0 px-2.5 py-1 rounded-full text-[11px] font-semibold transition-all border ${
                     selectedTags.length === 0
                       ? 'bg-blue-600 text-white border-transparent'
-                      : 'bg-neutral-50 dark:bg-neutral-950 text-neutral-500 dark:text-neutral-500 border-neutral-200 dark:border-neutral-800 hover:border-neutral-700'
+                      : 'bg-neutral-50 dark:bg-neutral-950 text-neutral-500 dark:text-neutral-500 border-neutral-200 dark:border-neutral-800 hover:border-neutral-300 dark:hover:border-neutral-700'
                   }`}
                 >
                   {t('projectViewer.libraryPreview.allItems')}
@@ -197,7 +197,7 @@ export function LibraryPreviewModal({
                     className={`shrink-0 max-w-[60vw] md:max-w-80 px-2.5 py-1 rounded-full text-[11px] font-semibold transition-all border ${
                       isTagSelected(tag)
                         ? 'bg-blue-600/20 text-blue-500 dark:text-blue-400 border-blue-500/50'
-                        : 'bg-neutral-50 dark:bg-neutral-950 text-neutral-500 dark:text-neutral-500 border-neutral-200 dark:border-neutral-800 hover:border-neutral-700'
+                        : 'bg-neutral-50 dark:bg-neutral-950 text-neutral-500 dark:text-neutral-500 border-neutral-200 dark:border-neutral-800 hover:border-neutral-300 dark:hover:border-neutral-700'
                     }`}
                   >
                     <span className="block truncate">{tag}</span>

--- a/src/components/ProjectViewer/LibrarySelectionModal.tsx
+++ b/src/components/ProjectViewer/LibrarySelectionModal.tsx
@@ -177,7 +177,7 @@ export function LibrarySelectionModal({
         <div className="p-4 sm:p-6 pb-[max(1rem,env(safe-area-inset-bottom))] border-t border-neutral-200 dark:border-neutral-800 bg-neutral-50/40 dark:bg-neutral-950/40 flex justify-end">
           <button 
             onClick={onClose}
-            className="px-6 py-2.5 text-neutral-600 dark:text-neutral-400 hover:text-white font-bold uppercase tracking-widest text-[10px] transition-all"
+            className="px-6 py-2.5 text-neutral-600 dark:text-neutral-400 hover:text-neutral-900 dark:hover:text-white font-bold uppercase tracking-widest text-[10px] transition-all"
           >
             {t('projectViewer.common.cancel')}
           </button>

--- a/src/components/ProjectViewer/ModelSelectorModal.tsx
+++ b/src/components/ProjectViewer/ModelSelectorModal.tsx
@@ -44,15 +44,15 @@ export function ModelSelectorModal({
 
   return (
     <div 
-      className="fixed inset-0 z-[200] flex items-center justify-center p-3 sm:p-4 md:p-6 bg-black/90 backdrop-blur-xl animate-in fade-in duration-300"
+      className="fixed inset-0 z-[200] flex items-center justify-center p-3 sm:p-4 md:p-6 bg-black/60 dark:bg-black/90 backdrop-blur-xl animate-in fade-in duration-300"
       onClick={onClose}
     >
       <div
-        className="bg-white/40 dark:bg-neutral-900/40 border border-neutral-200/50 dark:border-white/5 backdrop-blur-3xl rounded-card md:rounded-[40px] shadow-[0_50px_100px_rgba(0,0,0,0.9)] max-w-4xl w-full max-h-[calc(100dvh-1.5rem)] sm:max-h-[85dvh] overflow-hidden flex flex-col animate-in zoom-in-95 duration-300"
+        className="bg-white dark:bg-neutral-900/40 dark:backdrop-blur-3xl border border-neutral-200 dark:border-white/5 rounded-card md:rounded-[40px] shadow-2xl dark:shadow-[0_50px_100px_rgba(0,0,0,0.9)] max-w-4xl w-full max-h-[calc(100dvh-1.5rem)] sm:max-h-[85dvh] overflow-hidden flex flex-col animate-in zoom-in-95 duration-300"
         onClick={(e) => e.stopPropagation()}
       >
         {/* Header */}
-        <div className="p-4 sm:p-6 md:p-8 border-b border-neutral-200/50 dark:border-neutral-800/50 flex flex-col gap-4 sm:gap-5 bg-neutral-50/20 dark:bg-neutral-950/20 backdrop-blur-md">
+        <div className="p-4 sm:p-6 md:p-8 border-b border-neutral-200 dark:border-neutral-800/50 flex flex-col gap-4 sm:gap-5 bg-neutral-50 dark:bg-neutral-950/20 dark:backdrop-blur-md">
           <div className="flex items-start justify-between gap-3">
             <div className="min-w-0">
               <h3 className="text-xl sm:text-2xl md:text-3xl font-black text-neutral-900 dark:text-white tracking-tight leading-none mb-2">{t('projectViewer.modelSelector.title')}</h3>
@@ -60,7 +60,7 @@ export function ModelSelectorModal({
             </div>
             <button 
               onClick={onClose}
-              className="p-2.5 md:p-3 bg-neutral-200/50 dark:bg-neutral-800/50 hover:bg-neutral-200 dark:hover:bg-neutral-800 text-neutral-600 dark:text-neutral-400 hover:text-neutral-900 dark:hover:text-white rounded-xl md:rounded-card transition-all active:scale-90 border border-neutral-300/60 dark:border-neutral-700/30 shrink-0"
+              className="p-2.5 md:p-3 bg-white dark:bg-neutral-800/50 hover:bg-neutral-100 dark:hover:bg-neutral-800 text-neutral-600 dark:text-neutral-400 hover:text-neutral-900 dark:hover:text-white rounded-xl md:rounded-card transition-all active:scale-90 border border-neutral-200 dark:border-neutral-700/30 shrink-0"
             >
               <X className="w-4 h-4 md:w-5 md:h-5" />
             </button>
@@ -76,7 +76,7 @@ export function ModelSelectorModal({
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
               placeholder={t('projectViewer.modelSelector.searchPlaceholder')}
-              className="w-full bg-neutral-50/50 dark:bg-neutral-950/50 border border-neutral-200 dark:border-neutral-800 focus:border-blue-500/50 focus:ring-2 focus:ring-blue-500/20 rounded-card py-3 pl-11 pr-4 text-sm text-neutral-900 dark:text-white placeholder-neutral-500 outline-none transition-all"
+              className="w-full bg-white dark:bg-neutral-950/50 border border-neutral-200 dark:border-neutral-800 focus:border-blue-500/50 focus:ring-2 focus:ring-blue-500/20 rounded-card py-3 pl-11 pr-4 text-sm text-neutral-900 dark:text-white placeholder-neutral-400 dark:placeholder-neutral-500 outline-none transition-all"
             />
           </div>
         </div>
@@ -84,10 +84,10 @@ export function ModelSelectorModal({
         {/* Content */}
         <div className="min-h-0 flex-1 overflow-y-auto p-4 sm:p-6 md:p-8 space-y-6 sm:space-y-8 custom-scrollbar">
           {providers.length === 0 ? (
-            <div className="text-center py-20 bg-neutral-50/30 dark:bg-neutral-950/30 rounded-card border border-dashed border-neutral-200 dark:border-neutral-800">
-              <AlertCircle className="w-12 h-12 text-neutral-600 mx-auto mb-4" />
+            <div className="text-center py-20 bg-neutral-50 dark:bg-neutral-950/30 rounded-card border border-dashed border-neutral-200 dark:border-neutral-800">
+              <AlertCircle className="w-12 h-12 text-neutral-400 dark:text-neutral-600 mx-auto mb-4" />
               <p className="text-neutral-500 dark:text-neutral-500 font-bold uppercase tracking-widest text-xs">{t('projectViewer.modelSelector.noProviders')}</p>
-              <p className="text-neutral-600 text-sm mt-2">{t('projectViewer.modelSelector.noProvidersHint')}</p>
+              <p className="text-neutral-500 dark:text-neutral-600 text-sm mt-2">{t('projectViewer.modelSelector.noProvidersHint')}</p>
             </div>
           ) : filteredProviders.length === 0 ? (
             <div className="text-center py-16">
@@ -103,7 +103,7 @@ export function ModelSelectorModal({
                   <div>
                     <h4 className="text-xs font-black text-neutral-900 dark:text-white uppercase tracking-wider">{provider.name}</h4>
                     {provider.name.toLowerCase().replace(/\s/g, '') !== provider.type.toLowerCase().replace(/\s/g, '') && (
-                      <span className="text-[10px] font-bold text-neutral-600 uppercase tracking-widest">{provider.type}</span>
+                      <span className="text-[10px] font-bold text-neutral-500 dark:text-neutral-600 uppercase tracking-widest">{provider.type}</span>
                     )}
                   </div>
                 </div>
@@ -117,19 +117,19 @@ export function ModelSelectorModal({
                         onClick={() => onSelect(provider.id, model.id)}
                         className={`group relative p-3 rounded-xl text-left transition-ui border active:scale-[0.98] overflow-hidden ${
                           isSelected
-                            ? 'bg-blue-600/10 border-blue-500/50 shadow-[0_0_15px_rgba(37,99,235,0.15)] ring-1 ring-blue-500'
-                            : 'bg-white/70 dark:bg-neutral-900/70 border-neutral-200/50 dark:border-white/5 hover:border-neutral-700 hover:bg-white/80 dark:hover:bg-neutral-900/80 shadow-sm backdrop-blur-xl'
+                            ? 'bg-blue-50 dark:bg-blue-600/10 border-blue-500 dark:border-blue-500/50 shadow-[0_0_15px_rgba(37,99,235,0.15)] ring-1 ring-blue-500'
+                            : 'bg-white dark:bg-neutral-900/70 border-neutral-200 dark:border-white/5 hover:border-neutral-300 dark:hover:border-neutral-700 hover:bg-neutral-50 dark:hover:bg-neutral-900/80 shadow-sm dark:backdrop-blur-xl'
                         }`}
                       >
                         <div className="relative z-10 flex items-center justify-between gap-3">
                           <div className="min-w-0 flex-1">
-                            <div className={`text-sm font-bold leading-5 line-clamp-2 break-words tracking-tight transition-colors ${isSelected ? 'text-blue-50' : 'text-neutral-700 dark:text-neutral-300'}`}>
+                            <div className={`text-sm font-bold leading-5 line-clamp-2 break-words tracking-tight transition-colors ${isSelected ? 'text-blue-700 dark:text-blue-50' : 'text-neutral-700 dark:text-neutral-300'}`}>
                               {model.name}
                             </div>
                           </div>
                           {isSelected && (
                             <div className="shrink-0 p-1 bg-blue-500 rounded-full shadow-lg">
-                              <CheckCircle2 className="w-3 h-3 text-neutral-900 dark:text-white" />
+                              <CheckCircle2 className="w-3 h-3 text-white" />
                             </div>
                           )}
                         </div>
@@ -137,7 +137,7 @@ export function ModelSelectorModal({
                         
                         {/* Hover/Selected decorators */}
                         <div className={`absolute inset-0 bg-gradient-to-br transition-all duration-500 pointer-events-none ${
-                          isSelected ? 'from-blue-500/5 to-transparent' : 'from-white/0 group-hover:from-white/[0.02]'
+                          isSelected ? 'from-blue-500/5 to-transparent' : 'from-transparent dark:group-hover:from-white/[0.02]'
                         }`} />
                       </button>
                     );
@@ -149,8 +149,8 @@ export function ModelSelectorModal({
         </div>
 
         {/* Footer */}
-        <div className="p-4 pb-[max(1rem,env(safe-area-inset-bottom))] bg-neutral-50/40 dark:bg-neutral-950/40 border-t border-neutral-200/50 dark:border-neutral-800/50 flex items-center justify-center">
-           <p className="text-[10px] font-bold text-neutral-600 uppercase tracking-widest">
+        <div className="p-4 pb-[max(1rem,env(safe-area-inset-bottom))] bg-neutral-50 dark:bg-neutral-950/40 border-t border-neutral-200 dark:border-neutral-800/50 flex items-center justify-center">
+           <p className="text-[10px] font-bold text-neutral-500 dark:text-neutral-600 uppercase tracking-widest">
              {t('projectViewer.modelSelector.footer')}
            </p>
         </div>

--- a/src/components/ProjectViewer/PromptModal.tsx
+++ b/src/components/ProjectViewer/PromptModal.tsx
@@ -59,7 +59,7 @@ export function PromptModal({ item, onClose, onSave }: PromptModalProps) {
           <div className="flex items-center gap-2 sm:gap-3">
             <button
               onClick={onClose}
-              className="px-4 py-2.5 sm:px-6 text-neutral-600 dark:text-neutral-400 hover:text-white font-bold uppercase tracking-widest text-[10px] transition-all"
+              className="px-4 py-2.5 sm:px-6 text-neutral-600 dark:text-neutral-400 hover:text-neutral-900 dark:hover:text-white font-bold uppercase tracking-widest text-[10px] transition-all"
             >
               {t('projectViewer.common.cancel')}
             </button>

--- a/src/components/ProjectViewer/SelectionToolbar.tsx
+++ b/src/components/ProjectViewer/SelectionToolbar.tsx
@@ -70,7 +70,7 @@ export function SelectionToolbar({
           onClick={onToggleSelectAll}
           title={t('projectViewer.common.selectAll')}
           aria-label={t('projectViewer.common.selectAll')}
-          className="flex items-center justify-start gap-2 @min-[56rem]/pane:gap-3 min-h-8 p-1 rounded-lg text-[10px] font-bold text-neutral-600 dark:text-neutral-400 hover:text-white uppercase tracking-widest transition-colors flex-shrink-0"
+          className="flex items-center justify-start gap-2 @min-[56rem]/pane:gap-3 min-h-8 p-1 rounded-lg text-[10px] font-bold text-neutral-600 dark:text-neutral-400 hover:text-neutral-900 dark:hover:text-white uppercase tracking-widest transition-colors flex-shrink-0"
         >
           {selectedCount === totalCount && totalCount > 0 ? (
             <CheckSquare className={`w-4 h-4 ${checkIconClass}`} />

--- a/src/components/ProjectViewer/TextAlbumCompareDialog.tsx
+++ b/src/components/ProjectViewer/TextAlbumCompareDialog.tsx
@@ -34,15 +34,15 @@ export function TextAlbumCompareDialog({ items, setLightboxData, onClose }: Text
   if (items.length === 0) return null;
 
   return (
-    <div className="fixed inset-0 z-[210] bg-black/90 backdrop-blur-sm animate-in fade-in duration-300" onClick={onClose}>
+    <div className="fixed inset-0 z-[210] bg-black/60 dark:bg-black/90 backdrop-blur-sm animate-in fade-in duration-300" onClick={onClose}>
       <div className="relative flex h-full w-full flex-col overflow-hidden" onClick={(e) => e.stopPropagation()}>
-        <div className="flex items-center justify-between gap-4 border-b border-white/10 bg-black/30 px-4 py-3 md:px-6">
+        <div className="flex items-center justify-between gap-4 border-b border-neutral-200 dark:border-white/10 bg-white dark:bg-black/30 px-4 py-3 md:px-6">
           <div className="flex min-w-0 items-center gap-3">
             <div className="rounded-xl bg-blue-600/10 p-2.5">
               <Columns3 className="w-5 h-5 text-blue-500" />
             </div>
             <div className="min-w-0">
-              <h3 className="text-lg font-bold text-white tracking-tight">{t('projectViewer.compare.title')}</h3>
+              <h3 className="text-lg font-bold text-neutral-900 dark:text-white tracking-tight">{t('projectViewer.compare.title')}</h3>
               <p className="mt-0.5 text-[10px] font-bold uppercase tracking-widest text-neutral-500 dark:text-neutral-500">
                 {t('projectViewer.compare.subtitle', { count: items.length })}
               </p>
@@ -50,7 +50,7 @@ export function TextAlbumCompareDialog({ items, setLightboxData, onClose }: Text
           </div>
           <button
             onClick={onClose}
-            className="rounded-xl p-2 text-neutral-500 dark:text-neutral-500 transition-all hover:bg-white/10 hover:text-white"
+            className="rounded-xl p-2 text-neutral-500 dark:text-neutral-500 transition-all hover:bg-neutral-100 dark:hover:bg-white/10 hover:text-neutral-900 dark:hover:text-white"
             aria-label={t('projectViewer.compare.closeAria')}
           >
             <X className="w-5 h-5" />
@@ -62,11 +62,11 @@ export function TextAlbumCompareDialog({ items, setLightboxData, onClose }: Text
             {items.map((item, index) => (
               <article
                 key={item.id}
-                className="flex h-full w-[min(40rem,calc(100vw-1.5rem))] sm:w-[min(40rem,calc(100vw-4rem))] shrink-0 flex-col overflow-hidden rounded-card sm:rounded-card border border-neutral-200 dark:border-neutral-800 bg-white/90 dark:bg-neutral-900/90 shadow-2xl shadow-black/30 md:w-[min(42rem,calc(100vw-8rem))]"
+                className="flex h-full w-[min(40rem,calc(100vw-1.5rem))] sm:w-[min(40rem,calc(100vw-4rem))] shrink-0 flex-col overflow-hidden rounded-card sm:rounded-card border border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-900/90 shadow-2xl shadow-black/30 md:w-[min(42rem,calc(100vw-8rem))]"
               >
                 <header className="flex items-start sm:items-center justify-between gap-3 border-b border-neutral-200 dark:border-neutral-800 bg-neutral-50/60 dark:bg-neutral-950/60 px-4 py-3">
                   <div className="min-w-0">
-                    <div className="text-[10px] font-mono text-neutral-600">#{(index + 1).toString().padStart(2, '0')}</div>
+                    <div className="text-[10px] font-mono text-neutral-500 dark:text-neutral-600">#{(index + 1).toString().padStart(2, '0')}</div>
                     <div className="truncate text-[10px] font-black uppercase tracking-[0.18em] text-neutral-500 dark:text-neutral-500">
                       {item.providerId || t('projectViewer.common.provider')} · {item.modelConfigId || t('projectViewer.common.model')}
                     </div>

--- a/src/components/ProjectViewer/TextAlbumDetailDialog.tsx
+++ b/src/components/ProjectViewer/TextAlbumDetailDialog.tsx
@@ -65,7 +65,7 @@ export function TextAlbumDetailDialog({ items, startIndex, setLightboxData, onCl
   };
 
   return (
-    <div className="fixed inset-0 z-[200] bg-black/90 backdrop-blur-sm animate-in fade-in duration-300" onClick={onClose}>
+    <div className="fixed inset-0 z-[200] bg-black/60 dark:bg-black/90 backdrop-blur-sm animate-in fade-in duration-300" onClick={onClose}>
       {hasMultipleItems && (
         <button
           onClick={showPrev}
@@ -83,7 +83,7 @@ export function TextAlbumDetailDialog({ items, startIndex, setLightboxData, onCl
         aria-label={t('projectViewer.textDetail.dialogAria')}
         onClick={(e) => e.stopPropagation()}
       >
-        <div className="flex items-center justify-between border-b border-white/10 bg-black/30 px-4 py-3 md:px-6">
+        <div className="flex items-center justify-between border-b border-neutral-200 dark:border-white/10 bg-white dark:bg-black/30 px-4 py-3 md:px-6">
           <div className="flex min-w-0 items-center gap-3">
             <div className="p-2.5 bg-blue-600/10 rounded-xl">
               <FileText className="w-5 h-5 text-blue-500" />
@@ -102,14 +102,14 @@ export function TextAlbumDetailDialog({ items, startIndex, setLightboxData, onCl
               <div className="flex items-center gap-1 md:gap-2">
                 <button
                   onClick={showPrev}
-                  className="p-2 text-white/50 hover:text-white hover:bg-white/10 rounded-xl transition-all"
+                  className="p-2 text-neutral-500 dark:text-white/50 hover:text-neutral-900 dark:hover:text-white hover:bg-neutral-100 dark:hover:bg-white/10 rounded-xl transition-all"
                   aria-label={t('projectViewer.textDetail.previousItem')}
                 >
                   <ChevronLeft className="w-5 h-5" />
                 </button>
                 <button
                   onClick={showNext}
-                  className="p-2 text-white/50 hover:text-white hover:bg-white/10 rounded-xl transition-all"
+                  className="p-2 text-neutral-500 dark:text-white/50 hover:text-neutral-900 dark:hover:text-white hover:bg-neutral-100 dark:hover:bg-white/10 rounded-xl transition-all"
                   aria-label={t('projectViewer.textDetail.nextItem')}
                 >
                   <ChevronRight className="w-5 h-5" />
@@ -118,7 +118,7 @@ export function TextAlbumDetailDialog({ items, startIndex, setLightboxData, onCl
             )}
             <button
               onClick={onClose}
-              className="p-2 text-neutral-500 dark:text-neutral-500 hover:text-white hover:bg-white/10 rounded-xl transition-all"
+              className="p-2 text-neutral-500 dark:text-neutral-500 hover:text-neutral-900 dark:hover:text-white hover:bg-neutral-100 dark:hover:bg-white/10 rounded-xl transition-all"
               aria-label={t('projectViewer.textDetail.closeAria')}
             >
               <X className="w-5 h-5" />
@@ -127,7 +127,7 @@ export function TextAlbumDetailDialog({ items, startIndex, setLightboxData, onCl
         </div>
 
         <div className="grid flex-1 min-h-0 grid-cols-1 lg:grid-cols-[minmax(280px,34vw)_1fr]">
-          <section className="min-h-0 border-b border-white/10 bg-neutral-50/60 dark:bg-neutral-950/60 lg:border-b-0 lg:border-r">
+          <section className="min-h-0 border-b border-neutral-200 dark:border-white/10 bg-neutral-50 dark:bg-neutral-950/60 lg:border-b-0 lg:border-r">
             <div className="flex h-full flex-col">
               <div className="px-4 md:px-5 py-4 border-b border-neutral-200 dark:border-neutral-800 flex items-center justify-between gap-3">
                 <div className="flex items-center gap-2 text-neutral-700 dark:text-neutral-300">
@@ -180,7 +180,7 @@ export function TextAlbumDetailDialog({ items, startIndex, setLightboxData, onCl
             </div>
           </section>
 
-          <section className="min-h-0 bg-black/20">
+          <section className="min-h-0 bg-white dark:bg-black/20">
             <div className="flex h-full flex-col">
               <div className="px-4 md:px-5 py-4 border-b border-neutral-200 dark:border-neutral-800 flex items-center justify-between gap-3">
                 <div className="flex items-center gap-2 text-neutral-700 dark:text-neutral-300">
@@ -197,7 +197,7 @@ export function TextAlbumDetailDialog({ items, startIndex, setLightboxData, onCl
                 </button>
               </div>
               <div className="flex-1 overflow-y-auto custom-scrollbar p-4 md:p-8">
-                <div className="mx-auto max-w-4xl whitespace-pre-wrap break-words text-base md:text-lg text-neutral-100 leading-relaxed">
+                <div className="mx-auto max-w-4xl whitespace-pre-wrap break-words text-base md:text-lg text-neutral-900 dark:text-neutral-100 leading-relaxed">
                   {item.textContent || t('projectViewer.textDetail.noGeneratedText')}
                 </div>
               </div>
@@ -205,11 +205,11 @@ export function TextAlbumDetailDialog({ items, startIndex, setLightboxData, onCl
           </section>
         </div>
 
-        <div className="flex items-center justify-between gap-4 border-t border-white/10 bg-black/30 px-4 py-3 md:px-6">
-          <div className="text-[10px] font-bold text-neutral-600 uppercase tracking-widest">
+        <div className="flex items-center justify-between gap-4 border-t border-neutral-200 dark:border-white/10 bg-white dark:bg-black/30 px-4 py-3 md:px-6">
+          <div className="text-[10px] font-bold text-neutral-500 dark:text-neutral-600 uppercase tracking-widest">
             {t('projectViewer.textDetail.characterCount', { count: (item.textContent || '').length })}
           </div>
-          <div className="hidden md:block text-[10px] font-bold text-neutral-600 uppercase tracking-widest">
+          <div className="hidden md:block text-[10px] font-bold text-neutral-500 dark:text-neutral-600 uppercase tracking-widest">
             {t('projectViewer.textDetail.keyboardHint')}
           </div>
         </div>

--- a/src/components/TagModal.tsx
+++ b/src/components/TagModal.tsx
@@ -58,9 +58,9 @@ export function TagModal({
 
   return (
     <div className="fixed inset-0 z-[100] flex items-center justify-center p-4">
-      <div className="absolute inset-0 bg-black/60 backdrop-blur-xl animate-in fade-in duration-300 cursor-pointer" onClick={onClose} />
+      <div className="absolute inset-0 bg-black/60 dark:bg-black/80 backdrop-blur-xl animate-in fade-in duration-300 cursor-pointer" onClick={onClose} />
       
-      <div className="relative w-full max-w-lg max-h-[calc(100dvh-2rem)] bg-white/40 dark:bg-neutral-900/40 border border-neutral-200/50 dark:border-white/5 backdrop-blur-3xl rounded-card shadow-2xl flex flex-col overflow-hidden animate-in zoom-in-95 duration-300">
+      <div className="relative w-full max-w-lg max-h-[calc(100dvh-2rem)] bg-white dark:bg-neutral-900/40 dark:backdrop-blur-3xl border border-neutral-200 dark:border-white/5 rounded-card shadow-2xl flex flex-col overflow-hidden animate-in zoom-in-95 duration-300">
         <div className="p-4 sm:p-6 border-b border-neutral-200 dark:border-neutral-800 flex items-center justify-between bg-neutral-50/20 dark:bg-neutral-950/20">
           <div className="flex items-center gap-3">
             <div className="p-2.5 bg-blue-500/10 rounded-xl">
@@ -100,7 +100,7 @@ export function TagModal({
 
           <div className="flex flex-wrap gap-2 min-h-[100px] content-start">
             {tags.length === 0 && (
-              <div className="w-full text-center py-8 text-neutral-600 text-xs font-bold uppercase tracking-widest italic border border-dashed border-neutral-200/50 dark:border-white/5 bg-white/40 dark:bg-neutral-900/40 backdrop-blur-3xl rounded-xl">
+              <div className="w-full text-center py-8 text-neutral-500 dark:text-neutral-600 text-xs font-bold uppercase tracking-widest italic border border-dashed border-neutral-200 dark:border-white/5 bg-neutral-50 dark:bg-neutral-900/40 dark:backdrop-blur-3xl rounded-xl">
                 {t('tagModal.noTags')}
               </div>
             )}
@@ -118,7 +118,7 @@ export function TagModal({
         <div className="p-4 sm:p-6 pb-[max(1rem,env(safe-area-inset-bottom))] border-t border-neutral-200 dark:border-neutral-800 bg-neutral-50/40 dark:bg-neutral-950/40 flex justify-end gap-3">
           <button 
             onClick={onClose}
-            className="px-6 py-2.5 text-neutral-600 dark:text-neutral-400 hover:text-white font-bold uppercase tracking-widest text-[10px] transition-all"
+            className="px-6 py-2.5 text-neutral-600 dark:text-neutral-400 hover:text-neutral-900 dark:hover:text-white font-bold uppercase tracking-widest text-[10px] transition-all"
           >
             {t('confirmModal.cancel')}
           </button>

--- a/src/components/TrashView.tsx
+++ b/src/components/TrashView.tsx
@@ -184,7 +184,7 @@ export function TrashView() {
       </div>
 
       {!loading && items.length === 0 ? (
-        <div className="flex flex-col items-center justify-center py-24 bg-white/40 dark:bg-neutral-900/40 border-2 border-dashed border-neutral-200/50 dark:border-white/5 rounded-card text-center space-y-6 transition-colors hover:border-neutral-700 backdrop-blur-3xl shadow-sm">
+        <div className="flex flex-col items-center justify-center py-24 bg-white/40 dark:bg-neutral-900/40 border-2 border-dashed border-neutral-200/50 dark:border-white/5 rounded-card text-center space-y-6 transition-colors hover:border-neutral-300 dark:hover:border-neutral-700 backdrop-blur-3xl shadow-sm">
           <div className="p-6 bg-white/50 dark:bg-neutral-900/50 rounded-full border border-neutral-200 dark:border-neutral-800">
             <Trash2 className="w-12 h-12 text-neutral-800" />
           </div>

--- a/src/pages/AdminInvites.tsx
+++ b/src/pages/AdminInvites.tsx
@@ -170,7 +170,7 @@ export function AdminInvites() {
                             <button
                               type="button"
                               onClick={() => void copyText(invite.code, t('adminInvites.codeCopied'))}
-                              className="text-neutral-500 dark:text-neutral-500 transition hover:text-white"
+                              className="text-neutral-500 dark:text-neutral-500 transition hover:text-neutral-900 dark:hover:text-white"
                               title={t('adminInvites.copyCode')}
                             >
                               <Copy className="h-4 w-4" />

--- a/src/pages/LibraryImportExport.tsx
+++ b/src/pages/LibraryImportExport.tsx
@@ -380,7 +380,7 @@ export function LibraryImportExport() {
           <div className="flex items-start gap-3 md:gap-4">
             <button
               onClick={() => navigate(`/library/${id}`)}
-              className="mt-0.5 md:mt-1 rounded-card border border-neutral-200/80 dark:border-neutral-800/80 bg-neutral-50/70 dark:bg-neutral-950/70 p-2 md:p-3 text-neutral-500 dark:text-neutral-500 transition-all hover:border-neutral-700 hover:text-neutral-900 dark:hover:text-white hover:bg-neutral-900/80"
+              className="mt-0.5 md:mt-1 rounded-card border border-neutral-200/80 dark:border-neutral-800/80 bg-neutral-50/70 dark:bg-neutral-950/70 p-2 md:p-3 text-neutral-500 dark:text-neutral-500 transition-all hover:border-neutral-300 dark:hover:border-neutral-700 hover:text-neutral-900 dark:hover:text-white hover:bg-neutral-900/80"
             >
               <ChevronLeft className="h-5 w-5 md:h-6 md:w-6" />
             </button>
@@ -473,7 +473,7 @@ export function LibraryImportExport() {
                   </button>
                   <button
                     onClick={() => fileInputRef.current?.click()}
-                    className="inline-flex items-center gap-2 rounded-xl border border-blue-500/30 bg-blue-500/10 px-4 py-2.5 text-xs font-black uppercase tracking-[0.18em] text-blue-300 transition-all hover:bg-blue-500 hover:text-white"
+                    className="inline-flex items-center gap-2 rounded-xl border border-blue-500/30 bg-blue-500/10 px-4 py-2.5 text-xs font-black uppercase tracking-[0.18em] text-blue-600 dark:text-blue-300 transition-all hover:bg-blue-500 hover:text-white"
                   >
                     <UploadCloud className="h-4 w-4" />
                     {t('libraryImportExport.importSource.uploadText')}
@@ -523,7 +523,7 @@ export function LibraryImportExport() {
               className={`relative mt-5 flex min-h-[320px] flex-1 flex-col rounded-card border-2 border-dashed p-4 transition-all md:p-5 ${
                 isDragOver
                   ? 'border-blue-500 bg-blue-500/8 shadow-[0_0_0_1px_rgba(59,130,246,0.25)]'
-                  : 'border-neutral-200/80 dark:border-neutral-800/80 bg-white/35 dark:bg-neutral-900/35 hover:border-neutral-700/90'
+                  : 'border-neutral-200/80 dark:border-neutral-800/80 bg-white/35 dark:bg-neutral-900/35 hover:border-neutral-300 dark:hover:border-neutral-700/90'
               }`}
               onDragOver={(event) => {
                 event.preventDefault();
@@ -754,7 +754,7 @@ export function LibraryImportExport() {
                 <button
                   onClick={handleCopyOutput}
                   disabled={!currentExportText}
-                  className="inline-flex items-center gap-2 rounded-xl border border-neutral-200 dark:border-neutral-800 bg-neutral-50/90 dark:bg-neutral-950/90 px-4 py-2.5 text-xs font-black uppercase tracking-[0.18em] text-neutral-700 dark:text-neutral-300 transition-all hover:border-neutral-700 hover:text-white disabled:opacity-35"
+                  className="inline-flex items-center gap-2 rounded-xl border border-neutral-200 dark:border-neutral-800 bg-neutral-50/90 dark:bg-neutral-950/90 px-4 py-2.5 text-xs font-black uppercase tracking-[0.18em] text-neutral-700 dark:text-neutral-300 transition-all hover:border-neutral-300 dark:hover:border-neutral-700 hover:text-neutral-900 dark:hover:text-white disabled:opacity-35"
                 >
                   <Copy className="h-4 w-4" />
                   {t('libraryImportExport.output.copy')}
@@ -762,7 +762,7 @@ export function LibraryImportExport() {
                 <button
                   onClick={handleDownloadOutput}
                   disabled={!currentExportText}
-                  className="inline-flex items-center gap-2 rounded-xl border border-blue-500/30 bg-blue-500/10 px-4 py-2.5 text-xs font-black uppercase tracking-[0.18em] text-blue-300 transition-all hover:bg-blue-500 hover:text-white disabled:opacity-35"
+                  className="inline-flex items-center gap-2 rounded-xl border border-blue-500/30 bg-blue-500/10 px-4 py-2.5 text-xs font-black uppercase tracking-[0.18em] text-blue-600 dark:text-blue-300 transition-all hover:bg-blue-500 hover:text-white disabled:opacity-35"
                 >
                   <Download className="h-4 w-4" />
                   {t('libraryImportExport.output.download', { ext: exportFormat === 'json' ? 'json' : 'md' })}

--- a/src/pages/McpConnections.tsx
+++ b/src/pages/McpConnections.tsx
@@ -593,7 +593,7 @@ export function McpConnections({ embedded = false }: McpConnectionsProps) {
                   </div>
                   <button
                     onClick={handleCloseNewToken}
-                    className="text-sm font-bold text-neutral-600 dark:text-neutral-400 hover:text-white transition-colors"
+                    className="text-sm font-bold text-neutral-600 dark:text-neutral-400 hover:text-neutral-900 dark:hover:text-white transition-colors"
                   >
                     {t('mcpConnections.tokens.form.done')}
                   </button>
@@ -638,7 +638,7 @@ export function McpConnections({ embedded = false }: McpConnectionsProps) {
                     </button>
                     <button
                       onClick={() => { setShowCreatePat(false); setPatName(''); setPatExpiry(0); }}
-                      className="flex-1 sm:flex-none text-sm font-bold text-neutral-600 dark:text-neutral-400 hover:text-white px-6 py-2.5 rounded-xl transition-colors bg-white dark:bg-neutral-900 border border-neutral-200 dark:border-neutral-800"
+                      className="flex-1 sm:flex-none text-sm font-bold text-neutral-600 dark:text-neutral-400 hover:text-neutral-900 dark:hover:text-white px-6 py-2.5 rounded-xl transition-colors bg-white dark:bg-neutral-900 border border-neutral-200 dark:border-neutral-800"
                     >
                       {t('mcpConnections.tokens.form.cancel')}
                     </button>
@@ -774,7 +774,7 @@ export function McpConnections({ embedded = false }: McpConnectionsProps) {
                 </button>
                 <button
                   onClick={() => { setEditingClient(null); setEditingRedirectUrisText(''); }}
-                  className="flex-1 sm:flex-none text-sm font-bold text-neutral-600 dark:text-neutral-400 hover:text-white px-6 py-2.5 rounded-xl transition-colors bg-white dark:bg-neutral-900 border border-neutral-200 dark:border-neutral-800"
+                  className="flex-1 sm:flex-none text-sm font-bold text-neutral-600 dark:text-neutral-400 hover:text-neutral-900 dark:hover:text-white px-6 py-2.5 rounded-xl transition-colors bg-white dark:bg-neutral-900 border border-neutral-200 dark:border-neutral-800"
                 >
                   {t('mcpConnections.tokens.form.cancel')}
                 </button>
@@ -840,7 +840,7 @@ export function McpConnections({ embedded = false }: McpConnectionsProps) {
                   </div>
                   <button
                     onClick={handleCloseNewClient}
-                    className="text-sm font-bold text-neutral-600 dark:text-neutral-400 hover:text-white transition-colors"
+                    className="text-sm font-bold text-neutral-600 dark:text-neutral-400 hover:text-neutral-900 dark:hover:text-white transition-colors"
                   >
                     {t('mcpConnections.tokens.form.done')}
                   </button>
@@ -896,7 +896,7 @@ export function McpConnections({ embedded = false }: McpConnectionsProps) {
                     </button>
                     <button
                       onClick={handleCloseNewClient}
-                      className="flex-1 sm:flex-none text-sm font-bold text-neutral-600 dark:text-neutral-400 hover:text-white px-6 py-2.5 rounded-xl transition-colors bg-white dark:bg-neutral-900 border border-neutral-200 dark:border-neutral-800"
+                      className="flex-1 sm:flex-none text-sm font-bold text-neutral-600 dark:text-neutral-400 hover:text-neutral-900 dark:hover:text-white px-6 py-2.5 rounded-xl transition-colors bg-white dark:bg-neutral-900 border border-neutral-200 dark:border-neutral-800"
                     >
                       {t('mcpConnections.tokens.form.cancel')}
                     </button>

--- a/src/pages/ProjectOrphans.tsx
+++ b/src/pages/ProjectOrphans.tsx
@@ -225,7 +225,7 @@ export function ProjectOrphans() {
             <div className="flex items-center justify-between">
               <button 
                 onClick={toggleSelectAll}
-                className="flex items-center gap-2 text-[10px] font-black text-neutral-600 dark:text-neutral-400 hover:text-white uppercase tracking-widest transition-colors"
+                className="flex items-center gap-2 text-[10px] font-black text-neutral-600 dark:text-neutral-400 hover:text-neutral-900 dark:hover:text-white uppercase tracking-widest transition-colors"
               >
                 {selectedKeys.size === orphans.length ? (
                   <CheckSquare className="w-4 h-4 text-blue-500" />
@@ -264,7 +264,7 @@ export function ProjectOrphans() {
                    <div 
                     key={file.key} 
                     onClick={(e) => toggleSelection(file.key, e.shiftKey)}
-                    className={`group relative aspect-square w-full rounded-xl overflow-hidden border transition-ui cursor-pointer hover:scale-[1.02] ${isSelected ? 'border-blue-500 ring-2 ring-blue-500/10' : 'border-neutral-200/50 dark:border-white/5 bg-white/70 dark:bg-neutral-900/70 backdrop-blur-xl text-neutral-500 dark:text-neutral-500 hover:border-neutral-700'}`}
+                    className={`group relative aspect-square w-full rounded-xl overflow-hidden border transition-ui cursor-pointer hover:scale-[1.02] ${isSelected ? 'border-blue-500 ring-2 ring-blue-500/10' : 'border-neutral-200/50 dark:border-white/5 bg-white/70 dark:bg-neutral-900/70 backdrop-blur-xl text-neutral-500 dark:text-neutral-500 hover:border-neutral-300 dark:hover:border-neutral-700'}`}
                    >
                      {/* Overlay Actions */}
                      <div className="absolute inset-0 bg-black/60 opacity-100 transition-opacity z-10 flex flex-col justify-between p-1.5">

--- a/src/pages/PromptEditor.tsx
+++ b/src/pages/PromptEditor.tsx
@@ -117,7 +117,7 @@ export function PromptEditor() {
                 <div className="w-px h-3 bg-neutral-200 dark:bg-neutral-800 hidden sm:block"></div>
                 <button 
                   onClick={() => setShowTagModal(true)}
-                  className="flex items-center gap-1 px-1.5 py-0.5 rounded transition-all text-[9px] font-bold tracking-widest uppercase truncate border border-transparent hover:border-neutral-800 text-neutral-500 dark:text-neutral-500 hover:text-blue-400 group/tagbtn"
+                  className="flex items-center gap-1 px-1.5 py-0.5 rounded transition-all text-[9px] font-bold tracking-widest uppercase truncate border border-transparent hover:border-neutral-300 dark:hover:border-neutral-800 text-neutral-500 dark:text-neutral-500 hover:text-blue-400 group/tagbtn"
                 >
                   <TagIcon className="w-3 h-3 transition-transform group-hover/tagbtn:scale-110" />
                   {tags.length > 0 ? t('promptEditor.tagsCount', { count: tags.length }) : t('promptEditor.addTags')}


### PR DESCRIPTION
The model selection dialog was unreadable in light mode: a translucent
bg-white/40 panel sat on a bg-black/90 scrim and composited into a muddy
grey, and the selected model card painted near-white text (text-blue-50)
on a 10%-opacity blue background.

Give the dialog an opaque light surface with a lighter scrim, and restyle
the selected state as blue-50/blue-700. Dark mode values are unchanged
throughout - the glass treatment is preserved behind dark: variants.

Apply the same class of fixes across the rest of the UI:

- Muddy modal panels on dark scrims: CopyMoveItemsDialog,
  DuplicateLibraryDialog, ExportFileNameModal, TagModal.
- Unguarded hover:text-white on light surfaces, which faded text to
  invisible on hover, across 14 components. Overlays that are dark in
  both themes (image lightbox, media tiles) are left as-is.
- Unguarded hover:border-neutral-700/800, which snapped light-mode
  borders to near-black on hover, across 12 components.
- TextAlbumDetailDialog and TextAlbumCompareDialog: the panes carried
  full light/dark pairs but the surrounding chrome was pinned dark, so
  light-mode text landed on black. Made the chrome theme-aware.
- Low-contrast text-blue-300 on translucent blue in LibraryImportExport.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014tXcNi3fqnoVw6GVWJaQSZ