### PR TITLE
feat(models): add Grok 4.6 and Gemini 3.7 Flash, retire Grok Imagine Pro

### DIFF
--- a/agent/model-maintenance-guide.md
+++ b/agent/model-maintenance-guide.md
@@ -20,10 +20,10 @@ server/generators/                    -- One generator class per provider per ca
     +-- build-audio-generator.ts      -- Factory: provider type -> audio generator
     +-- claude-text-generator.ts      -- Default model: claude-sonnet-4-6
     +-- openai-text-generator.ts      -- Default model: gpt-5.6
-    +-- grok-text-generator.ts        -- Default model: grok-4.20-0309-non-reasoning
+    +-- grok-text-generator.ts        -- Default model: grok-4.6
     +-- minimax-text-generator.ts     -- Default model: MiniMax-M3
-    +-- google-ai-text-generator.ts   -- Default model: gemini-3.6-flash
-    +-- vertex-ai-text-generator.ts   -- Default model: gemini-3.6-flash
+    +-- google-ai-text-generator.ts   -- Default model: gemini-3.7-flash
+    +-- vertex-ai-text-generator.ts   -- Default model: gemini-3.7-flash
     +-- google-ai-generator.ts        -- Image gen (GoogleAI)
     +-- vertex-ai-generator.ts        -- Image gen (VertexAI)
     +-- google-ai-audio-generator.ts  -- Gemini TTS (GoogleAI)
@@ -161,7 +161,7 @@ The lister fetches all models, then filters to only those whose `id` matches a `
 
 ---
 
-## Current Model Inventory (July 2026)
+## Current Model Inventory (August 2026)
 
 ### Google AI / Vertex AI
 | Name | Model ID | Category | Max Output |
@@ -169,12 +169,29 @@ The lister fetches all models, then filters to only those whose `id` matches a `
 | nano banana Pro | `gemini-3-pro-image` | image | 32,768 |
 | nano banana 2 | `gemini-3.1-flash-image-preview` | image | 32,768 |
 | nano banana 2 Lite | `gemini-3.1-flash-lite-image` | image | 32,768 |
-| Gemini 3 Flash | `gemini-3-flash-preview` | text | 65,536 |
+| Gemini 3.7 Flash | `gemini-3.7-flash` | text | 65,536 |
+| Gemini 3.6 Flash | `gemini-3.6-flash` | text | 65,536 |
+| Gemini 3.5 Flash | `gemini-3.5-flash` | text | 65,536 |
+| Gemini 3.5 Flash Lite | `gemini-3.5-flash-lite` | text | 65,536 |
 | Gemini 3.1 Pro | `gemini-3.1-pro-preview` | text | 65,536 |
 | Gemini 3.1 Flash Lite | `gemini-3.1-flash-lite-preview` | text | 65,536 |
+| Gemma 4 | `gemma-4-31b-it` | text | 65,536 |
+| Veo 3.1 | `veo-3.1-generate-preview` | video | 720p/1080p/4k, 4-8s |
+| Veo 3.1 Lite | `veo-3.1-lite-generate-preview` | video | 720p/1080p, 4-8s |
+| Lyria 3 Clip | `lyria-3-clip-preview` | audio | Music generation |
+| Lyria 3 Pro | `lyria-3-pro-preview` | audio | Music generation |
 | Gemini 3.1 Flash TTS Preview | `gemini-3.1-flash-tts-preview` | audio | 32k context window |
 | Gemini 2.5 Flash Preview TTS | `gemini-2.5-flash-preview-tts` | audio | 32k context window |
 | Gemini 2.5 Pro Preview TTS | `gemini-2.5-pro-preview-tts` | audio | 32k context window |
+
+Gemini 3.x is progressively dropping the legacy sampling knobs (`temperature`,
+`topP`, `topK`) — the newer models are tuned for their defaults and reject the
+fields rather than ignoring them. `geminiSupportsSamplingParameters` in
+`server/utils/gemini.ts` holds that list, and the assistant chat adapter plus
+both REST text generators read it before putting `temperature` on a request. A
+new Gemini release that drops the knobs gets added there, not to a per-caller
+check. The Veo rows are video-only and the Lyria rows are music, so neither
+takes the text sampling fields at all.
 
 ### OpenAI
 | Name | Model ID | Category | Max Output |
