### PR TITLE
Show scheduled post totals on Scheduled Posts and Campaigns

### DIFF
--- a/src/lib/date.ts
+++ b/src/lib/date.ts
@@ -7,18 +7,7 @@ export function shouldShowYear(...dates: (Date | null | undefined)[]): boolean {
   return dates.some((date) => !!date && date.getFullYear() !== currentYear);
 }
 
-/** "Mar 3, 10:00 AM", or "Mar 3, 2027, 10:00 AM" when the year matters. */
-export function formatDateTime(date: Date, showYear = shouldShowYear(date)): string {
-  return date.toLocaleString(undefined, {
-    ...(showYear ? { year: 'numeric' as const } : {}),
-    month: 'short',
-    day: 'numeric',
-    hour: '2-digit',
-    minute: '2-digit',
-  });
-}
-
-/** "Mar 3", or "Mar 3, 2027" when the year matters. */
+/** "Mar 3", or "Mar 3, 2027" when the year matters. Pass `true` to always keep the year. */
 export function formatShortDate(date: Date, showYear = shouldShowYear(date)): string {
   return date.toLocaleDateString(undefined, {
     ...(showYear ? { year: 'numeric' as const } : {}),

--- a/src/lib/date.ts
+++ b/src/lib/date.ts
@@ -1,0 +1,44 @@
+/**
+ * Dates in the current year are rendered without it to keep labels short; anything
+ * outside it keeps the year so ranges crossing a year boundary stay unambiguous.
+ */
+export function shouldShowYear(...dates: (Date | null | undefined)[]): boolean {
+  const currentYear = new Date().getFullYear();
+  return dates.some((date) => !!date && date.getFullYear() !== currentYear);
+}
+
+/** "Mar 3, 10:00 AM", or "Mar 3, 2027, 10:00 AM" when the year matters. */
+export function formatDateTime(date: Date, showYear = shouldShowYear(date)): string {
+  return date.toLocaleString(undefined, {
+    ...(showYear ? { year: 'numeric' as const } : {}),
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+/** "Mar 3", or "Mar 3, 2027" when the year matters. */
+export function formatShortDate(date: Date, showYear = shouldShowYear(date)): string {
+  return date.toLocaleDateString(undefined, {
+    ...(showYear ? { year: 'numeric' as const } : {}),
+    month: 'short',
+    day: 'numeric',
+  });
+}
+
+/**
+ * Clock time for today, a short date otherwise. For activity feeds, where a bare
+ * "10:04 AM" on a months-old entry reads as if it just happened.
+ */
+export function formatTimeOrDate(date: Date): string {
+  const now = new Date();
+  const isToday =
+    date.getFullYear() === now.getFullYear() &&
+    date.getMonth() === now.getMonth() &&
+    date.getDate() === now.getDate();
+
+  return isToday
+    ? date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+    : formatShortDate(date);
+}

--- a/src/pages/Campaigns.tsx
+++ b/src/pages/Campaigns.tsx
@@ -138,6 +138,7 @@ export function Campaigns() {
   const [recentPosts, setRecentPosts] = useState<any[]>([]);
   const [recentPostsLoading, setRecentPostsLoading] = useState(true);
   const [scheduledPosts, setScheduledPosts] = useState<any[]>([]);
+  const [scheduledPostsTotal, setScheduledPostsTotal] = useState(0);
   const [scheduledPostsLoading, setScheduledPostsLoading] = useState(true);
   const trendRange = useMemo(() => lastNDaysRange(7), []);
 
@@ -170,6 +171,7 @@ export function Campaigns() {
     try {
       const data = await fetchScheduledPosts(1, 5);
       setScheduledPosts(data.items);
+      setScheduledPostsTotal(data.total);
     } catch (error) {
       console.error('Failed to load scheduled posts', error);
     } finally {
@@ -556,6 +558,9 @@ export function Campaigns() {
                 <h3 className="flex items-center gap-2 text-xl font-semibold text-neutral-900 dark:text-white">
                   <Calendar className="h-5 w-5 text-indigo-500" />
                   {t('scheduledPosts')}
+                  {scheduledPostsTotal > 0 && (
+                    <span className="text-sm font-normal text-neutral-500 dark:text-neutral-500">({scheduledPostsTotal})</span>
+                  )}
                 </h3>
               </div>
 

--- a/src/pages/Campaigns.tsx
+++ b/src/pages/Campaigns.tsx
@@ -24,7 +24,7 @@ import { ConfirmDialog } from '../components/ConfirmDialog';
 import { PageHeader } from '../components/PageHeader';
 import { cn } from '../lib/utils';
 import { applyAvatarFallback, defaultAvatar } from '../lib/avatar';
-import { formatDateTime, formatShortDate, formatTimeOrDate, shouldShowYear } from '../lib/date';
+import { formatShortDate, formatTimeOrDate } from '../lib/date';
 import { PostingTrendChart, lastNDaysRange } from '../components/PostingTrendChart';
 
 type CampaignStatus = 'Active' | 'Inactive';
@@ -81,10 +81,9 @@ function mapCampaign(raw: any): CampaignCardModel {
     end = new Date(Math.max(...scheduledTimes));
   }
 
-  // Both ends share one decision so a range never mixes a bare date with a dated one.
-  const showYear = shouldShowYear(start, end);
-  const startDate = start ? formatDateTime(start, showYear) : 'Not scheduled';
-  const endDate = end ? formatDateTime(end, showYear) : 'Not scheduled';
+  // Cards carry the date and year only; the campaign detail page has the time of day.
+  const startDate = start ? formatShortDate(start, true) : 'Not scheduled';
+  const endDate = end ? formatShortDate(end, true) : 'Not scheduled';
 
   let latestPostThumbnail = '';
   const postWithMedia = posts.find((p: any) => p.media && p.media.length > 0);

--- a/src/pages/Campaigns.tsx
+++ b/src/pages/Campaigns.tsx
@@ -358,11 +358,11 @@ export function Campaigns() {
                         <div className="mb-4 grid grid-cols-2 gap-2">
                           <div className="rounded-xl border border-white/10 bg-white/10 px-3 py-2 backdrop-blur-md">
                             <div className="mb-0.5 text-[9px] font-black uppercase tracking-[0.18em] text-white/45">Start</div>
-                            <div className="truncate text-[12px] font-bold text-white/90">{campaign.startDate}</div>
+                            <div className="text-[12px] font-bold leading-tight text-white/90">{campaign.startDate}</div>
                           </div>
                           <div className="rounded-xl border border-white/10 bg-white/10 px-3 py-2 backdrop-blur-md">
                             <div className="mb-0.5 text-[9px] font-black uppercase tracking-[0.18em] text-white/45">End</div>
-                            <div className="truncate text-[12px] font-bold text-white/90">{campaign.endDate}</div>
+                            <div className="text-[12px] font-bold leading-tight text-white/90">{campaign.endDate}</div>
                           </div>
                         </div>
                         

--- a/src/pages/Campaigns.tsx
+++ b/src/pages/Campaigns.tsx
@@ -24,6 +24,7 @@ import { ConfirmDialog } from '../components/ConfirmDialog';
 import { PageHeader } from '../components/PageHeader';
 import { cn } from '../lib/utils';
 import { applyAvatarFallback, defaultAvatar } from '../lib/avatar';
+import { formatDateTime, formatShortDate, formatTimeOrDate, shouldShowYear } from '../lib/date';
 import { PostingTrendChart, lastNDaysRange } from '../components/PostingTrendChart';
 
 type CampaignStatus = 'Active' | 'Inactive';
@@ -57,15 +58,6 @@ function campaignThumbnail(id: string) {
   return `https://api.dicebear.com/7.x/shapes/svg?seed=${encodeURIComponent(id)}&backgroundColor=0f172a,1e293b,334155&shape1Color=6366f1,818cf8,4f46e5`;
 }
 
-function formatCampaignDateTime(value: Date) {
-  return value.toLocaleString(undefined, {
-    month: 'short',
-    day: 'numeric',
-    hour: '2-digit',
-    minute: '2-digit',
-  });
-}
-
 function mapCampaign(raw: any): CampaignCardModel {
   const posts = Array.isArray(raw.posts) ? raw.posts : [];
   const totalPosts = raw._count?.posts ?? posts.length ?? 0;
@@ -73,20 +65,26 @@ function mapCampaign(raw: any): CampaignCardModel {
   const scheduledTimes = posts
     .map((post: any) => (post.scheduledAt ? new Date(post.scheduledAt).getTime() : Number.NaN))
     .filter(Number.isFinite);
-  let startDate = 'Not scheduled';
-  let endDate = 'Not scheduled';
+
+  let start: Date | null = null;
+  let end: Date | null = null;
 
   if (raw.scheduledStart) {
-    startDate = formatCampaignDateTime(new Date(raw.scheduledStart));
+    start = new Date(raw.scheduledStart);
   } else if (scheduledTimes.length > 0) {
-    startDate = formatCampaignDateTime(new Date(Math.min(...scheduledTimes)));
+    start = new Date(Math.min(...scheduledTimes));
   }
 
   if (raw.scheduledEnd) {
-    endDate = formatCampaignDateTime(new Date(raw.scheduledEnd));
+    end = new Date(raw.scheduledEnd);
   } else if (scheduledTimes.length > 0) {
-    endDate = formatCampaignDateTime(new Date(Math.max(...scheduledTimes)));
+    end = new Date(Math.max(...scheduledTimes));
   }
+
+  // Both ends share one decision so a range never mixes a bare date with a dated one.
+  const showYear = shouldShowYear(start, end);
+  const startDate = start ? formatDateTime(start, showYear) : 'Not scheduled';
+  const endDate = end ? formatDateTime(end, showYear) : 'Not scheduled';
 
   let latestPostThumbnail = '';
   const postWithMedia = posts.find((p: any) => p.media && p.media.length > 0);
@@ -518,7 +516,7 @@ export function Campaigns() {
                               <span className="shrink-0 text-neutral-300 dark:text-neutral-700">•</span>
                               <span className="shrink-0 flex items-center gap-1 opacity-80">
                                 <Clock className="h-3 w-3" />
-                                {new Date(post.updatedAt).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
+                                {formatTimeOrDate(new Date(post.updatedAt))}
                               </span>
                             </div>
                           </div>
@@ -611,7 +609,7 @@ export function Campaigns() {
                           <div className="flex items-center gap-2 text-[13px] font-medium text-neutral-500">
                             <span className="flex items-center gap-1.5 font-bold text-indigo-600 dark:text-indigo-400">
                               <Clock className="h-3.5 w-3.5" />
-                              {new Date(post.scheduledAt).toLocaleDateString(undefined, { month: 'short', day: 'numeric' })}
+                              {formatShortDate(new Date(post.scheduledAt))}
                             </span>
                             <span className="shrink-0 text-neutral-300 dark:text-neutral-700">•</span>
                             <span className="truncate opacity-80">{post.campaign?.name}</span>

--- a/src/pages/ScheduledPosts.tsx
+++ b/src/pages/ScheduledPosts.tsx
@@ -64,6 +64,7 @@ export function ScheduledPosts() {
   const [counts, setCounts] = useState<PostCount[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [total, setTotal] = useState(0);
+  const [totalScheduled, setTotalScheduled] = useState<number | null>(null);
   const [totalPages, setTotalPages] = useState(1);
   const [searchQuery, setSearchQuery] = useState(q);
 
@@ -78,6 +79,8 @@ export function ScheduledPosts() {
       setPosts(data.items);
       setTotal(data.total);
       setTotalPages(data.totalPages);
+      // Without a search filter the list total is already the overall total.
+      if (!q) setTotalScheduled(data.total);
     } catch (error: any) {
       console.error('[ScheduledPosts] loadPosts error:', error);
       toast.error(error.message || 'Failed to load scheduled posts');
@@ -115,6 +118,16 @@ export function ScheduledPosts() {
     }
   };
 
+  // Total across every scheduled post, independent of the search filter or the calendar month.
+  const loadTotalScheduled = async () => {
+    try {
+      const data = await fetchScheduledPosts(1, 1);
+      setTotalScheduled(data.total);
+    } catch (error: any) {
+      console.error('[ScheduledPosts] loadTotalScheduled error:', error);
+    }
+  };
+
   useEffect(() => {
     if (viewMode === 'list') {
       void loadPosts();
@@ -122,6 +135,12 @@ export function ScheduledPosts() {
       void loadCounts();
     }
   }, [viewMode, page, q, currentMonth]);
+
+  useEffect(() => {
+    // In list view without a search, loadPosts already reports the overall total.
+    if (viewMode === 'list' && !q) return;
+    void loadTotalScheduled();
+  }, [viewMode, q]);
 
   const toggleView = (mode: ViewMode) => {
     const params = new URLSearchParams(searchParams);
@@ -197,11 +216,31 @@ export function ScheduledPosts() {
     return countsByDate.get(formatLocalDateKey(date));
   }
 
+  // The fetched range covers full weeks, so only count days belonging to the displayed month.
+  const monthTotal = useMemo(
+    () =>
+      calendarDays.reduce(
+        (sum, day) =>
+          day.isCurrentMonth ? sum + (countsByDate.get(formatLocalDateKey(day.date))?.postCount || 0) : sum,
+        0,
+      ),
+    [calendarDays, countsByDate],
+  );
+
   return (
     <div className="h-full flex flex-col p-4 md:p-8 overflow-y-auto">
       <div className="w-full flex flex-col gap-6 pb-20">
         <PageHeader
-          title="Scheduled Posts"
+          title={
+            <span className="inline-flex flex-wrap items-center gap-3">
+              Scheduled Posts
+              {totalScheduled !== null && (
+                <span className="rounded-full bg-indigo-50 px-3 py-1 text-sm font-bold text-indigo-600 dark:bg-indigo-500/10 dark:text-indigo-400">
+                  {totalScheduled} total
+                </span>
+              )}
+            </span>
+          }
           description="View and manage your upcoming social media posts."
           backLink={{ to: '/campaigns', label: 'Back to Campaigns' }}
           actions={
@@ -254,6 +293,11 @@ export function ScheduledPosts() {
               >
                 Search
               </button>
+              {!isLoading && total > 0 && (
+                <span className="ml-auto hidden shrink-0 text-xs font-medium text-neutral-500 sm:block">
+                  {`Showing ${(page - 1) * 25 + 1}–${(page - 1) * 25 + posts.length} of ${total}${q ? ' matching' : ''} ${total === 1 ? 'post' : 'posts'}`}
+                </span>
+              )}
             </div>
 
             <div className="overflow-hidden rounded-card border border-neutral-200/50 bg-white shadow-sm dark:border-white/5 dark:bg-neutral-900/50">
@@ -325,7 +369,9 @@ export function ScheduledPosts() {
 
               {totalPages > 1 && (
                 <div className="px-4 sm:px-6 py-4 border-t border-neutral-100 dark:border-white/5 bg-neutral-50/30 flex flex-col items-center gap-3 sm:flex-row sm:items-center sm:justify-between">
-                  <span className="text-xs text-neutral-500">Page {page} of {totalPages}</span>
+                  <span className="text-xs text-neutral-500">
+                    Page {page} of {totalPages} &middot; {total} {total === 1 ? 'post' : 'posts'}
+                  </span>
                   <PageNav page={page} pages={totalPages} onPageChange={updatePage} />
                 </div>
               )}
@@ -350,6 +396,12 @@ export function ScheduledPosts() {
                   </button>
                 </div>
               </div>
+              {!isLoading && (
+                <span className="text-xs font-medium text-neutral-500">
+                  {monthTotal} {monthTotal === 1 ? 'post' : 'posts'} this month
+                  {totalScheduled !== null && <> &middot; {totalScheduled} total</>}
+                </span>
+              )}
             </div>
 
             <div className="grid grid-cols-7 gap-px bg-neutral-200 dark:bg-white/10 rounded-card overflow-hidden border border-neutral-200 dark:border-white/10">

--- a/src/pages/ScheduledPosts.tsx
+++ b/src/pages/ScheduledPosts.tsx
@@ -21,6 +21,7 @@ import { toast } from 'sonner';
 import { fetchScheduledPosts, fetchScheduledPostCounts } from '../api';
 import { PageHeader } from '../components/PageHeader';
 import { cn } from '../lib/utils';
+import { formatShortDate } from '../lib/date';
 import { PageNav } from '../components/PageNav';
 
 type ViewMode = 'list' | 'calendar';
@@ -350,7 +351,7 @@ export function ScheduledPosts() {
                       </div>
                       <div className="flex flex-col text-xs text-neutral-500">
                         <span className="font-bold text-neutral-700 dark:text-neutral-300">
-                          {new Date(post.scheduledAt).toLocaleDateString(undefined, { month: 'short', day: 'numeric' })}
+                          {formatShortDate(new Date(post.scheduledAt))}
                         </span>
                         <span>{new Date(post.scheduledAt).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}</span>
                       </div>

--- a/src/pages/ScheduledPosts.tsx
+++ b/src/pages/ScheduledPosts.tsx
@@ -380,9 +380,9 @@ export function ScheduledPosts() {
           </div>
         ) : (
           <div className="space-y-6">
-            <div className="flex items-center justify-between">
-              <div className="flex items-center gap-4">
-                <h3 className="text-xl font-bold">
+            <div className="flex flex-col items-start gap-3 sm:flex-row sm:items-center sm:justify-between">
+              <div className="flex items-center gap-3 sm:gap-4">
+                <h3 className="whitespace-nowrap text-lg font-bold sm:text-xl">
                   {currentMonth.toLocaleDateString(undefined, { month: 'long', year: 'numeric' })}
                 </h3>
                 <div className="flex items-center gap-1">
@@ -433,9 +433,10 @@ export function ScheduledPosts() {
                     </div>
                     {dayData && dayData.postCount > 0 && (
                       <div className="mt-2 space-y-1">
-                        <div className="px-2 py-1 bg-indigo-50 dark:bg-indigo-500/10 rounded-lg border border-indigo-100 dark:border-indigo-500/20">
-                          <div className="flex items-center justify-between">
-                            <span className="text-[10px] font-black text-indigo-600 dark:text-indigo-400 uppercase">Posts</span>
+                        <div className="px-1.5 py-1 sm:px-2 bg-indigo-50 dark:bg-indigo-500/10 rounded-lg border border-indigo-100 dark:border-indigo-500/20">
+                          {/* A day cell is only ~50px wide on a phone, so the label drops out and the count stays. */}
+                          <div className="flex items-center justify-center gap-1 sm:justify-between">
+                            <span className="hidden sm:inline text-[10px] font-black text-indigo-600 dark:text-indigo-400 uppercase">Posts</span>
                             <span className="text-xs font-bold text-indigo-700 dark:text-indigo-300">{dayData.postCount}</span>
                           </div>
                         </div>


### PR DESCRIPTION
The Scheduled Posts page fetched the total from the API but never
displayed it. Surface it in the page header (both list and calendar
views), add a "Showing X-Y of N" summary next to the search box, and
include the count in the pagination footer. Calendar view also reports
how many posts fall in the displayed month.

The Campaigns page shows the same total next to the "Scheduled Posts"
heading, matching the existing "All Campaigns" count style. The total
comes from the response it already fetches, so no extra request.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CuFuhjEyPRKhmwm8oGaP8G