### PR TITLE
feat(media-picker): paginate the item grid

### DIFF
--- a/server/db/prisma-repository.ts
+++ b/server/db/prisma-repository.ts
@@ -1,5 +1,6 @@
 import { PrismaClient } from '@prisma/client';
 import { AppData, Library, LibraryItem, LibraryType, Project, ProjectStatus, AlbumItem, TrashItem, Job } from '../../src/types';
+import type { AlbumItemSort } from '../../src/types';
 import { IRepository } from './repository';
 import { LibraryRepository } from './library-repository';
 import { ProjectRepository } from './project-repository';
@@ -81,10 +82,11 @@ export class PrismaRepository implements IRepository {
     options?: {
       page?: number;
       limit?: number;
-      sort?: 'newest' | 'oldest';
+      sort?: AlbumItemSort;
       aspectRatios?: string[];
       tags?: string[];
       tagMatch?: 'all' | 'any';
+      q?: string;
     },
   ) {
     return this.projects.getProjectAlbum(userId, projectId, options);

--- a/server/db/project-repository.ts
+++ b/server/db/project-repository.ts
@@ -1,6 +1,19 @@
 import { Prisma, PrismaClient } from '@prisma/client';
 import crypto from 'crypto';
 import { Project, ProjectStatus, Job, WorkflowItem, AlbumItem, TrashItem } from '../../src/types';
+import type { AlbumItemSort } from '../../src/types';
+
+/**
+ * Album items carry no title, so `name-*` orders on the prompt — the same
+ * field the UI shows as an item's label. Ties fall back to newest-first.
+ */
+function albumOrderBy(sort: AlbumItemSort) {
+  const newestFirst = [{ createdAt: 'desc' as const }, { id: 'desc' as const }];
+  if (sort === 'oldest') return [{ createdAt: 'asc' as const }, { id: 'asc' as const }];
+  if (sort === 'name-asc') return [{ prompt: 'asc' as const }, ...newestFirst];
+  if (sort === 'name-desc') return [{ prompt: 'desc' as const }, ...newestFirst];
+  return newestFirst;
+}
 
 function normalizeAspectRatio(value: string | null | undefined): string {
   const ratio = value?.trim();
@@ -348,10 +361,11 @@ export class ProjectRepository {
     options: {
       page?: number;
       limit?: number;
-      sort?: 'newest' | 'oldest';
+      sort?: AlbumItemSort;
       aspectRatios?: string[];
       tags?: string[];
       tagMatch?: 'all' | 'any';
+      q?: string;
     } = {},
   ): Promise<{
     items: AlbumItem[];
@@ -364,7 +378,7 @@ export class ProjectRepository {
   }> {
     const page = options.page ?? 1;
     const limit = options.limit ?? 500;
-    const sort = options.sort ?? 'newest';
+    const sort: AlbumItemSort = options.sort ?? 'newest';
 
     const [ratioRows, sizeAgg, tagCounts] = await Promise.all([
       this.prisma.albumItem.groupBy({
@@ -423,10 +437,23 @@ export class ProjectRepository {
       }
     }
 
+    // Album items have no title column, so free-text search looks at the two
+    // fields the UI renders as an item's label: its prompt and its text output.
+    const search = options.q?.trim();
+    if (search) {
+      where.AND = [
+        ...(Array.isArray(where.AND) ? where.AND : []),
+        {
+          OR: [
+            { prompt: { contains: search, mode: 'insensitive' } },
+            { textContent: { contains: search, mode: 'insensitive' } },
+          ],
+        },
+      ];
+    }
+
     const skip = (page - 1) * limit;
-    const orderBy = sort === 'oldest'
-      ? [{ createdAt: 'asc' as const }, { id: 'asc' as const }]
-      : [{ createdAt: 'desc' as const }, { id: 'desc' as const }];
+    const orderBy = albumOrderBy(sort);
 
     const [total, items] = await Promise.all([
       this.prisma.albumItem.count({ where }),

--- a/server/db/repository.ts
+++ b/server/db/repository.ts
@@ -1,4 +1,5 @@
 import { AppData, Library, LibraryItem, LibraryType, Project, ProjectStatus, AlbumItem, TrashItem, Job } from '../../src/types';
+import type { AlbumItemSort } from '../../src/types';
 
 export interface IRepository {
   // === Library CRUD ===
@@ -49,10 +50,11 @@ export interface IRepository {
     options?: {
       page?: number;
       limit?: number;
-      sort?: 'newest' | 'oldest';
+      sort?: AlbumItemSort;
       aspectRatios?: string[];
       tags?: string[];
       tagMatch?: 'all' | 'any';
+      q?: string;
     },
   ): Promise<{
     items: AlbumItem[];

--- a/server/routes/projects.ts
+++ b/server/routes/projects.ts
@@ -17,7 +17,7 @@ import {
 import { checkStorageLimit } from '../utils/storage-check';
 import { normalizeWorkflowForStorage, stripToKey } from '../utils/storage-keys';
 import { UserRepository } from '../auth/user-repository';
-import type { WorkflowItem, Job, Project, LibraryItem, QueueMonitorView, AlbumItem } from '../../src/types';
+import type { WorkflowItem, Job, Project, LibraryItem, QueueMonitorView, AlbumItem, AlbumItemSort } from '../../src/types';
 import type { ProjectEventPublisher, ProjectLiveEventReason } from '../live/project-live-hub';
 import { normalizePostWatermarkPayload, postWatermarkSettingSchema } from '../utils/watermark';
 
@@ -145,6 +145,8 @@ export async function signJobs(jobs: Job[], storage: S3Storage): Promise<Job[]> 
     })
   );
 }
+
+const ALBUM_ITEM_SORTS: AlbumItemSort[] = ['newest', 'oldest', 'name-asc', 'name-desc'];
 
 /**
  * Read the album tag filter from a request — a comma-separated `tags` query
@@ -563,14 +565,17 @@ export function createProjectRouter(repository: IRepository, userRepository: Use
       const page = parseInt(c.req.query('page') || '1', 10);
       const limit = parseInt(c.req.query('limit') || '500', 10);
       const sortRaw = c.req.query('sort');
-      const sort: 'newest' | 'oldest' = sortRaw === 'oldest' ? 'oldest' : 'newest';
+      const sort: AlbumItemSort = ALBUM_ITEM_SORTS.includes(sortRaw as AlbumItemSort)
+        ? (sortRaw as AlbumItemSort)
+        : 'newest';
       const aspectRatiosRaw = c.req.query('aspectRatios');
       const aspectRatios = aspectRatiosRaw
         ? aspectRatiosRaw.split(',').map((s) => s.trim()).filter(Boolean)
         : undefined;
+      const q = c.req.query('q')?.trim() || undefined;
       const { tags, tagMatch } = readAlbumTagFilter(c);
       if (!projectId) return c.json({ error: 'Project id is required' }, 400);
-      const result = await repository.getProjectAlbum(user.userId, projectId, { page, limit, sort, aspectRatios, tags, tagMatch });
+      const result = await repository.getProjectAlbum(user.userId, projectId, { page, limit, sort, aspectRatios, tags, tagMatch, q });
       return c.json({
         ...result,
         items: await signAlbumItems(result.items, storage)

--- a/src/api.ts
+++ b/src/api.ts
@@ -583,10 +583,11 @@ export async function fetchProjectAlbum(
   options: {
     page?: number;
     limit?: number;
-    sort?: 'newest' | 'oldest';
+    sort?: import('./types').AlbumItemSort;
     aspectRatios?: string[];
     tags?: string[];
     tagMatch?: import('./types').AlbumTagMatch;
+    q?: string;
   } = {},
 ): Promise<import('./types').AlbumPageResult> {
   const params = new URLSearchParams({
@@ -601,6 +602,7 @@ export async function fetchProjectAlbum(
     params.set('tags', options.tags.join(','));
     if (options.tagMatch === 'any') params.set('tagMatch', 'any');
   }
+  if (options.q) params.set('q', options.q);
   const res = await apiFetch(`/api/projects/${id}/album?${params.toString()}`, { headers: getHeaders(false) });
   return handleResponse<import('./types').AlbumPageResult>(res, 'Failed to get project album');
 }

--- a/src/components/UniversalMediaPicker.tsx
+++ b/src/components/UniversalMediaPicker.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
 import {
@@ -13,6 +13,7 @@ import {
   Image as ImageIcon,
   Images,
   Layers,
+  List,
   Loader2,
   Music,
   Search,
@@ -21,11 +22,19 @@ import {
 } from 'lucide-react';
 import { fetchLibraries, fetchLibrary, fetchLibraryItems, fetchProject, fetchProjectAlbum, fetchProjects, imageDisplayUrl } from '../api';
 import { AlbumItem, AspectRatioCount, Library, LibraryItem, LibraryType, Project } from '../types';
+import type { AlbumItemSort } from '../types';
 import { cn } from '../lib/utils';
+import { PaginationBar, PAGE_SIZE_OPTIONS } from './ProjectViewer/PaginationBar';
 import { getLastMediaPickerSource, setLastMediaPickerSource } from '../lib/media-picker-memory';
 
 export type PickerSourceKind = 'library' | 'album';
-export type UniversalPickerSort = 'newest' | 'oldest' | 'name-asc' | 'name-desc';
+export type UniversalPickerSort = AlbumItemSort;
+
+/**
+ * Items are fetched a page at a time, so the grid stays light for libraries
+ * and albums that hold thousands of entries. Sources are still loaded flat.
+ */
+const DEFAULT_ITEM_PAGE_SIZE = 100;
 
 export interface UniversalPickedItem {
   sourceKind: PickerSourceKind;
@@ -129,6 +138,14 @@ function sortByChoice<T extends { id: string; name?: string; title?: string; raw
   });
 }
 
+/** Maps the picker's sort choice onto the library items endpoint's params. */
+function librarySortParams(sort: UniversalPickerSort): ['time' | 'name', 'asc' | 'desc'] {
+  if (sort === 'oldest') return ['time', 'asc'];
+  if (sort === 'name-asc') return ['name', 'asc'];
+  if (sort === 'name-desc') return ['name', 'desc'];
+  return ['time', 'desc'];
+}
+
 function libraryItemToPickerItem(item: LibraryItem, source: PickerSource): PickerItem {
   return {
     sourceKind: 'library',
@@ -209,6 +226,9 @@ export function UniversalMediaPicker({
   const [selectedTypes, setSelectedTypes] = useState<Set<LibraryType>>(() => new Set(allowedTypes));
   const [sourceQuery, setSourceQuery] = useState('');
   const [itemQuery, setItemQuery] = useState('');
+  // The item search now runs on the server, so it is debounced to keep typing
+  // from firing a request per keystroke.
+  const [debouncedItemQuery, setDebouncedItemQuery] = useState('');
   const [sourceSort, setSourceSort] = useState<UniversalPickerSort>('newest');
   const [itemSort, setItemSort] = useState<UniversalPickerSort>('newest');
   const [activeSourceId, setActiveSourceId] = useState<string | null>(null);
@@ -221,6 +241,10 @@ export function UniversalMediaPicker({
   const [selectedItemMap, setSelectedItemMap] = useState<Record<string, PickerItem>>({});
   const [loadingSources, setLoadingSources] = useState(false);
   const [loadingItems, setLoadingItems] = useState(false);
+  const [itemPage, setItemPage] = useState(1);
+  const [itemPageSize, setItemPageSize] = useState<number | 'all'>(DEFAULT_ITEM_PAGE_SIZE);
+  const [itemTotal, setItemTotal] = useState(0);
+  const [itemPages, setItemPages] = useState(1);
   const [lastSelectedKey, setLastSelectedKey] = useState<string | null>(null);
   const [imageVersion, setImageVersion] = useState<'raw' | 'optimized'>('optimized');
 
@@ -230,6 +254,7 @@ export function UniversalMediaPicker({
     setSelectedTypes(new Set(allowedTypes));
     setSourceQuery('');
     setItemQuery('');
+    setDebouncedItemQuery('');
     setActiveSourceId(initialSourceId);
     setSelectedKeys(new Set());
     setSelectedItemMap({});
@@ -237,6 +262,9 @@ export function UniversalMediaPicker({
     setAspectRatioCounts([]);
     setSelectedAspectRatios([]);
     setImageVersion('optimized');
+    setItemPage(1);
+    setItemTotal(0);
+    setItemPages(1);
   }, [allowedTypeKey, initialKind, initialSourceId, isOpen, fixedSourceId]);
 
   useEffect(() => {
@@ -341,7 +369,9 @@ export function UniversalMediaPicker({
   }, [filteredSources, loadingSources]);
 
   useEffect(() => {
-    setSelectedAspectRatios([]);
+    // Keep the existing array when it is already empty: a new [] would be a new
+    // identity, and the item effect depends on it, so it would refetch twice.
+    setSelectedAspectRatios((current) => (current.length === 0 ? current : []));
     setAspectRatioCounts([]);
   }, [activeSource?.id, activeSource?.kind]);
 
@@ -351,9 +381,26 @@ export function UniversalMediaPicker({
   }, [isOpen, memoryEnabled, memoryKey, activeSource?.id, activeSource?.kind]);
 
   useEffect(() => {
-    if (!isOpen || !activeSource) {
+    const handle = window.setTimeout(() => setDebouncedItemQuery(itemQuery.trim()), 250);
+    return () => window.clearTimeout(handle);
+  }, [itemQuery]);
+
+  // Paging is server-side, so anything that changes *which* items match has to
+  // send the grid back to page 1 — otherwise page 5 of the old result set is
+  // requested against a shorter new one.
+  useEffect(() => {
+    setItemPage(1);
+  }, [activeSource?.id, activeSource?.kind, debouncedItemQuery, itemSort, itemPageSize, selectedAspectRatios]);
+
+  const itemTypeAllowed = !!activeSource && selectedTypes.has(activeSource.type);
+  const itemLimit = itemPageSize === 'all' ? 999999 : itemPageSize;
+
+  useEffect(() => {
+    if (!isOpen || !activeSource || !itemTypeAllowed) {
       setItems([]);
-      setAspectRatioCounts([]);
+      setItemTotal(0);
+      setItemPages(1);
+      if (!activeSource) setAspectRatioCounts([]);
       return;
     }
 
@@ -362,17 +409,36 @@ export function UniversalMediaPicker({
       setLoadingItems(true);
       try {
         if (activeSource.kind === 'library') {
-          const result = await fetchLibraryItems(activeSource.id, 1, 500);
+          const [sortBy, sortOrder] = librarySortParams(itemSort);
+          const result = await fetchLibraryItems(
+            activeSource.id,
+            itemPage,
+            itemLimit,
+            debouncedItemQuery || undefined,
+            [],
+            sortBy,
+            sortOrder,
+          );
           if (!cancelled) {
             setItems((result.items || []).map((item) => libraryItemToPickerItem(item, activeSource)));
+            setItemTotal(result.total ?? 0);
+            setItemPages(Math.max(1, result.pages ?? 1));
             setAspectRatioCounts([]);
           }
         } else {
-          const albumResult = await fetchProjectAlbum(activeSource.id, { aspectRatios: selectedAspectRatios });
+          const albumResult = await fetchProjectAlbum(activeSource.id, {
+            page: itemPage,
+            limit: itemLimit,
+            sort: itemSort,
+            aspectRatios: selectedAspectRatios.length > 0 ? selectedAspectRatios : undefined,
+            q: debouncedItemQuery || undefined,
+          });
           if (!cancelled) {
             setItems((albumResult.items || [])
               .filter((item) => activeSource.type === 'text' ? (item.textContent || item.prompt) : item.imageUrl)
               .map((item) => albumItemToPickerItem(item, activeSource)));
+            setItemTotal(albumResult.total ?? 0);
+            setItemPages(Math.max(1, albumResult.pages ?? 1));
             setAspectRatioCounts(albumResult.aspectRatioCounts || []);
           }
         }
@@ -385,21 +451,22 @@ export function UniversalMediaPicker({
     return () => {
       cancelled = true;
     };
-  }, [activeSource?.id, activeSource?.kind, activeSource?.type, isOpen, selectedAspectRatios]);
+  }, [
+    activeSource?.id,
+    activeSource?.kind,
+    activeSource?.type,
+    isOpen,
+    itemTypeAllowed,
+    itemPage,
+    itemLimit,
+    itemSort,
+    debouncedItemQuery,
+    selectedAspectRatios,
+  ]);
 
-  const filteredItems = useMemo(() => {
-    const q = itemQuery.trim().toLowerCase();
-    const visibleItems = items.filter((item) => {
-      if (!selectedTypes.has(item.type)) return false;
-      return !q || (
-        item.title?.toLowerCase().includes(q) ||
-        item.sourceLabel.toLowerCase().includes(q) ||
-        item.rawUrl?.toLowerCase().includes(q) ||
-        item.value.toLowerCase().includes(q)
-      );
-    });
-    return sortByChoice(visibleItems, itemSort);
-  }, [itemQuery, itemSort, items, selectedTypes]);
+  // Search, sort and paging are all resolved by the server, so the grid renders
+  // exactly the page it was handed.
+  const filteredItems = items;
 
   const filteredKeys = useMemo(
     () => filteredItems.map((item) => `${item.sourceKind}:${item.sourceId}:${item.itemId}`),
@@ -411,6 +478,21 @@ export function UniversalMediaPicker({
   );
 
   const selectedItems = useMemo(() => Object.values(selectedItemMap), [selectedItemMap]);
+
+  // Paging swaps the grid's contents under a scroll position that no longer
+  // means anything, so each page change returns to the top — as the album does.
+  const itemScrollRef = useRef<HTMLDivElement | null>(null);
+  const scrollItemsTop = useCallback(() => {
+    itemScrollRef.current?.scrollTo({ top: 0 });
+  }, []);
+  const handleItemPageChange = useCallback((nextPage: number) => {
+    setItemPage(nextPage);
+    scrollItemsTop();
+  }, [scrollItemsTop]);
+  const handleItemPageSizeChange = useCallback((size: number | 'all') => {
+    setItemPageSize(size);
+    scrollItemsTop();
+  }, [scrollItemsTop]);
 
   const allFilteredSelected = filteredKeys.length > 0 && filteredKeys.every((key) => selectedKeys.has(key));
   const showImageVersionSelection = enableImageVersionSelection
@@ -757,6 +839,7 @@ export function UniversalMediaPicker({
               />
             )}
             <SortSelect value={itemSort} onChange={setItemSort} ariaLabel="Sort items" className="w-[7.5rem] shrink-0 md:w-auto" />
+            <PageSizeSelect value={itemPageSize} onChange={handleItemPageSizeChange} ariaLabel="Items per page" />
             {multiple && (
               <button
                 onClick={toggleSelectAll}
@@ -773,7 +856,7 @@ export function UniversalMediaPicker({
             )}
           </div>
 
-          <div className="min-h-0 flex-1 overflow-y-auto p-3 md:p-5">
+          <div ref={itemScrollRef} className="min-h-0 flex-1 overflow-y-auto p-3 md:p-5">
             {!activeSource ? (
               <EmptyPickerState icon={Layers} title="No source selected" description="Choose a library or album first." />
             ) : loadingItems ? (
@@ -852,6 +935,17 @@ export function UniversalMediaPicker({
               </div>
             )}
           </div>
+
+          {activeSource && (
+            <PaginationBar
+              page={itemPage}
+              pageSize={itemPageSize}
+              total={itemTotal}
+              pages={itemPages}
+              onPageChange={handleItemPageChange}
+              onPageSizeChange={handleItemPageSizeChange}
+            />
+          )}
 
           <div className="flex items-center justify-between gap-3 border-t border-neutral-200 p-3 pb-[max(0.75rem,env(safe-area-inset-bottom))] dark:border-white/10 md:p-5">
             {multiple ? (
@@ -973,6 +1067,43 @@ function AspectRatioFilter({
           </div>
         </div>
       )}
+    </div>
+  );
+}
+
+/**
+ * The page-size choice lives up in the toolbar, not only in the PaginationBar:
+ * the bar hides itself on "All", so this is what lets a viewer switch back.
+ */
+function PageSizeSelect({
+  value,
+  onChange,
+  ariaLabel,
+}: {
+  value: number | 'all';
+  onChange: (value: number | 'all') => void;
+  ariaLabel: string;
+}) {
+  return (
+    <div className="relative shrink-0">
+      <select
+        className="h-10 w-[5.5rem] appearance-none rounded-xl border border-neutral-200 bg-white pl-3 pr-8 text-xs font-semibold dark:border-white/10 dark:bg-neutral-900 dark:text-white md:h-11 md:text-sm"
+        value={value === 'all' ? 'all' : String(value)}
+        onChange={(event) => {
+          const next = event.target.value;
+          onChange(next === 'all' ? 'all' : Number(next));
+        }}
+        aria-label={ariaLabel}
+      >
+        {PAGE_SIZE_OPTIONS.map((option) => (
+          <option key={String(option)} value={String(option)}>
+            {option === 'all' ? 'All' : option}
+          </option>
+        ))}
+      </select>
+      <div className="pointer-events-none absolute right-2.5 top-1/2 -translate-y-1/2 text-neutral-500">
+        <List className="h-3.5 w-3.5" />
+      </div>
     </div>
   );
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -2254,6 +2254,9 @@ export interface AlbumTagCount {
 /** How a multi-tag album filter combines its tags. */
 export type AlbumTagMatch = 'all' | 'any';
 
+/** Ordering for album item listings. The `name-*` values sort on the prompt. */
+export type AlbumItemSort = 'newest' | 'oldest' | 'name-asc' | 'name-desc';
+
 export interface AlbumPageResult extends PaginatedResult<AlbumItem> {
   totalSize: number;
   aspectRatioCounts: AspectRatioCount[];


### PR DESCRIPTION
## What

Pages the media grid inside `UniversalMediaPicker` on the server, using the same `PaginationBar` the project album uses.

## Why

The picker loaded a flat `limit: 500` per source and did all searching, sorting and filtering client-side in a `useMemo`. Two consequences:

- anything past the 500th item in a library or album was silently unreachable — no error, no indication, just a truncated grid
- every open pulled the whole slice down, thumbnails and all

## Changes

**Picker — [`src/components/UniversalMediaPicker.tsx`](https://github.com/ShinChven/remix-studio/blob/feat/media-picker-pagination/src/components/UniversalMediaPicker.tsx)**

- item loading sends `page` / `limit` / `q` / `sort` to the server; the grid renders exactly the page it was handed
- `<PaginationBar>` under the grid — page nav, page-size selector, `showing X–Y of Z`, self-hiding when one page covers the set
- page change scrolls the grid back to the top, matching the album's `scrollTabContentTop`
- anything that changes *which* items match (source, search, sort, aspect ratio, page size) resets to page 1
- item search debounced 250 ms, now that it costs a request
- default page size is 100 rather than the album's 500 — the picker grid is a modal full of thumbnails

The page-size select also appears in the item toolbar, not only in the bar. `PaginationBar` returns `null` on `All`, so without the toolbar copy, choosing `All` would be a one-way door with no control left to switch back. AlbumTab solves it the same way.

**Album endpoint — parity with library items**

The picker offers name A–Z/Z–A sorting and a search box for both source kinds, but `/api/projects/:id/album` supported only `newest|oldest` and had no `q`. Moving to server-side paging without those would have quietly reduced album search and name-sort to *the current page*. So:

- `AlbumItemSort` in `src/types.ts`, shared by client and server; `UniversalPickerSort` is now an alias so the two can't drift
- `getProjectAlbum` accepts `q` — case-insensitive match on `prompt` + `textContent`, combined through `where.AND` so it composes with the existing tag `OR` rather than clobbering it
- sort widened via a new `albumOrderBy` helper; `name-*` orders on `prompt`, the field the UI renders as an item's label, with newest-first as the tie-break
- the route validates `sort` against an allow-list instead of the old `=== 'oldest'` check

Widening the union is backward-compatible — `'newest' | 'oldest'` remains valid — so **AlbumTab is unaffected**.

## Reviewer notes

- **Not verified at runtime.** `npm run lint` (tsc) and `npm run build` both pass, but Postgres wasn't running locally, so the paging/search/sort behavior has not been exercised against a real database. Worth a manual pass on a library and an album with >100 items.
- Selections persist across pages (`selectedItemMap` is keyed by source + item id), but **Select All** applies to the current page only — same semantics as the album's.
- Album items missing an `imageUrl` are still dropped client-side after the fetch, so a page can render slightly fewer tiles than the `of Z` count implies. Pre-existing; paging just makes it visible. Left alone deliberately — happy to fix separately.
- The source column on the left is unchanged: still a flat 500. Paging it server-side would need type filtering and sort added to the `/api/libraries` and `/api/projects` list endpoints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)