### PR TITLE
fix(album): stop the loading overlay from covering the grid

### DIFF
--- a/src/components/ProjectViewer.tsx
+++ b/src/components/ProjectViewer.tsx
@@ -2465,7 +2465,15 @@ export function ProjectViewer({ project, libraries, onUpdate: onUpdateProp, onDe
               onSortChange={handleCompletedSortChange}
             />
           )}
-          {activeTab === 'album' && isLoadingAlbum && (
+          {/*
+            The album list stays mounted while it reloads, so a full-surface overlay would
+            sit on top of the rows the user is still looking at. It is absolutely positioned
+            inside this scroller too, which anchors it to the top of the scrolled content
+            rather than to the viewport — once the list was scrolled, the dimmed panel and
+            its spinner landed in the middle of the grid. Show it only when there is nothing
+            underneath; otherwise the album toolbar carries the spinner.
+          */}
+          {activeTab === 'album' && isLoadingAlbum && albumItems.length === 0 && (
             <div className="absolute inset-0 flex items-center justify-center bg-white/50 dark:bg-black/50 z-20 pointer-events-none">
               <Loader2 className="w-8 h-8 text-neutral-500 animate-spin" />
             </div>

--- a/src/components/ProjectViewer/AlbumTab.tsx
+++ b/src/components/ProjectViewer/AlbumTab.tsx
@@ -677,6 +677,7 @@ export function AlbumTab({
         <SelectionToolbar
             totalCount={displayItems.length}
             selectedCount={selectedDisplayItemIds.length}
+            isLoading={isLoading}
             onToggleSelectAll={() => toggleSelectAllAlbum(displayItemIds)}
             prefix={!isTextProject && (
               <div className="flex items-center gap-2 text-[10px] font-bold text-neutral-600 dark:text-neutral-400 uppercase tracking-widest">

--- a/src/components/ProjectViewer/SelectionToolbar.tsx
+++ b/src/components/ProjectViewer/SelectionToolbar.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { CheckSquare, Square } from 'lucide-react';
+import { CheckSquare, Square, Loader2 } from 'lucide-react';
 
 interface SelectionToolbarProps {
   /** Total number of items in the list. */
@@ -31,6 +31,11 @@ interface SelectionToolbarProps {
    * separated by a vertical divider (e.g. AlbumTab's item count + MB display).
    */
   prefix?: React.ReactNode;
+  /**
+   * Shows a small spinner inside the bar while the list behind it is refreshing.
+   * The bar is always on screen, so the spinner never covers a row.
+   */
+  isLoading?: boolean;
 }
 
 /** A thin vertical divider — only shown once the pane is wide enough for labelled buttons. */
@@ -47,6 +52,7 @@ export function SelectionToolbar({
   zeroSelectionActions,
   rightActions,
   prefix,
+  isLoading = false,
 }: SelectionToolbarProps) {
   const { t } = useTranslation();
 
@@ -88,6 +94,17 @@ export function SelectionToolbar({
         <span className="text-[10px] font-bold text-neutral-500 dark:text-neutral-500 uppercase tracking-widest whitespace-nowrap flex-shrink-0 @min-[56rem]/pane:hidden">
           {selectedCount > 0 ? `${selectedCount}/${totalCount}` : `${totalCount}`}
         </span>
+
+        {isLoading && (
+          <span
+            role="status"
+            title={t('projectViewer.common.loading')}
+            aria-label={t('projectViewer.common.loading')}
+            className="flex items-center flex-shrink-0"
+          >
+            <Loader2 className="w-3.5 h-3.5 text-blue-500 animate-spin" />
+          </span>
+        )}
 
         {selectedCount > 0 && (
           <>

--- a/src/locales/en/project-viewer.json
+++ b/src/locales/en/project-viewer.json
@@ -15,6 +15,7 @@
       "save": "Save",
       "cancel": "Cancel",
       "close": "Close",
+      "loading": "Loading...",
       "preview": "Preview",
       "copy": "Copy",
       "edit": "Edit",

--- a/src/locales/fr/project-viewer.json
+++ b/src/locales/fr/project-viewer.json
@@ -16,6 +16,7 @@
       "save": "Enregistrer",
       "cancel": "Annuler",
       "close": "Fermer",
+      "loading": "Chargement...",
       "preview": "Aperçu",
       "copy": "Copier",
       "edit": "Modifier",

--- a/src/locales/ja/project-viewer.json
+++ b/src/locales/ja/project-viewer.json
@@ -15,6 +15,7 @@
       "save": "保存",
       "cancel": "キャンセル",
       "close": "閉じる",
+      "loading": "読み込み中...",
       "preview": "プレビュー",
       "copy": "コピー",
       "edit": "編集",

--- a/src/locales/ko/project-viewer.json
+++ b/src/locales/ko/project-viewer.json
@@ -15,6 +15,7 @@
       "save": "저장",
       "cancel": "취소",
       "close": "닫기",
+      "loading": "불러오는 중...",
       "preview": "미리보기",
       "copy": "복사",
       "edit": "편집",

--- a/src/locales/zh-CN/project-viewer.json
+++ b/src/locales/zh-CN/project-viewer.json
@@ -15,6 +15,7 @@
       "save": "保存",
       "cancel": "取消",
       "close": "关闭",
+      "loading": "加载中...",
       "preview": "预览",
       "copy": "复制",
       "edit": "编辑",

--- a/src/locales/zh-TW/project-viewer.json
+++ b/src/locales/zh-TW/project-viewer.json
@@ -15,6 +15,7 @@
       "save": "保存",
       "cancel": "取消",
       "close": "關閉",
+      "loading": "載入中...",
       "preview": "預覽",
       "copy": "複製",
       "edit": "編輯",


### PR DESCRIPTION
## What

The album tab's loading indicator no longer paints a dimmed panel over the grid. The full-surface overlay is now shown only on the initial load, when the list is still empty; every later refresh (page change, search, filter, sort) shows a small spinner in the album toolbar instead.

## Why

Two things went wrong together:

1. **The album list stays mounted while it reloads.** The drafts, queue and completed tabs unmount their content and render the overlay over a blank area. The album branch renders unconditionally, so the overlay landed on top of the rows the user was still looking at.

2. **The overlay is `absolute inset-0` inside the tab's `overflow-y-auto` scroller**, which anchors it to the top of the *scrolled content* rather than to the viewport. Once the list had been scrolled, the dimmed panel and its spinner drifted into the middle of the grid instead of staying centred on screen — the reported symptom, with the top rows washed out and a spinner floating between two columns.

## Changes

- `ProjectViewer.tsx` — gate the album overlay on `albumItems.length === 0`, with a comment recording why it cannot be used once the list has content.
- `SelectionToolbar.tsx` — new optional `isLoading` prop rendering a small spinner next to the selection count. The bar is `sticky top-0`, so it is always on screen and never covers a row. Carries `role="status"` plus a translated `aria-label`/`title`.
- `AlbumTab.tsx` — pass its existing `isLoading` through to the toolbar.
- Added `projectViewer.common.loading` to all six locales.

Other consumers of `SelectionToolbar` are unaffected: `isLoading` defaults to `false`.

## Verification

- `npm run lint` (tsc --noEmit) clean. Three pre-existing `assistantConversationResource` errors turned out to be a stale Prisma client and cleared after `npx prisma generate`; they are unrelated to this change.
- `npm run i18n:check` — no missing keys in any locale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)