### PR TITLE
Refactor footer version/commit layout to horizontal flex layout

### DIFF
--- a/src/components/MainLayout.tsx
+++ b/src/components/MainLayout.tsx
@@ -405,22 +405,23 @@ export function MainLayout() {
             </Link>
           )}
 
-          <div
-            className={`mt-3 flex flex-col items-center gap-0.5 text-[10px] leading-tight text-neutral-400 dark:text-neutral-600 ${isCollapsed ? 'lg:gap-0' : ''}`}
-          >
+          <div className="mt-3 flex flex-row flex-wrap items-center justify-center gap-x-1.5 gap-y-0.5 text-[10px] leading-tight text-neutral-400 dark:text-neutral-600">
             <span className="font-mono" title={`${t('mainLayout.version')} ${APP_VERSION}`}>
               v{APP_VERSION}
             </span>
             {GIT_COMMIT && (
-              <a
-                href={`https://github.com/shinchven/remix-studio/commit/${GIT_COMMIT}`}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="font-mono transition-colors hover:text-neutral-600 dark:hover:text-neutral-400"
-                title={`${t('mainLayout.commit')} ${GIT_COMMIT}`}
-              >
-                {GIT_COMMIT}
-              </a>
+              <>
+                <span aria-hidden="true">·</span>
+                <a
+                  href={`https://github.com/shinchven/remix-studio/commit/${GIT_COMMIT}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="font-mono transition-colors hover:text-neutral-600 dark:hover:text-neutral-400"
+                  title={`${t('mainLayout.commit')} ${GIT_COMMIT}`}
+                >
+                  {GIT_COMMIT}
+                </a>
+              </>
             )}
           </div>
         </div>


### PR DESCRIPTION
## Summary
Updated the footer version and commit information layout from a vertical flex column to a horizontal flex row with wrapping, improving the visual presentation and spacing of these elements.

## Key Changes
- Changed footer container from `flex-col` to `flex-row flex-wrap` for horizontal layout
- Updated gap spacing from `gap-0.5` with conditional `lg:gap-0` to `gap-x-1.5 gap-y-0.5` for better control over horizontal and vertical spacing
- Added a visual separator (·) between version and commit hash using `aria-hidden="true"` for accessibility
- Wrapped the commit link and separator in a fragment to maintain proper conditional rendering

## Implementation Details
- The layout now displays version and commit information side-by-side on wider screens, wrapping to multiple lines if needed
- The separator bullet is hidden from screen readers to avoid redundant announcements
- Removed the responsive gap adjustment logic in favor of explicit gap values that work better with the new flex-row layout
- Maintains the same styling for the commit link hover states and dark mode support

https://claude.ai/code/session_01JGDetAr8gxYV2LCKmWPxZ7