### PR TITLE
fix(ui): scroll list back to top when changing pages

### DIFF
--- a/src/components/PageNav.tsx
+++ b/src/components/PageNav.tsx
@@ -1,7 +1,8 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ChevronLeft, ChevronRight, ChevronsLeft, ChevronsRight, MoreHorizontal } from 'lucide-react';
 import { useIsCompactViewport } from '../hooks/useMediaQuery';
+import { scrollListToTop } from '../lib/scroll';
 
 const ELLIPSIS_JUMP = 5;
 
@@ -35,6 +36,8 @@ interface PageNavProps {
   size?: 'sm' | 'lg';
   /** Page numbers shown on each side of the current page. */
   siblings?: number;
+  /** Set false where the list is short enough that jumping to the top is jarring. */
+  scrollToTop?: boolean;
   className?: string;
 }
 
@@ -44,9 +47,11 @@ export function PageNav({
   onPageChange,
   size = 'sm',
   siblings = 1,
+  scrollToTop = true,
   className = '',
 }: PageNavProps) {
   const { t } = useTranslation();
+  const rootRef = useRef<HTMLDivElement | null>(null);
   // Phones cannot fit the full window: drop the siblings and the first/last jumps,
   // which the always-visible "1" and last-page buttons already cover.
   const isCompact = useIsCompactViewport();
@@ -60,6 +65,8 @@ export function PageNav({
     const next = Math.min(Math.max(1, p), effectivePages);
     if (next === safePage) return;
     onPageChange(next);
+    // The new page starts at the top of the list, not where the pager was clicked.
+    if (scrollToTop) scrollListToTop(rootRef.current);
   };
 
   // Touch targets stay at least 36px wide on phones, where the desktop 'sm' size is too small to tap.
@@ -76,7 +83,7 @@ export function PageNav({
   const items = buildPageItems(safePage, effectivePages, isCompact ? 0 : siblings);
 
   return (
-    <div className={`flex items-center justify-center gap-1 ${className}`}>
+    <div ref={rootRef} className={`flex items-center justify-center gap-1 ${className}`}>
       {!isCompact && (
         <button
           type="button"

--- a/src/lib/scroll.ts
+++ b/src/lib/scroll.ts
@@ -1,0 +1,40 @@
+/**
+ * Scroll helpers for list views.
+ *
+ * Pages are not scrolled by the window in this app: `MainLayout` puts the routed
+ * content inside its own `overflow-y-auto` pane, and some views (project tabs,
+ * chat history) add another scroller of their own. So "back to top" means the
+ * nearest scrollable ancestor of the control that was clicked, with the window
+ * as the fallback.
+ */
+
+function prefersReducedMotion(): boolean {
+  return typeof window.matchMedia === 'function'
+    && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+}
+
+/** The closest ancestor that actually scrolls vertically, or null when none does. */
+function findScrollableAncestor(from: HTMLElement | null): HTMLElement | null {
+  let el = from?.parentElement ?? null;
+  while (el && el !== document.body && el !== document.documentElement) {
+    const { overflowY } = window.getComputedStyle(el);
+    const scrolls = overflowY === 'auto' || overflowY === 'scroll' || overflowY === 'overlay';
+    // A wrapper that only scrolls sideways (overflow-x-auto tables) computes an
+    // 'auto' overflow-y too, so check that there is vertical overflow as well.
+    if (scrolls && el.scrollHeight > el.clientHeight + 1) return el;
+    el = el.parentElement;
+  }
+  return null;
+}
+
+/**
+ * Scroll the list `element` sits in back to the top, so a new page of results
+ * starts at its first row instead of wherever the pager was clicked.
+ */
+export function scrollListToTop(element: HTMLElement | null): void {
+  if (typeof window === 'undefined') return;
+  const behavior: ScrollBehavior = prefersReducedMotion() ? 'auto' : 'smooth';
+  const scroller = findScrollableAncestor(element);
+  if (scroller) scroller.scrollTo({ top: 0, behavior });
+  else window.scrollTo({ top: 0, behavior });
+}


### PR DESCRIPTION
Every paginated view except the project viewer's album/completed tabs left
the scroll position where the pager was clicked, so a new page of results
opened mid-list.

PageNav now scrolls its list back to the top after a page change. Pages are
not scrolled by the window here (MainLayout owns an overflow-y-auto pane and
some views nest another scroller), so the new scrollListToTop helper walks up
to the nearest ancestor that actually scrolls vertically and falls back to the
window. It honours prefers-reduced-motion, and takes a scrollToTop={false}
opt-out.

Fixes paging in Projects, Libraries, Library editor, Exports, Release history,
Chat history, Admin users, Campaigns, Campaign detail, Campaign history,
Campaign batch actions and Scheduled posts.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015t7gburKoeSuWGdnpM4Au1