### PR TITLE
fix(storage): paginate S3 object listings

### DIFF
--- a/server/storage/s3-storage.ts
+++ b/server/storage/s3-storage.ts
@@ -4,9 +4,10 @@ import {
   GetObjectCommand,
   HeadObjectCommand,
   DeleteObjectCommand,
-  ListObjectsV2Command,
   CopyObjectCommand,
+  paginateListObjectsV2,
 } from '@aws-sdk/client-s3';
+import type { _Object } from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import { Upload } from '@aws-sdk/lib-storage';
 import type { Readable } from 'node:stream';
@@ -163,27 +164,37 @@ export class S3Storage implements IStorage {
     );
   }
 
-  async listObjects(prefix: string): Promise<string[]> {
-    const result = await this.client.send(
-      new ListObjectsV2Command({
-        Bucket: this.bucket,
-        Prefix: prefix,
-      })
+  /**
+   * Yield every object under a prefix, following continuation tokens.
+   * A single S3/MinIO list response is capped at 1000 keys, so callers that
+   * need the whole prefix must page through it.
+   */
+  private async *iterateObjects(prefix: string): AsyncGenerator<_Object> {
+    const pages = paginateListObjectsV2(
+      { client: this.client },
+      { Bucket: this.bucket, Prefix: prefix }
     );
-    return (result.Contents || []).map((obj) => obj.Key!).filter(Boolean);
+    for await (const page of pages) {
+      for (const obj of page.Contents || []) {
+        yield obj;
+      }
+    }
   }
-  
+
+  async listObjects(prefix: string): Promise<string[]> {
+    const keys: string[] = [];
+    for await (const obj of this.iterateObjects(prefix)) {
+      if (obj.Key) keys.push(obj.Key);
+    }
+    return keys;
+  }
+
   async listObjectsWithMetadata(prefix: string): Promise<{ key: string; size: number | undefined }[]> {
-    const result = await this.client.send(
-      new ListObjectsV2Command({
-        Bucket: this.bucket,
-        Prefix: prefix,
-      })
-    );
-    return (result.Contents || []).map((obj) => ({
-      key: obj.Key!,
-      size: obj.Size
-    })).filter((obj) => Boolean(obj.key));
+    const objects: { key: string; size: number | undefined }[] = [];
+    for await (const obj of this.iterateObjects(prefix)) {
+      if (obj.Key) objects.push({ key: obj.Key, size: obj.Size });
+    }
+    return objects;
   }
 
   async getPresignedUrl(
@@ -211,24 +222,21 @@ export class S3Storage implements IStorage {
   }
 
   async rename(oldPrefix: string, newPrefix: string): Promise<void> {
-    const listed = await this.client.send(
-      new ListObjectsV2Command({
-        Bucket: this.bucket,
-        Prefix: oldPrefix,
-      })
-    );
+    // Collect the full listing before mutating, so copies and deletes never
+    // interleave with the pagination that produced the keys.
+    const keys = await this.listObjects(oldPrefix);
 
-    for (const obj of listed.Contents || []) {
-      const newKey = obj.Key!.replace(oldPrefix, newPrefix);
+    for (const key of keys) {
+      const newKey = newPrefix + key.slice(oldPrefix.length);
       await this.client.send(
         new CopyObjectCommand({
           Bucket: this.bucket,
-          CopySource: `${this.bucket}/${obj.Key}`,
+          CopySource: `${this.bucket}/${key}`,
           Key: newKey,
         })
       );
       await this.client.send(
-        new DeleteObjectCommand({ Bucket: this.bucket, Key: obj.Key! })
+        new DeleteObjectCommand({ Bucket: this.bucket, Key: key })
       );
     }
   }


### PR DESCRIPTION
## 问题

`S3Storage.listObjects`、`listObjectsWithMetadata` 和 `rename` 各自只发一次 `ListObjectsV2Command`，直接用 `result.Contents`，从不读 `IsTruncated` / `NextContinuationToken`。S3 和 MinIO 单次响应上限 1000 个 key，所以三者都静默地只拿到第一页。

后果（全部无声）：

| 调用方 | 影响 |
|---|---|
| `GET /api/projects/:id/orphans` | 超过 1000 个对象的项目，第一页之后的孤儿文件永远看不到，清理页少报，存储收不回来 |
| `POST /api/projects/rename` | 数据库行改写到新前缀，但 1000 之后的文件还留在旧前缀，那些文件就坏了 |
| `DELETE /api/projects/:id` | 删项目时泄漏 1000 之后的对象 |
| campaign 删除清理 | 同上 |
| `storage-router` 用量统计 | 总量偏小 |

这是 `main` 上的既有问题，与 album move 无关。

## 改动

只改 `server/storage/s3-storage.ts`。新增私有生成器 `iterateObjects(prefix)`，基于 SDK 自带的 `paginateListObjectsV2`，翻页逻辑交给 SDK；三个方法都走它。

两处超出"加翻页"本身的判断：

- **`rename` 先收集完整列表再 copy/delete**，不边翻页边删。边翻边删其实能跑（continuation token 按 key 位置走，删已返回的 key 不移动游标），但正确性会依赖分页协议的细节。而且 `rename` 是公开方法：若 `newPrefix` 嵌套在 `oldPrefix` 之下，边翻边写会把自己产出的新对象再列进去而无限循环。当前调用方不会（两个前缀都是 `userId/safeId/`，`safeId` 无斜杠），但先收集就没这个问题。代价只是一个字符串数组，而删除路径本来就在做全量 list。
- **`key.replace(oldPrefix, newPrefix)` 换成 `newPrefix + key.slice(oldPrefix.length)`**。`String.replace` 传字符串时匹配第一次出现处，未必是开头。因为 key 都来自 `Prefix: oldPrefix` 的列举，今天两者等价，slice 只是把这个前提写进结构。

顺带把 `obj.Key!` + 事后 `.filter(Boolean)` 改成入列前 `if (obj.Key)`，行为不变，去掉非空断言。

## 验证

- `npm run lint`（`tsc --noEmit`）在 rebase 后的 `origin/main` 基线上通过。
- 改动前确认 `S3Storage` 是 `IStorage` 的唯一实现，且四个调用方要的都是完整列表，没有依赖"只返回一页"的。
- **未跑真实 bucket**：MinIO 在本地 worktree 连不上。验证仅限类型检查加调用方审查。

## 未做

`rename` 仍是串行 copy+delete，每个对象两次往返。以前被 1000 卡着不明显，现在会走完整个前缀，一万个对象的改名就是两万次串行请求，全在一个 HTTP handler 里。要修是批量删除（`DeleteObjectsCommand`，一次 1000）加限流并发 copy，属于对本次未涉及接口的性能改动，留作单独处理。

🤖 Generated with [Claude Code](https://claude.com/claude-code)