### PR TITLE
Allow multiple references to the same library in workflows

### DIFF
--- a/docs-site/concepts/workflows.md
+++ b/docs-site/concepts/workflows.md
@@ -12,6 +12,8 @@ Workflow steps can be:
 
 Direct steps contribute one fixed choice. A library step contributes all of its non-empty, tag-matching items. Disabled steps are skipped entirely without being deleted.
 
+The same library can be referenced by more than one step. Each reference is an independent choice group with its own tag filter, so a library of 12 subjects added twice yields 12 × 12 combinations and, in shuffle mode, two independently drawn items per draft.
+
 Text choices are joined in workflow order with a blank line between them. Media choices are collected into the corresponding image, video, and audio context arrays. This means workflow order is significant for composed text even though a library's own items are sorted only for browsing.
 
 ## Filtering a Library Step

--- a/src/components/ProjectViewer.tsx
+++ b/src/components/ProjectViewer.tsx
@@ -1097,10 +1097,6 @@ export function ProjectViewer({ project, libraries, onUpdate: onUpdateProp, onDe
       setShowLibrarySelector(false);
       return;
     }
-    if ((localProject.workflow || []).some(item => item.type === 'library' && item.value === libraryId)) {
-      setShowLibrarySelector(false);
-      return;
-    }
     const newItem: WorkflowItemType = { id: crypto.randomUUID(), type: 'library', value: libraryId };
     const updated = { ...localProject, workflow: [...(localProject.workflow || []), newItem] };
     setLocalProject(updated);
@@ -1144,7 +1140,7 @@ export function ProjectViewer({ project, libraries, onUpdate: onUpdateProp, onDe
       return;
     }
 
-    if (targetItem.value === libraryId || workflow.some((item) => item.id !== workflowItemId && item.type === 'library' && item.value === libraryId)) {
+    if (targetItem.value === libraryId) {
       setChangingLibraryItemId(null);
       return;
     }

--- a/src/components/ProjectViewer/LibrarySelectionModal.tsx
+++ b/src/components/ProjectViewer/LibrarySelectionModal.tsx
@@ -9,6 +9,7 @@ interface LibrarySelectionModalProps {
   onClose: () => void;
   onSelect: (id: string) => void;
   libraries: Library[];
+  /** Library ids already placed in the workflow. The same id may appear more than once. */
   selectedLibraryIds: string[];
   isLoading?: boolean;
   error?: string | null;
@@ -39,6 +40,14 @@ export function LibrarySelectionModal({
     if (!q) return libraries;
     return libraries.filter((lib) => lib.name.toLowerCase().includes(q));
   }, [libraries, query]);
+
+  const usageCounts = useMemo(() => {
+    const counts = new Map<string, number>();
+    for (const id of selectedLibraryIds) {
+      counts.set(id, (counts.get(id) || 0) + 1);
+    }
+    return counts;
+  }, [selectedLibraryIds]);
 
   if (!isOpen) return null;
 
@@ -110,21 +119,16 @@ export function LibrarySelectionModal({
           ) : (
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 sm:gap-4">
               {filteredLibraries.map(lib => {
-                const isSelected = selectedLibraryIds.includes(lib.id);
+                const usageCount = usageCounts.get(lib.id) || 0;
                 return (
                   <button
                     key={lib.id}
-                    onClick={() => !isSelected && onSelect(lib.id)}
-                    disabled={isSelected}
-                    className={`group flex items-start gap-3 p-4 sm:gap-4 sm:p-5 border rounded-card text-left transition-all ${
-                      isSelected 
-                        ? 'bg-white/20 dark:bg-neutral-900/20 border-neutral-200 dark:border-neutral-800 opacity-50 cursor-not-allowed' 
-                        : 'bg-neutral-50/40 dark:bg-neutral-950/40 border-neutral-200 dark:border-neutral-800 hover:bg-neutral-200 dark:hover:bg-neutral-800 hover:border-emerald-500/30 hover:scale-[1.02] active:scale-100'
-                    }`}
+                    onClick={() => onSelect(lib.id)}
+                    className="group flex items-start gap-3 p-4 sm:gap-4 sm:p-5 border rounded-card text-left transition-all bg-neutral-50/40 dark:bg-neutral-950/40 border-neutral-200 dark:border-neutral-800 hover:bg-neutral-200 dark:hover:bg-neutral-800 hover:border-emerald-500/30 hover:scale-[1.02] active:scale-100"
                   >
                     <div className="flex-shrink-0">
                       {(lib.type === 'image' || lib.type === 'video') && lib.items[0] ? (
-                        <div className={`w-12 h-12 rounded-xl overflow-hidden border shadow-md ${isSelected ? 'border-neutral-200 dark:border-neutral-800 grayscale' : 'border-neutral-200 dark:border-neutral-800'}`}>
+                        <div className="w-12 h-12 rounded-xl overflow-hidden border shadow-md border-neutral-200 dark:border-neutral-800">
                           <img 
                             src={lib.type === 'image' 
                               ? (lib.items[0].thumbnailUrl || lib.items[0].content)
@@ -134,35 +138,31 @@ export function LibrarySelectionModal({
                           />
                         </div>
                       ) : (
-                        <div className={`p-3 bg-white dark:bg-neutral-900 rounded-xl border transition-all ${isSelected ? 'border-neutral-200 dark:border-neutral-800' : 'border-neutral-200 dark:border-neutral-800 group-hover:bg-neutral-100 dark:group-hover:bg-neutral-950 group-hover:border-emerald-500/20'}`}>
-                          <LibraryIcon className={`w-6 h-6 ${isSelected ? 'text-neutral-600' : 'text-emerald-500'}`} />
+                        <div className="p-3 bg-white dark:bg-neutral-900 rounded-xl border transition-all border-neutral-200 dark:border-neutral-800 group-hover:bg-neutral-100 dark:group-hover:bg-neutral-950 group-hover:border-emerald-500/20">
+                          <LibraryIcon className="w-6 h-6 text-emerald-500" />
                         </div>
                       )}
                     </div>
                     <div className="flex-1 pt-1 min-w-0">
                       <div className="flex items-center justify-between gap-2">
-                        <div className={`text-sm font-bold truncate transition-colors ${isSelected ? 'text-neutral-500 dark:text-neutral-500' : 'text-neutral-900 dark:text-neutral-100 dark:group-hover:text-white'}`}>
+                        <div className="text-sm font-bold truncate transition-colors text-neutral-900 dark:text-neutral-100 dark:group-hover:text-white">
                           {lib.name}
                         </div>
-                        {isSelected && (
-                          <span className="text-[8px] font-black uppercase tracking-widest text-emerald-500 bg-emerald-500/10 px-1.5 py-0.5 rounded border border-emerald-500/20">
-                            {t('projectViewer.librarySelection.added')}
+                        {usageCount > 0 && (
+                          <span className="shrink-0 text-[8px] font-black uppercase tracking-widest text-emerald-500 bg-emerald-500/10 px-1.5 py-0.5 rounded border border-emerald-500/20">
+                            {t('projectViewer.librarySelection.added')}{usageCount > 1 ? ` ×${usageCount}` : ''}
                           </span>
                         )}
                       </div>
                       <div className="flex items-center gap-3 mt-1">
-                        <span className={`text-[10px] font-black uppercase tracking-widest px-2 py-0.5 rounded border ${
-                          isSelected 
-                            ? 'bg-white/50 dark:bg-neutral-900/50 border-neutral-200 dark:border-neutral-800 text-neutral-600' 
-                            : 'bg-neutral-50 dark:bg-neutral-950 border-neutral-200 dark:border-neutral-800 text-neutral-500 dark:text-neutral-500 group-hover:border-neutral-300 dark:group-hover:border-neutral-700'
-                        }`}>
+                        <span className="text-[10px] font-black uppercase tracking-widest px-2 py-0.5 rounded border bg-neutral-50 dark:bg-neutral-950 border-neutral-200 dark:border-neutral-800 text-neutral-500 dark:text-neutral-500 group-hover:border-neutral-300 dark:group-hover:border-neutral-700">
                           {lib.type === 'text' ? t('projectViewer.common.text') :
                            lib.type === 'image' ? t('projectViewer.common.imageShort') :
                            lib.type === 'video' ? t('projectViewer.common.video') :
                            lib.type === 'audio' ? t('projectViewer.common.audio') :
                            lib.type}
                         </span>
-                        <span className={`text-[10px] font-bold uppercase tracking-widest ${isSelected ? 'text-neutral-700' : 'text-neutral-600'}`}>
+                        <span className="text-[10px] font-bold uppercase tracking-widest text-neutral-600">
                           {t('projectViewer.workflow.itemsCount', { count: lib.items.length })}
                         </span>
                       </div>


### PR DESCRIPTION
## Summary
This change enables users to add the same library multiple times to a workflow, with each reference acting as an independent choice group. Previously, the system prevented duplicate library references.

## Key Changes

- **LibrarySelectionModal.tsx**: 
  - Removed the "disabled" state that prevented selecting already-added libraries
  - Added `usageCounts` memoized map to track how many times each library is referenced in the workflow
  - Updated UI to show usage count (e.g., "Added ×2") instead of a simple "Added" badge
  - Simplified button styling by removing conditional classes for selected/disabled states
  - Libraries can now be clicked multiple times to add multiple references

- **ProjectViewer.tsx**:
  - Removed the check that prevented adding a library if it already existed in the workflow
  - Simplified the library replacement logic to only check if the target item's value matches, not if the library exists elsewhere in the workflow

- **Documentation** (workflows.md):
  - Added clarification that the same library can be referenced multiple times
  - Explained that each reference is an independent choice group with its own tag filter
  - Noted the combinatorial effect: a library of 12 items added twice yields 12 × 12 combinations

## Implementation Details

The usage count feature uses a `useMemo` hook to efficiently calculate how many times each library ID appears in `selectedLibraryIds`, allowing the UI to display the multiplicity without performance concerns. The visual feedback now shows the count next to the "Added" label when a library has been added more than once.

https://claude.ai/code/session_01Urftz8DyoFyci6JvQtAg5F