### PR TITLE
Simplify album toolbar and add name/prompt search

### DIFF
--- a/server/db/prisma-repository.ts
+++ b/server/db/prisma-repository.ts
@@ -127,6 +127,7 @@ export class PrismaRepository implements IRepository {
       aspectRatios?: string[];
       tags?: string[];
       tagMatch?: 'all' | 'any';
+      q?: string;
     },
   ) {
     return this.projects.updateAlbumItemsTags(userId, projectId, options);

--- a/server/db/project-repository.ts
+++ b/server/db/project-repository.ts
@@ -438,14 +438,15 @@ export class ProjectRepository {
       }
     }
 
-    // Album items have no title column, so free-text search looks at the two
-    // fields the UI renders as an item's label: its prompt and its text output.
+    // Media names are stored in the imageUrl storage key; text albums also
+    // expose their generated content as a searchable label.
     const search = options.q?.trim();
     if (search) {
       where.AND = [
         ...(Array.isArray(where.AND) ? where.AND : []),
         {
           OR: [
+            { imageUrl: { contains: search, mode: 'insensitive' } },
             { prompt: { contains: search, mode: 'insensitive' } },
             { textContent: { contains: search, mode: 'insensitive' } },
           ],
@@ -733,6 +734,7 @@ export class ProjectRepository {
       aspectRatios?: string[];
       tags?: string[];
       tagMatch?: 'all' | 'any';
+      q?: string;
     },
   ): Promise<{ updated: number }> {
     await this.assertOwnedProject(userId, projectId);
@@ -751,6 +753,7 @@ export class ProjectRepository {
         aspectRatios: options.aspectRatios,
         tags: options.tags,
         tagMatch: options.tagMatch,
+        q: options.q,
       });
       targets = scoped.items.map((item) => ({ id: item.id, tags: item.tags ?? [] }));
     } else {

--- a/server/db/repository.ts
+++ b/server/db/repository.ts
@@ -97,6 +97,7 @@ export interface IRepository {
       aspectRatios?: string[];
       tags?: string[];
       tagMatch?: 'all' | 'any';
+      q?: string;
     },
   ): Promise<{ updated: number }>;
 

--- a/server/routes/projects.ts
+++ b/server/routes/projects.ts
@@ -1073,6 +1073,7 @@ export function createProjectRouter(repository: IRepository, userRepository: Use
         aspectRatios,
         tags: filterTags,
         tagMatch,
+        q: typeof body?.q === 'string' ? body.q : undefined,
       });
 
       projectEvents?.notifyProjectChanged({

--- a/src/api.ts
+++ b/src/api.ts
@@ -1072,6 +1072,7 @@ export async function batchUpdateAlbumTags(
     aspectRatios?: string[];
     filterTags?: string[];
     tagMatch?: import('./types').AlbumTagMatch;
+    q?: string;
   },
 ): Promise<{ updated: number; tagCounts: import('./types').AlbumTagCount[] }> {
   const res = await apiFetch(`/api/projects/${projectId}/album/tags-batch`, {

--- a/src/components/ProjectViewer.tsx
+++ b/src/components/ProjectViewer.tsx
@@ -153,6 +153,7 @@ export function ProjectViewer({ project, libraries, onUpdate: onUpdateProp, onDe
   const albumPageSize: number | 'all' = albumSizeParam === 'all'
     ? 'all'
     : (Number(albumSizeParam) > 0 ? Math.floor(Number(albumSizeParam)) : 500);
+  const albumSearch = searchParams.get('albumSearch') || '';
   const albumSort: 'newest' | 'oldest' = searchParams.get('albumSort') === 'oldest' ? 'oldest' : 'newest';
   const albumRatiosParam = searchParams.get('albumRatios') || '';
   const albumSelectedRatios = React.useMemo(
@@ -174,6 +175,7 @@ export function ProjectViewer({ project, libraries, onUpdate: onUpdateProp, onDe
       ratios?: string[];
       tags?: string[];
       tagMatch?: AlbumTagMatch;
+      search?: string;
     }) => {
       setSearchParams((prev) => {
         const next = new URLSearchParams(prev);
@@ -184,6 +186,7 @@ export function ProjectViewer({ project, libraries, onUpdate: onUpdateProp, onDe
           || updates.ratios !== undefined
           || updates.tags !== undefined
           || updates.tagMatch !== undefined
+          || updates.search !== undefined
         ) {
           next.delete('albumPage');
         }
@@ -210,6 +213,10 @@ export function ProjectViewer({ project, libraries, onUpdate: onUpdateProp, onDe
         if (updates.tagMatch !== undefined) {
           if (updates.tagMatch === 'any') next.set('albumTagMatch', 'any');
           else next.delete('albumTagMatch');
+        }
+        if (updates.search !== undefined) {
+          if (updates.search) next.set('albumSearch', updates.search);
+          else next.delete('albumSearch');
         }
         return next;
       });
@@ -346,6 +353,7 @@ export function ProjectViewer({ project, libraries, onUpdate: onUpdateProp, onDe
         next.delete('albumPage');
         next.delete('albumSize');
         next.delete('albumSort');
+        next.delete('albumSearch');
         next.delete('albumRatios');
         next.delete('albumTags');
         next.delete('albumTagMatch');
@@ -392,7 +400,8 @@ export function ProjectViewer({ project, libraries, onUpdate: onUpdateProp, onDe
     aspectRatios: albumSelectedRatios,
     tags: albumSelectedTags,
     tagMatch: albumTagMatch,
-  }), [project.id, albumPage, albumPageSize, albumSort, albumSelectedRatios, albumSelectedTags, albumTagMatch]);
+    q: albumSearch,
+  }), [project.id, albumPage, albumPageSize, albumSort, albumSelectedRatios, albumSelectedTags, albumTagMatch, albumSearch]);
   const loadAlbumPage = useCallback(async (signalToken: number, showLoading = true) => {
     if (showLoading) setIsLoadingAlbum(true);
     try {
@@ -403,6 +412,7 @@ export function ProjectViewer({ project, libraries, onUpdate: onUpdateProp, onDe
         aspectRatios: albumSelectedRatios.length > 0 ? albumSelectedRatios : undefined,
         tags: albumSelectedTags.length > 0 ? albumSelectedTags : undefined,
         tagMatch: albumTagMatch,
+        q: albumSearch,
       });
       if (albumFetchTokenRef.current !== signalToken || isDeletingAlbumItemsRef.current) return;
       setLocalAlbum(res.items);
@@ -411,7 +421,7 @@ export function ProjectViewer({ project, libraries, onUpdate: onUpdateProp, onDe
       setAlbumTotalSize(res.totalSize);
       setAlbumAspectRatioCounts(res.aspectRatioCounts);
       setAlbumTagCounts(res.tagCounts || []);
-      if (albumPage === 1 && albumSort === 'newest' && albumSelectedRatios.length === 0 && albumSelectedTags.length === 0) {
+      if (albumPage === 1 && albumSort === 'newest' && albumSelectedRatios.length === 0 && albumSelectedTags.length === 0 && !albumSearch.trim()) {
         setAlbumPreviewItems(res.items.slice(0, 5));
       }
       albumLoadedKeyRef.current = albumQueryKey;
@@ -421,7 +431,7 @@ export function ProjectViewer({ project, libraries, onUpdate: onUpdateProp, onDe
     } finally {
       if (albumFetchTokenRef.current === signalToken) setIsLoadingAlbum(false);
     }
-  }, [project.id, albumPage, albumPageSize, albumSort, albumSelectedRatios, albumSelectedTags, albumTagMatch, albumQueryKey]);
+  }, [project.id, albumPage, albumPageSize, albumSort, albumSelectedRatios, albumSelectedTags, albumTagMatch, albumSearch, albumQueryKey]);
 
   useEffect(() => {
     if (activeTab !== 'album') return;
@@ -490,6 +500,9 @@ export function ProjectViewer({ project, libraries, onUpdate: onUpdateProp, onDe
   }, [updateAlbumParams]);
   const handleAlbumSelectedTagsChange = useCallback((tags: string[]) => {
     updateAlbumParams({ tags });
+  }, [updateAlbumParams]);
+  const handleAlbumSearchChange = useCallback((search: string) => {
+    updateAlbumParams({ search });
   }, [updateAlbumParams]);
   const handleAlbumTagMatchChange = useCallback((tagMatch: AlbumTagMatch) => {
     updateAlbumParams({ tagMatch });
@@ -587,6 +600,9 @@ export function ProjectViewer({ project, libraries, onUpdate: onUpdateProp, onDe
     albumPageSize,
     albumSort,
     albumSelectedRatios,
+    albumSelectedTags,
+    albumTagMatch,
+    albumSearch,
     albumQueryKey,
     completedPage,
     completedPageSize,
@@ -614,6 +630,9 @@ export function ProjectViewer({ project, libraries, onUpdate: onUpdateProp, onDe
       albumPageSize,
       albumSort,
       albumSelectedRatios,
+      albumSelectedTags,
+      albumTagMatch,
+      albumSearch,
       albumQueryKey,
       completedPage,
       completedPageSize,
@@ -625,6 +644,9 @@ export function ProjectViewer({ project, libraries, onUpdate: onUpdateProp, onDe
     albumPageSize,
     albumSort,
     albumSelectedRatios,
+    albumSelectedTags,
+    albumTagMatch,
+    albumSearch,
     albumQueryKey,
     completedPage,
     completedPageSize,
@@ -748,6 +770,9 @@ export function ProjectViewer({ project, libraries, onUpdate: onUpdateProp, onDe
               limit: query.albumPageSize === 'all' ? 999999 : query.albumPageSize,
               sort: query.albumSort,
               aspectRatios: query.albumSelectedRatios.length > 0 ? query.albumSelectedRatios : undefined,
+              tags: query.albumSelectedTags,
+              tagMatch: query.albumTagMatch,
+              q: query.albumSearch,
             }).catch(() => null)
           : fetchProjectAlbum(localProject.id, {
               page: 1,
@@ -783,11 +808,12 @@ export function ProjectViewer({ project, libraries, onUpdate: onUpdateProp, onDe
         setAlbumTotal(updatedAlbumRes.total);
         setAlbumTotalSize(updatedAlbumRes.totalSize);
         setAlbumAspectRatioCounts(updatedAlbumRes.aspectRatioCounts);
+        setAlbumTagCounts(updatedAlbumRes.tagCounts || []);
         if (tab === 'album') {
           if (JSON.stringify(updatedAlbumRes.items) !== JSON.stringify(localAlbumRef.current)) {
             setLocalAlbum(updatedAlbumRes.items);
           }
-          if (query.albumPage === 1 && query.albumSort === 'newest' && query.albumSelectedRatios.length === 0) {
+          if (query.albumPage === 1 && query.albumSort === 'newest' && query.albumSelectedRatios.length === 0 && query.albumSelectedTags.length === 0 && !query.albumSearch.trim()) {
             setAlbumPreviewItems(updatedAlbumRes.items.slice(0, 5));
           }
           setAlbumPages(updatedAlbumRes.pages);
@@ -2440,11 +2466,11 @@ export function ProjectViewer({ project, libraries, onUpdate: onUpdateProp, onDe
             />
           )}
           {activeTab === 'album' && isLoadingAlbum && (
-            <div className="absolute inset-0 flex items-center justify-center bg-white/50 dark:bg-black/50 z-20">
+            <div className="absolute inset-0 flex items-center justify-center bg-white/50 dark:bg-black/50 z-20 pointer-events-none">
               <Loader2 className="w-8 h-8 text-neutral-500 animate-spin" />
             </div>
           )}
-          {activeTab === 'album' && !isLoadingAlbum && (
+          {activeTab === 'album' && (
             <AlbumTab
               projectId={localProject.id}
               projectName={localProject.name}
@@ -2468,6 +2494,9 @@ export function ProjectViewer({ project, libraries, onUpdate: onUpdateProp, onDe
               tagCounts={albumTagCounts}
               selectedTags={albumSelectedTags}
               tagMatch={albumTagMatch}
+              search={albumSearch}
+              isLoading={isLoadingAlbum}
+              onSearchChange={handleAlbumSearchChange}
               onPageChange={handleAlbumPageChange}
               onPageSizeChange={handleAlbumPageSizeChange}
               onSortChange={handleAlbumSortChange}

--- a/src/components/ProjectViewer/AlbumTab.tsx
+++ b/src/components/ProjectViewer/AlbumTab.tsx
@@ -10,6 +10,7 @@ import { ExportPackageDialog } from './ExportPackageDialog';
 import { TextAlbumCompareDialog } from './TextAlbumCompareDialog';
 import { TextAlbumDetailDialog } from './TextAlbumDetailDialog';
 import { CopyToLibraryDialog } from './CopyToLibraryDialog';
+import { AlbumActionsMenu, AlbumSearch, type AlbumAction } from './AlbumToolbarControls';
 import { SelectionToolbar } from './SelectionToolbar';
 import { AlbumBatchTagModal, AlbumBatchTagMode } from './AlbumBatchTagModal';
 import { TagModal } from '../TagModal';
@@ -49,6 +50,9 @@ interface AlbumTabProps {
   tagCounts: AlbumTagCount[];
   selectedTags: string[];
   tagMatch: AlbumTagMatch;
+  search: string;
+  isLoading: boolean;
+  onSearchChange: (search: string) => void;
   onPageChange: (page: number) => void;
   onPageSizeChange: (size: number | 'all') => void;
   onSortChange: (sort: 'newest' | 'oldest') => void;
@@ -65,6 +69,7 @@ interface AlbumTabProps {
     aspectRatios?: string[];
     filterTags?: string[];
     tagMatch?: AlbumTagMatch;
+    q?: string;
   }) => Promise<{ updated: number }>;
 }
 
@@ -193,8 +198,10 @@ const TagFilterControl = memo(function TagFilterControl({
   useEffect(() => {
     if (!isOpen) return;
     const handleClick = () => setIsOpen(false);
+    const handleKey = (event: KeyboardEvent) => { if (event.key === 'Escape') setIsOpen(false); };
+    window.addEventListener('keydown', handleKey);
     window.addEventListener('click', handleClick);
-    return () => window.removeEventListener('click', handleClick);
+    return () => { window.removeEventListener('click', handleClick); window.removeEventListener('keydown', handleKey); };
   }, [isOpen]);
 
   return (
@@ -204,6 +211,7 @@ const TagFilterControl = memo(function TagFilterControl({
         onClick={() => setIsOpen((open) => !open)}
         title={t('projectViewer.album.tagFilter')}
         aria-label={t('projectViewer.album.tagFilter')}
+        aria-expanded={isOpen}
         className={`flex items-center justify-center gap-1.5 min-h-8 min-w-8 px-2 @min-[56rem]/pane:px-3 py-1.5 text-[9px] font-black uppercase tracking-widest rounded-lg border transition-all ${
           hasFilter
             ? 'bg-blue-500/10 hover:bg-blue-500/20 text-blue-500 border-blue-500/30'
@@ -211,7 +219,7 @@ const TagFilterControl = memo(function TagFilterControl({
         }`}
       >
         <TagIcon className="w-3 h-3" />
-        <span className="hidden @min-[56rem]/pane:inline">
+        <span className="whitespace-nowrap">
           {selectedTags.length === 0
             ? t('projectViewer.album.tagFilter')
             : t('projectViewer.album.tagFilterCount', { count: selectedTags.length })}
@@ -344,6 +352,9 @@ export function AlbumTab({
   tagCounts,
   selectedTags,
   tagMatch,
+  search,
+  isLoading,
+  onSearchChange,
   onPageChange,
   onPageSizeChange,
   onSortChange,
@@ -460,6 +471,7 @@ export function AlbumTab({
           aspectRatios: hasAspectRatioFilter ? selectedAspectRatios : undefined,
           filterTags: hasTagFilter ? selectedTags : undefined,
           tagMatch,
+          q: search,
         };
       const { updated } = await onBatchUpdateAlbumTags({
         ...scope,
@@ -507,6 +519,7 @@ export function AlbumTab({
   }, [onSelectedAspectRatiosChange]);
 
   const hasTagFilter = selectedTags.length > 0;
+  const hasSearchFilter = search.trim().length > 0;
   const toggleTagFilter = useCallback((tag: string) => {
     const next = selectedTags.includes(tag)
       ? selectedTags.filter((item) => item !== tag)
@@ -527,7 +540,7 @@ export function AlbumTab({
   );
   const hasVisibleSelection = selectedDisplayItemIds.length > 0;
   const bulkItemIds = hasVisibleSelection ? selectedDisplayItemIds : displayItemIds;
-  const useAllAlbumScope = !hasVisibleSelection && !hasAspectRatioFilter && !hasTagFilter;
+  const useAllAlbumScope = !hasVisibleSelection && !hasAspectRatioFilter && !hasTagFilter && !hasSearchFilter;
 
   const toggleAudioExpand = (id: string) => {
     setExpandedAudioIds((prev) => {
@@ -622,11 +635,46 @@ export function AlbumTab({
     });
   };
 
+  const albumActions: AlbumAction[] = [
+    {
+      label: hasVisibleSelection ? t('projectViewer.album.exportSelected') : useAllAlbumScope ? t('projectViewer.album.exportAll') : t('projectViewer.album.exportPage'),
+      icon: <FileArchive className="w-4 h-4 shrink-0" />,
+      onClick: () => openExportDialog(!hasVisibleSelection),
+    },
+    {
+      label: hasVisibleSelection ? t('projectViewer.album.tagSelected') : useAllAlbumScope ? t('projectViewer.album.tagAll') : t('projectViewer.album.tagResults'),
+      icon: <TagIcon className="w-4 h-4 shrink-0" />,
+      onClick: () => setShowBatchTagModal(true),
+    },
+    {
+      label: hasVisibleSelection ? t('projectViewer.common.copyToLibrary') : useAllAlbumScope ? t('projectViewer.album.copyAllToLibrary') : t('projectViewer.album.copyPageToLibrary'),
+      icon: <Copy className="w-4 h-4 shrink-0" />,
+      onClick: () => setShowCopyDialog(true),
+    },
+    ...(isTextProject && selectedDisplayItemIds.length > 1 ? [{
+      label: t('projectViewer.album.compareSelected'),
+      icon: <Layers className="w-4 h-4 shrink-0" />,
+      onClick: () => setShowCompareDialog(true),
+    }] : []),
+    ...(hasVisibleSelection ? [{
+      label: t('projectViewer.moveToProject.moveSelected'),
+      icon: <FolderInput className="w-4 h-4 shrink-0" />,
+      onClick: openMoveToProject,
+    }, {
+      label: t('projectViewer.common.deleteSelected'),
+      icon: <Trash2 className="w-4 h-4 shrink-0" />,
+      destructive: true,
+      onClick: () => {
+        setAlbumItemsToDelete(displayItems.filter(item => selectedAlbumIds.has(item.id)));
+        setShowDeleteAlbumModal(true);
+      },
+    }] : []),
+  ];
+
   return (
     <section className="animate-in fade-in slide-in-from-bottom-4 duration-500">
       <div className="flex flex-col gap-0">
-        {total > 0 && (
-          <SelectionToolbar
+        <SelectionToolbar
             totalCount={displayItems.length}
             selectedCount={selectedDisplayItemIds.length}
             onToggleSelectAll={() => toggleSelectAllAlbum(displayItemIds)}
@@ -638,83 +686,11 @@ export function AlbumTab({
                 </span>
               </div>
             )}
+            selectionActions={<AlbumActionsMenu actions={albumActions} disabled={isLoading} />}
+            zeroSelectionActions={<AlbumActionsMenu actions={albumActions} disabled={isLoading || total === 0} />}
             rightActions={
-              // The visible label on each action is the short form; `title` and
-              // `aria-label` keep the full name, which is what a hover tooltip
-              // and a screen reader read out. Nine controls share this row once
-              // items are selected, and the long forms pushed it onto a second
-              // sticky line on every pane narrower than ~1200px.
               <>
-                <button
-                  onClick={() => openExportDialog(!hasVisibleSelection)}
-                  title={hasVisibleSelection ? t('projectViewer.album.exportSelected') : t('projectViewer.album.exportAll')}
-                  aria-label={hasVisibleSelection ? t('projectViewer.album.exportSelected') : t('projectViewer.album.exportAll')}
-                  className="flex items-center justify-center gap-1.5 min-h-8 min-w-8 px-2 @min-[56rem]/pane:px-3 py-1.5 bg-blue-500/10 hover:bg-blue-500/20 text-blue-500 text-[9px] font-black uppercase tracking-widest rounded-lg border border-blue-500/20 transition-all disabled:opacity-50"
-                >
-                  <FileArchive className="w-3 h-3" />
-                  <span className="hidden @min-[56rem]/pane:inline">
-                    {hasVisibleSelection ? t('projectViewer.album.exportShort') : t('projectViewer.album.exportAll')}
-                  </span>
-                </button>
-                <button
-                  onClick={() => setShowBatchTagModal(true)}
-                  title={hasVisibleSelection ? t('projectViewer.album.tagSelected') : t('projectViewer.album.tagAll')}
-                  aria-label={hasVisibleSelection ? t('projectViewer.album.tagSelected') : t('projectViewer.album.tagAll')}
-                  className="flex items-center justify-center gap-1.5 min-h-8 min-w-8 px-2 @min-[56rem]/pane:px-3 py-1.5 bg-blue-500/10 hover:bg-blue-500/20 text-blue-500 text-[9px] font-black uppercase tracking-widest rounded-lg border border-blue-500/20 transition-all"
-                >
-                  <TagIcon className="w-3 h-3" />
-                  <span className="hidden @min-[56rem]/pane:inline">
-                    {hasVisibleSelection ? t('projectViewer.album.tagShort') : t('projectViewer.album.tagAll')}
-                  </span>
-                </button>
-                <button
-                  onClick={() => setShowCopyDialog(true)}
-                  title={hasVisibleSelection ? t('projectViewer.common.copyToLibrary') : t('projectViewer.album.copyAllToLibrary')}
-                  aria-label={hasVisibleSelection ? t('projectViewer.common.copyToLibrary') : t('projectViewer.album.copyAllToLibrary')}
-                  className="flex items-center justify-center gap-1.5 min-h-8 min-w-8 px-2 @min-[56rem]/pane:px-3 py-1.5 bg-purple-500/10 hover:bg-purple-500/20 text-purple-400 text-[9px] font-black uppercase tracking-widest rounded-lg border border-purple-500/20 transition-all"
-                >
-                  <Copy className="w-3 h-3" />
-                  <span className="hidden @min-[56rem]/pane:inline">
-                    {hasVisibleSelection ? t('projectViewer.album.toLibraryShort') : t('projectViewer.album.allToLibraryShort')}
-                  </span>
-                </button>
-                {isTextProject && selectedDisplayItemIds.length > 1 && (
-                  <button
-                    onClick={() => setShowCompareDialog(true)}
-                    title={t('projectViewer.album.compareSelected')}
-                    aria-label={t('projectViewer.album.compareSelected')}
-                    className="flex items-center justify-center gap-1.5 min-h-8 min-w-8 px-2 @min-[56rem]/pane:px-3 py-1.5 bg-neutral-900/5 hover:bg-neutral-900/10 text-neutral-700 dark:bg-white/5 dark:hover:bg-white/10 dark:text-neutral-200 text-[9px] font-black uppercase tracking-widest rounded-lg border border-neutral-300 dark:border-neutral-700 transition-all"
-                  >
-                    <Layers className="w-3 h-3" />
-                    <span className="hidden @min-[56rem]/pane:inline">{t('projectViewer.album.compareShort')}</span>
-                  </button>
-                )}
-                {hasVisibleSelection && (
-                  <button
-                    onClick={openMoveToProject}
-                    title={t('projectViewer.moveToProject.moveSelected')}
-                    aria-label={t('projectViewer.moveToProject.moveSelected')}
-                    className="flex items-center justify-center gap-1.5 min-h-8 min-w-8 px-2 @min-[56rem]/pane:px-3 py-1.5 bg-amber-500/10 hover:bg-amber-500/20 text-amber-500 text-[9px] font-black uppercase tracking-widest rounded-lg border border-amber-500/20 transition-all"
-                  >
-                    <FolderInput className="w-3 h-3" />
-                    <span className="hidden @min-[56rem]/pane:inline">{t('projectViewer.moveToProject.moveShort')}</span>
-                  </button>
-                )}
-                {hasVisibleSelection && (
-                  <button
-                    onClick={() => {
-                      const itemsToDelete = displayItems.filter(item => selectedAlbumIds.has(item.id));
-                      setAlbumItemsToDelete(itemsToDelete);
-                      setShowDeleteAlbumModal(true);
-                    }}
-                    title={t('projectViewer.common.deleteSelected')}
-                    aria-label={t('projectViewer.common.deleteSelected')}
-                    className="flex items-center justify-center gap-1.5 min-h-8 min-w-8 px-2 @min-[56rem]/pane:px-3 py-1.5 bg-red-500/10 hover:bg-red-500/20 text-red-500 text-[9px] font-black uppercase tracking-widest rounded-lg border border-red-500/20 transition-all"
-                  >
-                    <Trash2 className="w-3 h-3" />
-                    <span className="hidden @min-[56rem]/pane:inline">{t('projectViewer.album.deleteShort')}</span>
-                  </button>
-                )}
+                <AlbumSearch value={search} onChange={onSearchChange} />
                 {showAspectRatioFilterControl && (
                   <AspectRatioFilterControl
                     options={aspectRatioOptions}
@@ -724,7 +700,7 @@ export function AlbumTab({
                     onClear={clearAspectRatioFilter}
                   />
                 )}
-                {tagCounts.length > 0 && (
+                {(tagCounts.length > 0 || hasTagFilter) && (
                   <TagFilterControl
                     options={tagCounts}
                     selectedTags={selectedTags}
@@ -774,9 +750,8 @@ export function AlbumTab({
               </>
             }
           />
-        )}
 
-        {total === 0 && !hasAspectRatioFilter && !hasTagFilter ? (
+        {total === 0 && !hasAspectRatioFilter && !hasTagFilter && !hasSearchFilter ? (
           <EmptyState
             Icon={isTextProject ? FileText : isVideoProject ? VideoIcon : isAudioProject ? Music : ImageIcon}
             title={isTextProject ? t('projectViewer.album.noTexts') : isVideoProject ? t('projectViewer.album.noVideos') : isAudioProject ? t('projectViewer.album.noAudios') : t('projectViewer.album.galleryEmpty')}
@@ -786,8 +761,8 @@ export function AlbumTab({
         ) : displayItems.length === 0 ? (
           <EmptyState
             Icon={Filter}
-            title={hasTagFilter && !hasAspectRatioFilter ? t('projectViewer.album.noTagMatches') : t('projectViewer.album.noAspectRatioMatches')}
-            description={hasTagFilter && !hasAspectRatioFilter ? t('projectViewer.album.noTagMatchesDescription') : t('projectViewer.album.noAspectRatioMatchesDescription')}
+            title={t('projectViewer.album.noFilterMatches')}
+            description={t('projectViewer.album.noFilterMatchesDescription')}
             animateIcon={false}
           />
         ) : isTextProject ? (

--- a/src/components/ProjectViewer/AlbumToolbarControls.tsx
+++ b/src/components/ProjectViewer/AlbumToolbarControls.tsx
@@ -1,0 +1,120 @@
+import React, { useEffect, useId, useRef, useState } from 'react';
+import { ChevronDown, Search, X } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+
+export function AlbumSearch({ value, onChange }: { value: string; onChange: (value: string) => void }) {
+  const { t } = useTranslation();
+  const [draft, setDraft] = useState(value);
+  const [isComposing, setIsComposing] = useState(false);
+  useEffect(() => setDraft(value), [value]);
+  useEffect(() => {
+    if (isComposing || draft === value) return;
+    const timer = window.setTimeout(() => onChange(draft), 300);
+    return () => window.clearTimeout(timer);
+  }, [draft, value, onChange, isComposing]);
+
+  return (
+    <div className="flex items-center gap-2 min-h-8 w-full @sm/pane:w-56 @min-[56rem]/pane:w-64 px-2.5 rounded-lg border border-neutral-300 dark:border-neutral-700 focus-within:ring-2 focus-within:ring-blue-500/40">
+      <Search className="w-3.5 h-3.5 shrink-0 text-neutral-500" />
+      <input
+        type="search"
+        value={draft}
+        onChange={(event) => setDraft(event.target.value)}
+        onCompositionStart={() => setIsComposing(true)}
+        onCompositionEnd={() => setIsComposing(false)}
+        placeholder={t('projectViewer.album.searchPlaceholder')}
+        aria-label={t('projectViewer.album.searchPlaceholder')}
+        className="w-full min-w-0 py-1.5 bg-transparent text-xs text-neutral-800 dark:text-neutral-200 outline-none [&::-webkit-search-cancel-button]:appearance-none"
+      />
+      {draft && (
+        <button type="button" onClick={() => { setDraft(''); onChange(''); }} aria-label={t('projectViewer.album.clearSearch')} className="p-1 text-neutral-500 hover:text-blue-500">
+          <X className="w-3 h-3" />
+        </button>
+      )}
+    </div>
+  );
+}
+
+export interface AlbumAction {
+  label: string;
+  icon: React.ReactNode;
+  onClick: () => void;
+  destructive?: boolean;
+}
+
+export function AlbumActionsMenu({ actions, disabled }: { actions: AlbumAction[]; disabled?: boolean }) {
+  const { t } = useTranslation();
+  const [open, setOpen] = useState(false);
+  const root = useRef<HTMLDivElement>(null);
+  const trigger = useRef<HTMLButtonElement>(null);
+  const menuId = useId();
+  const close = () => { setOpen(false); trigger.current?.focus(); };
+
+  useEffect(() => {
+    if (disabled) setOpen(false);
+  }, [disabled]);
+
+  useEffect(() => {
+    if (!open) return;
+    root.current?.querySelector<HTMLButtonElement>('[role="menuitem"]')?.focus();
+    const dismiss = (event: PointerEvent) => {
+      if (!root.current?.contains(event.target as Node)) setOpen(false);
+    };
+    document.addEventListener('pointerdown', dismiss);
+    return () => document.removeEventListener('pointerdown', dismiss);
+  }, [open]);
+
+  return (
+    <div ref={root} className="relative" onBlur={(event) => {
+      if (!event.currentTarget.contains(event.relatedTarget as Node)) setOpen(false);
+    }} onKeyDown={(event) => {
+      if (event.key === 'Escape') { event.preventDefault(); close(); }
+    }}>
+      <button
+        ref={trigger}
+        type="button"
+        disabled={disabled}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        aria-controls={open ? menuId : undefined}
+        onClick={() => setOpen(!open)}
+        onKeyDown={(event) => {
+          if (event.key === 'ArrowDown' || event.key === 'ArrowUp') { event.preventDefault(); setOpen(true); }
+        }}
+        className="flex items-center gap-1.5 min-h-8 px-3 py-1.5 text-[10px] font-bold rounded-lg border border-blue-500/30 bg-blue-500/10 text-blue-500 hover:bg-blue-500/20 disabled:opacity-50"
+      >
+        {t('projectViewer.album.actions')}
+        <ChevronDown className={`w-3 h-3 transition-transform ${open ? 'rotate-180' : ''}`} />
+      </button>
+      {open && (
+        <div id={menuId} role="menu" aria-label={t('projectViewer.album.actions')}
+          className="absolute top-full left-0 mt-2 w-60 max-w-[calc(100vw-2rem)] p-1.5 rounded-xl border border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-900 shadow-xl z-[100]"
+          onKeyDown={(event) => {
+            const items = Array.from(event.currentTarget.querySelectorAll<HTMLButtonElement>('[role="menuitem"]'));
+            const index = items.indexOf(document.activeElement as HTMLButtonElement);
+            let next: number;
+            if (event.key === 'ArrowDown') next = (index + 1) % items.length;
+            else if (event.key === 'ArrowUp') next = (index - 1 + items.length) % items.length;
+            else if (event.key === 'Home') next = 0;
+            else if (event.key === 'End') next = items.length - 1;
+            else return;
+            event.preventDefault();
+            items[next]?.focus();
+          }}
+        >
+          {actions.map((action) => (
+            <button key={action.label} type="button" role="menuitem" tabIndex={-1}
+              onClick={() => { close(); action.onClick(); }}
+              className={`flex items-center gap-2.5 w-full px-3 py-2.5 rounded-lg text-left text-xs font-medium outline-none ${action.destructive
+                ? 'text-red-500 hover:bg-red-500/10 focus:bg-red-500/10'
+                : 'text-neutral-700 dark:text-neutral-200 hover:bg-neutral-100 dark:hover:bg-neutral-800 focus:bg-neutral-100 dark:focus:bg-neutral-800'}`}
+            >
+              {action.icon}
+              {action.label}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/locales/en/project-viewer.json
+++ b/src/locales/en/project-viewer.json
@@ -338,6 +338,14 @@
       "moveFailed": "Move failed"
     },
     "album": {
+      "actions": "Actions",
+      "searchPlaceholder": "Search name or prompt…",
+      "clearSearch": "Clear search",
+      "noFilterMatches": "No matching items",
+      "noFilterMatchesDescription": "Try another search or adjust your filters.",
+      "exportPage": "Export this page",
+      "tagResults": "Tag matching items",
+      "copyPageToLibrary": "Copy this page to library",
       "exportQueued": "Export queued!",
       "viewArchiveProgress": "View progress in Archive →",
       "exportFailed": "Export failed: {{message}}",

--- a/src/locales/fr/project-viewer.json
+++ b/src/locales/fr/project-viewer.json
@@ -338,6 +338,14 @@
       "moveFailed": "Échec du déplacement"
     },
     "album": {
+      "actions": "Actions",
+      "searchPlaceholder": "Rechercher un nom ou un prompt…",
+      "clearSearch": "Effacer la recherche",
+      "noFilterMatches": "Aucun élément correspondant",
+      "noFilterMatchesDescription": "Essayez une autre recherche ou ajustez les filtres.",
+      "exportPage": "Exporter cette page",
+      "tagResults": "Étiqueter les résultats",
+      "copyPageToLibrary": "Copier cette page dans la bibliothèque",
       "exportQueued": "Export mis en file !",
       "viewArchiveProgress": "Voir la progression dans Archive →",
       "exportFailed": "Échec de l'export : {{message}}",

--- a/src/locales/ja/project-viewer.json
+++ b/src/locales/ja/project-viewer.json
@@ -338,6 +338,14 @@
       "moveFailed": "移動に失敗しました"
     },
     "album": {
+      "actions": "操作",
+      "searchPlaceholder": "名前やプロンプトで検索…",
+      "clearSearch": "検索をクリア",
+      "noFilterMatches": "一致する項目がありません",
+      "noFilterMatchesDescription": "別のキーワードを試すか、フィルターを調整してください。",
+      "exportPage": "このページをエクスポート",
+      "tagResults": "一致する項目にタグを付ける",
+      "copyPageToLibrary": "このページをライブラリにコピー",
       "exportQueued": "エクスポートをキューに追加しました！",
       "viewArchiveProgress": "Archive で進行状況を見る →",
       "exportFailed": "エクスポート失敗: {{message}}",

--- a/src/locales/ko/project-viewer.json
+++ b/src/locales/ko/project-viewer.json
@@ -338,6 +338,14 @@
       "moveFailed": "이동하지 못했습니다"
     },
     "album": {
+      "actions": "작업",
+      "searchPlaceholder": "이름 또는 프롬프트 검색…",
+      "clearSearch": "검색 지우기",
+      "noFilterMatches": "일치하는 항목이 없습니다",
+      "noFilterMatchesDescription": "다른 검색어를 입력하거나 필터를 조정하세요.",
+      "exportPage": "현재 페이지 내보내기",
+      "tagResults": "일치하는 항목에 태그 지정",
+      "copyPageToLibrary": "현재 페이지를 라이브러리에 복사",
       "exportQueued": "내보내기가 대기열에 추가되었습니다!",
       "viewArchiveProgress": "Archive에서 진행 상황 보기 →",
       "exportFailed": "내보내기 실패: {{message}}",

--- a/src/locales/zh-CN/project-viewer.json
+++ b/src/locales/zh-CN/project-viewer.json
@@ -338,6 +338,14 @@
       "moveFailed": "移动失败"
     },
     "album": {
+      "actions": "操作",
+      "searchPlaceholder": "搜索名称或提示词…",
+      "clearSearch": "清除搜索",
+      "noFilterMatches": "没有匹配的项目",
+      "noFilterMatchesDescription": "请尝试其他搜索词或调整筛选条件。",
+      "exportPage": "导出本页",
+      "tagResults": "标记匹配项目",
+      "copyPageToLibrary": "将本页复制到素材库",
       "exportQueued": "导出已加入队列！",
       "viewArchiveProgress": "在归档中查看进度 →",
       "exportFailed": "导出失败：{{message}}",

--- a/src/locales/zh-TW/project-viewer.json
+++ b/src/locales/zh-TW/project-viewer.json
@@ -338,6 +338,14 @@
       "moveFailed": "移動失敗"
     },
     "album": {
+      "actions": "操作",
+      "searchPlaceholder": "搜尋名稱或提示詞…",
+      "clearSearch": "清除搜尋",
+      "noFilterMatches": "沒有符合的項目",
+      "noFilterMatchesDescription": "請嘗試其他搜尋詞或調整篩選條件。",
+      "exportPage": "匯出本頁",
+      "tagResults": "標記符合的項目",
+      "copyPageToLibrary": "將本頁複製到素材庫",
       "exportQueued": "匯出已加入佇列！",
       "viewArchiveProgress": "前往封存查看進度 →",
       "exportFailed": "匯出失敗：{{message}}",


### PR DESCRIPTION
Simplify the project album toolbar by grouping bulk actions into one keyboard-accessible dropdown and adding debounced name/prompt search alongside visible tag filters. Search is applied across album pages, preserved with tag filters during live updates, and included in the scope of batch tagging. Filters remain accessible when no items match.

Validation: TypeScript checks, translation completeness, and the production build passed. Browser fixture checks covered menu keyboard navigation, narrow layouts, search, tag matching, and empty results. Mocked repository checks covered search/filter composition and batch-tagging scope. The user also tested the branch locally and approved merging.
