### PR TITLE
Refine modal styling for improved light mode appearance

### DIFF
--- a/src/components/Assistant/ApprovedToolsModal.tsx
+++ b/src/components/Assistant/ApprovedToolsModal.tsx
@@ -77,7 +77,7 @@ export function ApprovedToolsModal({ isOpen, conversationId, onClose }: Approved
       onClick={onClose}
     >
       <div
-        className="bg-white/70 dark:bg-neutral-900/70 border border-neutral-200/50 dark:border-white/5 backdrop-blur-2xl rounded-card shadow-[0_50px_100px_rgba(0,0,0,0.8)] max-w-2xl w-full max-h-[calc(100dvh-1.5rem)] sm:max-h-[min(720px,calc(100dvh-3rem))] overflow-hidden flex flex-col animate-in zoom-in-95 duration-300"
+        className="bg-white dark:bg-neutral-900/70 border border-neutral-200 dark:border-white/5 dark:backdrop-blur-2xl rounded-card shadow-2xl dark:shadow-[0_50px_100px_rgba(0,0,0,0.8)] max-w-2xl w-full max-h-[calc(100dvh-1.5rem)] sm:max-h-[min(720px,calc(100dvh-3rem))] overflow-hidden flex flex-col animate-in zoom-in-95 duration-300"
         onClick={(e) => e.stopPropagation()}
       >
         <div className="p-5 sm:p-8 flex items-start gap-4 sm:gap-6 border-b border-neutral-200/50 dark:border-white/5">

--- a/src/components/RenameItemModal.tsx
+++ b/src/components/RenameItemModal.tsx
@@ -32,7 +32,7 @@ export function RenameItemModal({
       onClick={onClose}
     >
       <div 
-        className="bg-white/70 dark:bg-neutral-900/70 border border-neutral-200/50 dark:border-white/5 backdrop-blur-2xl rounded-card sm:rounded-card shadow-[0_50px_100px_rgba(0,0,0,0.8)] max-w-md w-full max-h-[calc(100dvh-1.5rem)] sm:max-h-[min(720px,calc(100dvh-3rem))] overflow-hidden animate-in zoom-in-95 duration-300"
+        className="bg-white dark:bg-neutral-900/70 border border-neutral-200 dark:border-white/5 dark:backdrop-blur-2xl rounded-card sm:rounded-card shadow-2xl dark:shadow-[0_50px_100px_rgba(0,0,0,0.8)] max-w-md w-full max-h-[calc(100dvh-1.5rem)] sm:max-h-[min(720px,calc(100dvh-3rem))] overflow-hidden animate-in zoom-in-95 duration-300"
         onClick={(e) => e.stopPropagation()}
       >
         <div className="p-5 sm:p-8 overflow-y-auto">


### PR DESCRIPTION
## Summary
Updated modal component styling in `ApprovedToolsModal` and `RenameItemModal` to improve the visual appearance in light mode while maintaining dark mode aesthetics.

## Key Changes
- **Light mode background**: Changed from `bg-white/70` to solid `bg-white` for better contrast and clarity
- **Light mode border**: Updated from `border-neutral-200/50` to `border-neutral-200` for more defined edges
- **Backdrop blur**: Moved `backdrop-blur-2xl` to be dark mode only (`dark:backdrop-blur-2xl`) for a cleaner light mode appearance
- **Shadow styling**: Replaced custom shadow with `shadow-2xl` for light mode, keeping the custom `dark:shadow-[0_50px_100px_rgba(0,0,0,0.8)]` for dark mode

## Implementation Details
These changes were applied consistently across both modal components to ensure a unified design system. The modifications prioritize a cleaner, more opaque appearance in light mode while preserving the frosted glass effect and deeper shadows in dark mode.

https://claude.ai/code/session_01KkWYhbFmyFXNgbh7rRHzCi