@@ -194,9 +211,20 @@ The lister fetches all models, then filters to only those whose `id` matches a `
 | Name | Model ID | Category | Max Output |
 |---|---|---|---|
 | Grok Imagine | `grok-imagine-image` | image | - |
-| Grok Imagine Pro | `grok-imagine-image-pro` | image | - |
-| Grok 4.20 | `grok-4.20-0309-non-reasoning` | text | - |
-| Grok 4.1 Fast | `grok-4-1-fast-non-reasoning` | text | - |
+| Grok Imagine Quality | `grok-imagine-image-quality` | image | - |
+| Grok 4.6 | `grok-4.6` | text | 500K context |
+| Grok 4.5 | `grok-4.5` | text | 500K context |
+| Grok 4.20 | `grok-4.20-0309-non-reasoning` | text | 2M context |
+| Grok 4.3 | `grok-4.3` | text | 2M context |
+| Grok 4.1 Fast | `grok-4-1-fast-non-reasoning` | text | 2M context |
+| Grok Imagine Video | `grok-imagine-video` | video | 720p, 6-10s |
+
+xAI retired `grok-imagine-image-pro` in May 2026 and points it at the quality
+tier. Both take the same `quality` (`low`/`medium`/`high`) plus `resolution`
+(`1k`/`2k`) pair that `parseQualityPreset` in `grok-generator.ts` splits out of
+the project's single quality picker, so the migration was a `modelId` swap. The
+model entry keeps its original `id` (`grok-imagine-image-pro`) because projects
+persist `modelConfigId` — renaming it would orphan saved selections.
 
 ### Claude (Anthropic)
 | Name | Model ID | Category | Max Output |

--- a/docs-site/concepts/models.md
+++ b/docs-site/concepts/models.md
@@ -28,10 +28,10 @@ This matrix reflects the profiles shipped with the current release. Model availa
 
 | Provider | Supported Models |
 | :--- | :--- |
-| **Google AI** | `Gemini 3.6 Flash`, `Gemini 3.5 Flash`, `Gemini 3.5 Flash Lite`, `Gemini 3.1 Pro`, `Gemini 3.1 Flash Lite`, `Gemma 4` |
-| **Vertex AI** | `Gemini 3.6 Flash`, `Gemini 3.5 Flash`, `Gemini 3.5 Flash Lite`, `Gemini 3.1 Pro`, `Gemini 3.1 Flash Lite` |
+| **Google AI** | `Gemini 3.7 Flash`, `Gemini 3.6 Flash`, `Gemini 3.5 Flash`, `Gemini 3.5 Flash Lite`, `Gemini 3.1 Pro`, `Gemini 3.1 Flash Lite`, `Gemma 4` |
+| **Vertex AI** | `Gemini 3.7 Flash`, `Gemini 3.6 Flash`, `Gemini 3.5 Flash`, `Gemini 3.5 Flash Lite`, `Gemini 3.1 Pro`, `Gemini 3.1 Flash Lite` |
 | **OpenAI** | `GPT-5.6`, `GPT-5.6 Terra`, `GPT-5.6 Luna`, `GPT-5.5`, `GPT-5.4`, `GPT-5.4 Mini`, `GPT-5.4 Nano` |
-| **Grok** | `Grok 4.5`, `Grok 4.20`, `Grok 4.3`, `Grok 4.1 Fast` |
+| **Grok** | `Grok 4.6`, `Grok 4.5`, `Grok 4.20`, `Grok 4.3`, `Grok 4.1 Fast` |
 | **Claude** | `Claude Fable 5`, `Claude Opus 5`, `Claude Opus 4.8`, `Claude Sonnet 5`, `Claude Opus 4.7`, `Claude Sonnet 4.6`, `Claude Haiku 4.5` |
 | **Alibaba Cloud DashScope** | `Qwen3.6 Max`, `Qwen3.6 Plus`, `Qwen3.6 Flash`, `Qwen3.6 VL Max`, `Qwen3.6 VL Plus` |
 | **Kimi (Moonshot AI)** | `Kimi K3` |
@@ -44,7 +44,7 @@ This matrix reflects the profiles shipped with the current release. Model availa
 | **Google AI** | `nano banana 2`, `nano banana Pro`, `nano banana 2 Lite` |
 | **Vertex AI** | `nano banana 2`, `nano banana Pro`, `nano banana 2 Lite` |
 | **OpenAI** | `GPT Image 2`, `GPT Image 1.5`, `GPT Image 1 Mini` |
-| **Grok** | `Grok Imagine`, `Grok Imagine Pro` |
+| **Grok** | `Grok Imagine`, `Grok Imagine Quality` |
 | **MiniMax** | `MiniMax Image 01` |
 | **RunningHub** | `nano banana 2`, `nano banana Pro`, `GPT Image 2`, `GPT Image 2 Official`, `Qwen Image 2 Pro`, `Grok Imagine Pro`, `Seedream 5.0 Pro`, `Seedream V5 Pro`, `Wan 2.7 Pro` |
 | **BytePlus** | `Seedream 5.0 Pro`, `Seedream 5.0 Lite`, `Seedream 4.5`, `Seedream 4.0`, `Seedream 3.0 T2I`, `Seededit 3.0 I2I` |

--- a/server/assistant/providers/google.ts
+++ b/server/assistant/providers/google.ts
@@ -9,12 +9,14 @@ import {
   toolParametersJsonSchema,
 } from './types';
 import type { ChatMessage } from './types';
+import { geminiSupportsSamplingParameters } from '../../utils/gemini';
 
 /**
  * Maps local/synthetic model config IDs and retired preview aliases to the
  * model IDs accepted by the current Google API.
  */
 export function resolveRealGeminiModelId(modelId: string): string {
+  if (modelId.includes('3.7-flash')) return 'gemini-3.7-flash';
   if (modelId.includes('3.6-flash')) return 'gemini-3.6-flash';
   if (modelId.includes('3.5-flash-lite')) return 'gemini-3.5-flash-lite';
   if (modelId.includes('3.5-flash')) return 'gemini-3.5-flash';
@@ -31,11 +33,6 @@ export function resolveRealGeminiModelId(modelId: string): string {
 /** Gemini's low-latency tier — `gemini-3.5-flash-lite`, `…-flash-lite-preview`, etc. */
 function isFlashLite(modelId: string): boolean {
   return /flash-lite/.test(modelId);
-}
-
-/** Gemini 3.6 Flash and 3.5 Flash-Lite reject legacy sampling options. */
-function supportsSamplingParameters(modelId: string): boolean {
-  return modelId !== 'gemini-3.6-flash' && modelId !== 'gemini-3.5-flash-lite';
 }
 
 /**
@@ -63,7 +60,7 @@ export class GoogleAIChatProvider implements ChatProvider {
     const realModelId = resolveRealGeminiModelId(req.modelId);
 
     const config: any = {
-      ...(supportsSamplingParameters(realModelId) && typeof req.temperature === 'number'
+      ...(geminiSupportsSamplingParameters(realModelId) && typeof req.temperature === 'number'
         ? { temperature: req.temperature }
         : {}),
       ...(typeof req.maxTokens === 'number' ? { maxOutputTokens: req.maxTokens } : {}),

--- a/server/generators/google-ai-text-generator.ts
+++ b/server/generators/google-ai-text-generator.ts
@@ -1,4 +1,5 @@
 import { TextGenerator, TextGenerateRequest, TextGenerateResult } from './text-generator';
+import { geminiSupportsSamplingParameters } from '../utils/gemini';
 
 export class GoogleAITextGenerator extends TextGenerator {
   private apiKey: string;
@@ -12,7 +13,7 @@ export class GoogleAITextGenerator extends TextGenerator {
 
   async generate(req: TextGenerateRequest): Promise<TextGenerateResult> {
     const { prompt, systemPrompt, temperature = 0.7, maxTokens = 2048, refImagesBase64, modelId, apiUrl: reqApiUrl } = req;
-    const model = modelId || 'gemini-3.6-flash';
+    const model = modelId || 'gemini-3.7-flash';
 
     let actualApiUrl: string;
     if (reqApiUrl) {
@@ -34,7 +35,7 @@ export class GoogleAITextGenerator extends TextGenerator {
     const payload: any = {
       contents: [{ role: 'user', parts }],
       generationConfig: {
-        temperature,
+        ...(geminiSupportsSamplingParameters(model) ? { temperature } : {}),
         maxOutputTokens: maxTokens,
       },
     };

--- a/server/generators/grok-text-generator.ts
+++ b/server/generators/grok-text-generator.ts
@@ -15,7 +15,7 @@ export class GrokTextGenerator extends TextGenerator {
   async generate(req: TextGenerateRequest): Promise<TextGenerateResult> {
     try {
       const { prompt, systemPrompt, modelId, temperature = 0.7, maxTokens = 2048, refImagesBase64 } = req;
-      const model = modelId || 'grok-4.20-0309-non-reasoning';
+      const model = modelId || 'grok-4.6';
 
       const messages: Array<{ role: string; content: any }> = [];
 

--- a/server/generators/vertex-ai-text-generator.ts
+++ b/server/generators/vertex-ai-text-generator.ts
@@ -1,4 +1,5 @@
 import { TextGenerator, TextGenerateRequest, TextGenerateResult } from './text-generator';
+import { geminiSupportsSamplingParameters } from '../utils/gemini';
 
 const DEFAULT_ENDPOINT = 'aiplatform.googleapis.com';
 
@@ -14,7 +15,7 @@ export class VertexAITextGenerator extends TextGenerator {
 
   async generate(req: TextGenerateRequest): Promise<TextGenerateResult> {
     const { prompt, systemPrompt, temperature = 0.7, maxTokens = 2048, refImagesBase64, modelId, apiUrl: reqApiUrl } = req;
-    const model = modelId || 'gemini-3.6-flash';
+    const model = modelId || 'gemini-3.7-flash';
 
     let actualApiUrl: string;
     if (reqApiUrl) {
@@ -39,7 +40,7 @@ export class VertexAITextGenerator extends TextGenerator {
     const payload: any = {
       contents: [{ role: 'user', parts }],
       generationConfig: {
-        temperature,
+        ...(geminiSupportsSamplingParameters(model) ? { temperature } : {}),
         maxOutputTokens: maxTokens,
       },
     };

--- a/server/utils/gemini.ts
+++ b/server/utils/gemini.ts
@@ -1,0 +1,17 @@
+/**
+ * The newer Gemini 3.x models are tuned for their default sampling and reject
+ * the legacy knobs (`temperature`, `topP`, `topK`) instead of ignoring them, so
+ * those fields have to be left out of the request entirely.
+ *
+ * Kept in one place so the assistant chat adapter and the text generators agree
+ * on which models still accept them.
+ */
+const MODELS_WITHOUT_SAMPLING_PARAMETERS = new Set([
+  'gemini-3.7-flash',
+  'gemini-3.6-flash',
+  'gemini-3.5-flash-lite',
+]);
+
+export function geminiSupportsSamplingParameters(modelId: string): boolean {
+  return !MODELS_WITHOUT_SAMPLING_PARAMETERS.has(modelId);
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -282,6 +282,18 @@ export const PROVIDER_MODELS_MAP: Record<ProviderType, ModelConfig[]> = {
       },
     },
     {
+      id: 'google-gemini-3.7-flash-text',
+      name: 'Gemini 3.7 Flash',
+      generatorId: 'GoogleAI',
+      modelId: 'gemini-3.7-flash',
+      category: 'text',
+      promptLimit: { value: 1048576, unit: 'tokens' },
+      options: {
+        temperatures: [0, 0.2, 0.5, 0.7, 1.0, 1.5, 2.0],
+        maxTokenOptions: [256, 512, 1024, 2048, 4096, 8192, 16384, 32768, 65536],
+      },
+    },
+    {
       id: 'google-gemini-3.6-flash-text',
       name: 'Gemini 3.6 Flash',
       generatorId: 'GoogleAI',
@@ -481,6 +493,18 @@ export const PROVIDER_MODELS_MAP: Record<ProviderType, ModelConfig[]> = {
       options: {
         aspectRatios: ['1:1', '4:3', '3:4', '16:9', '9:16', '2:3', '3:2', '4:5', '5:4', '21:9'],
         qualities: ['1K'],
+      },
+    },
+    {
+      id: 'vertex-gemini-3.7-flash-text',
+      name: 'Gemini 3.7 Flash',
+      generatorId: 'VertexAI',
+      modelId: 'gemini-3.7-flash',
+      category: 'text',
+      promptLimit: { value: 1048576, unit: 'tokens' },
+      options: {
+        temperatures: [0, 0.2, 0.5, 0.7, 1.0, 1.5, 2.0],
+        maxTokenOptions: [256, 512, 1024, 2048, 4096, 8192, 16384, 32768, 65536],
       },
     },
     {
@@ -1058,14 +1082,30 @@ export const PROVIDER_MODELS_MAP: Record<ProviderType, ModelConfig[]> = {
       },
     },
     {
+      // `id` stays on the old name so saved projects keep their selection.
+      // `grok-imagine-image-pro` itself was retired by xAI in May 2026 and the
+      // quality tier is its migration target — same request shape, so only the
+      // model ID moves.
       id: 'grok-imagine-image-pro',
-      name: 'Grok Imagine Pro',
+      name: 'Grok Imagine Quality',
       generatorId: 'Grok',
-      modelId: 'grok-imagine-image-pro',
+      modelId: 'grok-imagine-image-quality',
       category: 'image',
       options: {
         aspectRatios: ['1:1', '3:4', '4:3', '9:16', '16:9', '2:3', '3:2', '9:19.5', '19.5:9', '9:20', '20:9', '1:2', '2:1', 'auto'],
         qualities: ['low/1k', 'low/2k', 'medium/1k', 'medium/2k', 'high/1k', 'high/2k'],
+      },
+    },
+    {
+      id: 'grok-4.6-text',
+      name: 'Grok 4.6',
+      generatorId: 'Grok',
+      modelId: 'grok-4.6',
+      category: 'text',
+      promptLimit: { value: 500000, unit: 'tokens' },
+      options: {
+        temperatures: [0, 0.2, 0.5, 0.7, 1.0, 1.5, 2.0],
+        maxTokenOptions: [256, 512, 1024, 2048, 4096, 8192, 16384, 32768],
       },
     },
     {


### PR DESCRIPTION
xAI shipped Grok 4.6 and Google shipped Gemini 3.7 Flash since the catalog
was last refreshed, and xAI's `grok-imagine-image-pro` was deactivated in
May 2026, so an image project pinned to it had no working upstream model.

Grok 4.6 (`grok-4.6`) joins the text models with the 500K context it
documents. The Grok Imagine Pro entry now points at
`grok-imagine-image-quality`, the tier xAI names as its migration target:
both take the same `quality` plus `resolution` pair that parseQualityPreset
already splits out of the project's single quality picker, so only the model
ID and the display name move. The entry keeps its original `id` because
projects persist `modelConfigId` — renaming it would orphan saved
selections.

Gemini 3.7 Flash (`gemini-3.7-flash`) joins both the Google AI and Vertex AI
text models with a 1M-token context and 64K output, and becomes the default
fallback in both REST text generators alongside Grok 4.6 in its own.

Gemini 3.x is progressively dropping the legacy sampling knobs, and 3.7
Flash rejects `temperature` outright rather than ignoring it — which would
have broken text jobs the moment it became the default. The assistant
adapter already guarded that for 3.6 Flash and 3.5 Flash-Lite while both
REST generators sent the field unconditionally, so the model list moves to
`server/utils/gemini.ts` and all three callers read it.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014kEtBKpoFdUx6XLvnRtjVM