### PR TITLE
Show app version and git commit at bottom of sidebar

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -55,6 +55,8 @@ jobs:
           file: ./Dockerfile
           push: ${{ github.event_name != 'pull_request' }}
           platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
+          build-args: |
+            GIT_COMMIT=${{ github.sha }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,10 @@ RUN npx prisma generate
 # Copy the rest of the application
 COPY . .
 
+# .git is excluded from the build context, so the commit is passed in explicitly.
+ARG GIT_COMMIT=""
+ENV VITE_GIT_COMMIT=$GIT_COMMIT
+
 # Build both frontend and backend
 RUN npm run build
 

--- a/src/components/MainLayout.tsx
+++ b/src/components/MainLayout.tsx
@@ -10,6 +10,9 @@ import { CommandPalette } from './CommandPalette';
 
 type ThemeMode = 'light' | 'dark' | 'system';
 
+const APP_VERSION = import.meta.env.VITE_APP_VERSION || '1.12.1';
+const GIT_COMMIT = import.meta.env.VITE_GIT_COMMIT || '';
+
 function NavItem({ to, icon, label, isActive, isCollapsed, onClick }: {
   to: string;
   icon: React.ReactNode;
@@ -112,7 +115,7 @@ export function MainLayout() {
         if (res.ok) {
           const data = await res.json();
           const latestVersion = data.tag_name.replace(/^v/, '');
-          const currentVersion = import.meta.env.VITE_APP_VERSION || '1.12.1';
+          const currentVersion = APP_VERSION;
           
           if (latestVersion && latestVersion !== currentVersion) {
             const v1 = latestVersion.split('.').map(Number);
@@ -401,6 +404,25 @@ export function MainLayout() {
               )}
             </Link>
           )}
+
+          <div
+            className={`mt-3 flex flex-col items-center gap-0.5 text-[10px] leading-tight text-neutral-400 dark:text-neutral-600 ${isCollapsed ? 'lg:gap-0' : ''}`}
+          >
+            <span className="font-mono" title={`${t('mainLayout.version')} ${APP_VERSION}`}>
+              v{APP_VERSION}
+            </span>
+            {GIT_COMMIT && (
+              <a
+                href={`https://github.com/shinchven/remix-studio/commit/${GIT_COMMIT}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="font-mono transition-colors hover:text-neutral-600 dark:hover:text-neutral-400"
+                title={`${t('mainLayout.commit')} ${GIT_COMMIT}`}
+              >
+                {GIT_COMMIT}
+              </a>
+            )}
+          </div>
         </div>
       </div>
 

--- a/src/locales/en/app.json
+++ b/src/locales/en/app.json
@@ -30,7 +30,9 @@
     "storageUnavailable": "Storage unavailable",
     "toggleMenu": "Toggle Menu",
     "expandSidebar": "Expand Sidebar",
-    "collapseSidebar": "Collapse Sidebar"
+    "collapseSidebar": "Collapse Sidebar",
+    "version": "Version",
+    "commit": "Commit"
   },
   "confirmModal": {
     "confirm": "Confirm",

--- a/src/locales/fr/app.json
+++ b/src/locales/fr/app.json
@@ -30,7 +30,9 @@
     "storageUnavailable": "Stockage indisponible",
     "toggleMenu": "Basculer le menu",
     "expandSidebar": "Développer la barre latérale",
-    "collapseSidebar": "Réduire la barre latérale"
+    "collapseSidebar": "Réduire la barre latérale",
+    "version": "Version",
+    "commit": "Commit"
   },
   "confirmModal": {
     "confirm": "Confirmer",

--- a/src/locales/ja/app.json
+++ b/src/locales/ja/app.json
@@ -30,7 +30,9 @@
     "storageUnavailable": "ストレージ利用不可",
     "toggleMenu": "メニュー切り替え",
     "expandSidebar": "サイドバーを展開",
-    "collapseSidebar": "サイドバーを折りたたむ"
+    "collapseSidebar": "サイドバーを折りたたむ",
+    "version": "バージョン",
+    "commit": "コミット"
   },
   "confirmModal": {
     "confirm": "確認",

--- a/src/locales/ko/app.json
+++ b/src/locales/ko/app.json
@@ -30,7 +30,9 @@
     "storageUnavailable": "스토리지 사용 불가",
     "toggleMenu": "메뉴 토글",
     "expandSidebar": "사이드바 확장",
-    "collapseSidebar": "사이드바 축소"
+    "collapseSidebar": "사이드바 축소",
+    "version": "버전",
+    "commit": "커밋"
   },
   "confirmModal": {
     "confirm": "확인",

--- a/src/locales/zh-CN/app.json
+++ b/src/locales/zh-CN/app.json
@@ -30,7 +30,9 @@
     "storageUnavailable": "存储不可用",
     "toggleMenu": "切换菜单",
     "expandSidebar": "展开侧边栏",
-    "collapseSidebar": "收起侧边栏"
+    "collapseSidebar": "收起侧边栏",
+    "version": "版本",
+    "commit": "提交"
   },
   "confirmModal": {
     "confirm": "确认",

--- a/src/locales/zh-TW/app.json
+++ b/src/locales/zh-TW/app.json
@@ -30,7 +30,9 @@
     "storageUnavailable": "存儲不可用",
     "toggleMenu": "切換選單",
     "expandSidebar": "展開側邊欄",
-    "collapseSidebar": "收起側邊欄"
+    "collapseSidebar": "收起側邊欄",
+    "version": "版本",
+    "commit": "提交"
   },
   "confirmModal": {
     "confirm": "確認",

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -2,6 +2,7 @@
 
 interface ImportMetaEnv {
   readonly VITE_APP_VERSION: string
+  readonly VITE_GIT_COMMIT: string
 }
 
 interface ImportMeta {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,10 +1,23 @@
 import tailwindcss from '@tailwindcss/vite';
 import react from '@vitejs/plugin-react';
+import {execSync} from 'child_process';
 import path from 'path';
 import fs from 'fs';
 import {defineConfig, loadEnv} from 'vite';
 
 const pkg = JSON.parse(fs.readFileSync('./package.json', 'utf-8'));
+
+// The commit is read from the environment first so that builds without a git
+// checkout (the Docker image ignores .git) can still be stamped via a build arg.
+const resolveGitCommit = (env: Record<string, string>) => {
+  const fromEnv = env.VITE_GIT_COMMIT || env.GIT_COMMIT || env.GITHUB_SHA;
+  if (fromEnv) return fromEnv.slice(0, 7);
+  try {
+    return execSync('git rev-parse --short=7 HEAD', {stdio: ['ignore', 'pipe', 'ignore']}).toString().trim();
+  } catch {
+    return '';
+  }
+};
 
 export default defineConfig(({mode}) => {
   const env = loadEnv(mode, '.', '');
@@ -13,6 +26,7 @@ export default defineConfig(({mode}) => {
     define: {
       'process.env.GEMINI_API_KEY': JSON.stringify(env.GEMINI_API_KEY),
       'import.meta.env.VITE_APP_VERSION': JSON.stringify(pkg.version),
+      'import.meta.env.VITE_GIT_COMMIT': JSON.stringify(resolveGitCommit(env)),
     },
     resolve: {
       alias: {


### PR DESCRIPTION
Stamp the short git commit into the frontend bundle alongside the existing
version define, and render both at the bottom of the sidebar. The commit
links to its GitHub page.

The Docker build context excludes .git, so the commit is passed through a
GIT_COMMIT build arg (wired to github.sha in the docker workflow) and the
vite config falls back to `git rev-parse` for local builds.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01C8T8oxd5MSXfoG12k7ZJJD