### PR TITLE
Fix z-index layering of selection toolbar and card overlays

### DIFF
--- a/src/components/ProjectViewer/AlbumTab.tsx
+++ b/src/components/ProjectViewer/AlbumTab.tsx
@@ -980,7 +980,13 @@ export function AlbumTab({
           // in portrait stay one card per row: there the pane spans the whole
           // viewport, which is wide enough to trip the 26rem step but far too narrow
           // to read two cards side by side.
-          <div className="grid grid-cols-1 sm:@min-[26rem]/pane:grid-cols-2 sm:@min-[44rem]/pane:grid-cols-3 sm:@min-[60rem]/pane:grid-cols-4 sm:@min-[76rem]/pane:grid-cols-5 sm:@min-[92rem]/pane:grid-cols-6 gap-3 @xl/pane:gap-4 p-3 @xl/pane:p-4">
+          //
+          // `isolate` keeps the cards in their own stacking context: the overlay
+          // buttons on a card sit at z-20, and without it they escape and paint over
+          // the sticky selection toolbar as a row scrolls under it. Cards only form a
+          // stacking context of their own where `backdrop-filter` takes effect, so the
+          // grid has to guarantee it instead.
+          <div className="isolate grid grid-cols-1 sm:@min-[26rem]/pane:grid-cols-2 sm:@min-[44rem]/pane:grid-cols-3 sm:@min-[60rem]/pane:grid-cols-4 sm:@min-[76rem]/pane:grid-cols-5 sm:@min-[92rem]/pane:grid-cols-6 gap-3 @xl/pane:gap-4 p-3 @xl/pane:p-4">
             {displayItems.map((item, index) => {
               const isSelected = selectedAlbumIds.has(item.id);
               const aspectRatioStr = getCssAspectRatio(item.aspectRatio);

--- a/src/components/ProjectViewer/SelectionToolbar.tsx
+++ b/src/components/ProjectViewer/SelectionToolbar.tsx
@@ -57,7 +57,11 @@ export function SelectionToolbar({
     // Everything here wraps. Buttons keep their intrinsic width (flex-shrink-0), so a
     // no-wrap row would let the two groups slide over each other once the pane got
     // narrow; wrapping makes an overflow impossible at any width.
-    <div className="sticky top-0 z-20 flex flex-wrap items-center justify-between bg-white dark:bg-neutral-950 border border-neutral-200/50 dark:border-white/5 gap-x-2 gap-y-2 @min-[56rem]/pane:gap-x-3 shadow-lg shadow-black/5 dark:shadow-black/20 px-3 py-2 @min-[56rem]/pane:p-3 rounded-none border-x-0 border-t-0">
+    //
+    // z-30 keeps the bar above the list below it. The card overlays in AlbumTab sit at
+    // z-20, and at an equal z-index the cards win on document order — their checkboxes
+    // and delete buttons were painting on top of this bar as a row scrolled under it.
+    <div className="sticky top-0 z-30 flex flex-wrap items-center justify-between bg-white dark:bg-neutral-950 border border-neutral-200/50 dark:border-white/5 gap-x-2 gap-y-2 @min-[56rem]/pane:gap-x-3 shadow-lg shadow-black/5 dark:shadow-black/20 px-3 py-2 @min-[56rem]/pane:p-3 rounded-none border-x-0 border-t-0">
       <div className="flex flex-wrap items-center min-w-0 gap-1.5 @min-[56rem]/pane:gap-x-3 @min-[56rem]/pane:gap-y-2">
         {prefix && (
           <div className="hidden @xl/pane:flex items-center gap-2 flex-shrink-0">


### PR DESCRIPTION
## Summary
Fixed a z-index stacking issue where card overlay buttons (checkboxes and delete buttons) were incorrectly painting on top of the sticky selection toolbar when rows scrolled underneath it.

## Changes
- **AlbumTab.tsx**: Added `isolate` class to the grid container to establish a new stacking context for the card grid, preventing card overlays from escaping their intended layer
- **SelectionToolbar.tsx**: Increased z-index from `z-20` to `z-30` to ensure the sticky toolbar remains above card overlays during scrolling

## Implementation Details
The fix addresses a CSS stacking context issue:
- Card overlay buttons are positioned at `z-20` and only form their own stacking context where `backdrop-filter` takes effect
- The `isolate` utility on the grid ensures cards stay within their own stacking context
- Raising the toolbar to `z-30` guarantees it paints above the `z-20` card overlays, regardless of document order
- This prevents the visual bug where card controls would appear on top of the selection toolbar as users scroll

https://claude.ai/code/session_01EsQtwYy4FiBV1Jt7hD9WFq