### PR TITLE
fix(project-viewer): align select-all checkbox with list item checkboxes

### DIFF
--- a/src/components/LibraryEditor.tsx
+++ b/src/components/LibraryEditor.tsx
@@ -579,19 +579,19 @@ export function LibraryEditor({ library, onUpdate, onDelete }: Props) {
               : 'bg-white dark:bg-neutral-900 border-neutral-200 dark:border-neutral-800'}
           `}>
              <div className="flex items-center gap-2 flex-1 min-w-0">
-               <div className="flex items-center gap-2 px-1">
+               <div className="flex items-center gap-2">
                  <div
                    onClick={toggleSelectAll}
                    className="p-1 hover:bg-white/5 transition-colors cursor-pointer"
                  >
                    {selectedItemIds.size === items.length && items.length > 0 ? (
-                     <CheckSquare className="w-5 h-5 text-blue-500" />
+                     <CheckSquare className="w-4 h-4 text-blue-500" />
                    ) : selectedItemIds.size > 0 ? (
-                     <div className="w-5 h-5 flex items-center justify-center">
+                     <div className="w-4 h-4 flex items-center justify-center">
                        <div className="w-2.5 h-0.5 bg-blue-500" />
                      </div>
                    ) : (
-                     <Square className="w-5 h-5 text-neutral-600" />
+                     <Square className="w-4 h-4 text-neutral-600" />
                    )}
                  </div>
                  <span className={`text-xs font-medium hidden sm:inline ${selectedItemIds.size > 0 ? 'text-white' : 'text-neutral-500 dark:text-neutral-500'}`}>

--- a/src/components/ProjectViewer/SelectionToolbar.tsx
+++ b/src/components/ProjectViewer/SelectionToolbar.tsx
@@ -57,7 +57,7 @@ export function SelectionToolbar({
     // Everything here wraps. Buttons keep their intrinsic width (flex-shrink-0), so a
     // no-wrap row would let the two groups slide over each other once the pane got
     // narrow; wrapping makes an overflow impossible at any width.
-    <div className="sticky top-0 z-20 flex flex-wrap items-center justify-between bg-white dark:bg-neutral-950 border border-neutral-200/50 dark:border-white/5 gap-x-2 gap-y-2 @min-[56rem]/pane:gap-x-3 shadow-lg shadow-black/5 dark:shadow-black/20 p-2 @min-[56rem]/pane:p-3 rounded-none border-x-0 border-t-0">
+    <div className="sticky top-0 z-20 flex flex-wrap items-center justify-between bg-white dark:bg-neutral-950 border border-neutral-200/50 dark:border-white/5 gap-x-2 gap-y-2 @min-[56rem]/pane:gap-x-3 shadow-lg shadow-black/5 dark:shadow-black/20 px-3 py-2 @min-[56rem]/pane:p-3 rounded-none border-x-0 border-t-0">
       <div className="flex flex-wrap items-center min-w-0 gap-1.5 @min-[56rem]/pane:gap-x-3 @min-[56rem]/pane:gap-y-2">
         {prefix && (
           <div className="hidden @xl/pane:flex items-center gap-2 flex-shrink-0">

--- a/src/pages/Exports.tsx
+++ b/src/pages/Exports.tsx
@@ -483,7 +483,7 @@ export function Exports() {
                 <button
                   type="button"
                   onClick={toggleSelectAll}
-                  className="inline-flex items-center gap-2 rounded-lg px-2 py-1.5 text-[10px] font-black uppercase tracking-widest text-neutral-600 transition hover:bg-neutral-100 hover:text-neutral-900 dark:text-neutral-400 dark:hover:bg-white/5 dark:hover:text-white"
+                  className="inline-flex items-center gap-2 rounded-lg px-3 py-1.5 md:px-4 text-[10px] font-black uppercase tracking-widest text-neutral-600 transition hover:bg-neutral-100 hover:text-neutral-900 dark:text-neutral-400 dark:hover:bg-white/5 dark:hover:text-white"
                 >
                   {selectedTaskIds.size === exports.length ? (
                     <CheckSquare className="h-4 w-4 text-blue-500" />


### PR DESCRIPTION
The selection toolbar used 8px horizontal padding on narrow panes while
list rows (JobListItem, album grid) use 12px, so the select-all checkbox
sat 4px left of every item checkbox below it. Keep the toolbar's compact
vertical padding but pin horizontal padding to 12px at all widths.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01GqTdtyZaKhTkNPtbz9sRZp