### PR TITLE
Improve PWA share handling with better diagnostics and blob support

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,5 +1,12 @@
 const SHARE_CACHE = 'remix-studio-share-v1';
-const META_KEY = '/__share-cache/meta.json';
+const SHARE_PREFIX = '/__share-cache/';
+const META_KEY = `${SHARE_PREFIX}meta.json`;
+
+// The manifest names these three fields, so they keep their meaning. Anything
+// else a share posts is still kept: an Android WebAPK installed against an
+// older manifest, or a sharing app that picks its own field name, would
+// otherwise hand us a payload that silently reads as empty.
+const NAMED_TEXT_FIELDS = ['text', 'title', 'url'];
 
 self.addEventListener('install', () => {
   self.skipWaiting();
@@ -11,59 +18,156 @@ self.addEventListener('activate', (event) => {
 
 self.addEventListener('fetch', (event) => {
   const url = new URL(event.request.url);
-  if (event.request.method === 'POST' && url.pathname === '/share-target') {
+  if (url.pathname !== '/share-target') return;
+  if (event.request.method === 'POST') {
     event.respondWith(handleShare(event.request));
+  } else if (event.request.method === 'GET') {
+    // A share target declared as GET (or a WebAPK still holding an older
+    // manifest) arrives with the payload in the query string.
+    event.respondWith(handleShareGet(url));
   }
 });
 
-async function handleShare(request) {
+function isFileLike(value) {
+  return value && typeof value !== 'string' && typeof value.arrayBuffer === 'function';
+}
+
+// Reads whatever the platform posted without assuming the field names, and
+// reports what it saw so the landing page can explain an empty share instead
+// of rendering a blank preview.
+async function readSharedPayload(request) {
+  const contentType = request.headers.get('content-type') || '';
+  const fields = {};
+  const fieldNames = [];
+  const files = [];
+  let unreadableFiles = 0;
+
+  let entries = [];
   try {
     const formData = await request.formData();
-    const text = String(formData.get('text') || '');
-    const title = String(formData.get('title') || '');
-    const sharedUrl = String(formData.get('url') || '');
-    const files = formData.getAll('files');
-
-    const cache = await caches.open(SHARE_CACHE);
-
-    // Clear any stale entries from a prior share
-    const existing = await cache.keys();
-    await Promise.all(existing.map((req) => cache.delete(req)));
-
-    const fileMeta = [];
-    for (let i = 0; i < files.length; i++) {
-      const file = files[i];
-      if (!file || typeof file === 'string' || !file.size) continue;
-      const key = `share-file-${Date.now()}-${i}`;
-      const cacheUrl = `/__share-cache/${key}`;
-      const response = new Response(file, {
-        headers: {
-          'Content-Type': file.type || 'application/octet-stream',
-        },
-      });
-      await cache.put(cacheUrl, response);
-      fileMeta.push({
-        key,
-        name: file.name || '',
-        type: file.type || 'application/octet-stream',
-      });
+    entries = Array.from(formData.entries());
+  } catch (e) {
+    // Not a form body after all — take the raw body as the shared text rather
+    // than losing the share.
+    const body = await request.clone().text();
+    if (body) {
+      try {
+        entries = Array.from(new URLSearchParams(body).entries());
+      } catch {
+        entries = [['text', body]];
+      }
     }
+  }
 
-    const meta = {
-      text,
+  for (const [name, value] of entries) {
+    fieldNames.push(name);
+    if (isFileLike(value)) {
+      if (value.size > 0) {
+        files.push({ field: name, file: value });
+      } else if (value.name) {
+        // The sharing app handed over a file the browser could not read.
+        unreadableFiles += 1;
+      }
+      continue;
+    }
+    const text = String(value == null ? '' : value).trim();
+    if (text && !fields[name]) fields[name] = text;
+  }
+
+  return buildMeta({ fields, fieldNames, files, unreadableFiles, contentType });
+}
+
+function buildMeta({ fields, fieldNames, files, unreadableFiles, contentType }) {
+  const text = fields.text || '';
+  const title = fields.title || '';
+  const url = fields.url || '';
+
+  // Anything posted under a name the manifest does not list still carries the
+  // shared content when the sender disagrees with us about field names.
+  const extras = Object.keys(fields)
+    .filter((name) => !NAMED_TEXT_FIELDS.includes(name))
+    .map((name) => fields[name]);
+
+  return {
+    meta: {
+      text: text || (title || url ? '' : extras.join('\n')),
       title,
-      url: sharedUrl,
-      files: fileMeta,
+      url,
+      extras,
+      files: [],
+      diagnostics: {
+        fieldNames,
+        fileCount: files.length,
+        unreadableFiles,
+        contentType,
+      },
       receivedAt: Date.now(),
-    };
+    },
+    files,
+  };
+}
 
-    await cache.put(
-      META_KEY,
-      new Response(JSON.stringify(meta), {
-        headers: { 'Content-Type': 'application/json' },
-      }),
-    );
+async function writeShare(payload) {
+  const cache = await caches.open(SHARE_CACHE);
 
+  // Clear the previous share only once this one has been parsed, so a failed
+  // parse never destroys what is already there.
+  const existing = await cache.keys();
+  await Promise.all(existing.map((req) => cache.delete(req)));
+
+  const fileMeta = [];
+  for (let i = 0; i < payload.files.length; i++) {
+    const { file } = payload.files[i];
+    const key = `share-file-${Date.now()}-${i}`;
+    const response = new Response(file, {
+      headers: { 'Content-Type': file.type || 'application/octet-stream' },
+    });
+    await cache.put(`${SHARE_PREFIX}${key}`, response);
+    fileMeta.push({
+      key,
+      name: file.name || '',
+      type: file.type || 'application/octet-stream',
+      size: file.size,
+    });
+  }
+
+  const meta = { ...payload.meta, files: fileMeta };
+  await cache.put(
+    META_KEY,
+    new Response(JSON.stringify(meta), {
+      headers: { 'Content-Type': 'application/json' },
+    }),
+  );
+}
+
+async function handleShare(request) {
+  try {
+    const payload = await readSharedPayload(request);
+    await writeShare(payload);
+    return Response.redirect(new URL('/share', self.location.origin).href, 303);
+  } catch (e) {
+    const message = encodeURIComponent(String(e && e.message ? e.message : e));
+    return Response.redirect(new URL(`/share?error=${message}`, self.location.origin).href, 303);
+  }
+}
+
+async function handleShareGet(url) {
+  try {
+    const fields = {};
+    const fieldNames = [];
+    for (const [name, value] of url.searchParams.entries()) {
+      fieldNames.push(name);
+      const text = String(value || '').trim();
+      if (text && !fields[name]) fields[name] = text;
+    }
+    const payload = buildMeta({
+      fields,
+      fieldNames,
+      files: [],
+      unreadableFiles: 0,
+      contentType: 'query-string',
+    });
+    await writeShare(payload);
     return Response.redirect(new URL('/share', self.location.origin).href, 303);
   } catch (e) {
     const message = encodeURIComponent(String(e && e.message ? e.message : e));

--- a/src/lib/pwa-share.ts
+++ b/src/lib/pwa-share.ts
@@ -1,12 +1,40 @@
 export const PWA_SHARE_SESSION_KEY = '__remix_pwa_share_handoff';
 
+const HANDOFF_CACHE = 'remix-studio-share-handoff-v1';
+const HANDOFF_BLOB_KEY = '/__share-handoff/payload';
+
 export type PwaShareHandoff = {
   type: 'text' | 'image';
   data: string;
   name?: string;
 };
 
-export function stashPwaShareHandoff(payload: PwaShareHandoff): boolean {
+export type PwaShareHandoffInput =
+  | { type: 'text'; data: string }
+  | { type: 'image'; blob: Blob; name?: string };
+
+type StoredHandoff =
+  | { type: 'text'; data: string; name?: string }
+  | { type: 'image'; ref: 'cache'; name?: string }
+  | { type: 'image'; data: string; name?: string };
+
+// The payload is consumed on mount, and a mount can happen more than once for
+// the same navigation (a remount while auth resolves, React's double-invoked
+// effects in development). Remembering what was read keeps the second caller
+// from finding an emptied slot.
+let consumed: { value: PwaShareHandoff | null } | null = null;
+let inFlight: Promise<PwaShareHandoff | null> | null = null;
+
+function blobToDataUrl(blob: Blob): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onloadend = () => resolve(String(reader.result || ''));
+    reader.onerror = () => reject(new Error('Failed to read shared image'));
+    reader.readAsDataURL(blob);
+  });
+}
+
+function writeSession(payload: StoredHandoff): boolean {
   try {
     sessionStorage.setItem(PWA_SHARE_SESSION_KEY, JSON.stringify(payload));
     return true;
@@ -15,16 +43,92 @@ export function stashPwaShareHandoff(payload: PwaShareHandoff): boolean {
   }
 }
 
-export function consumePwaShareHandoff(): PwaShareHandoff | null {
+/**
+ * Hands a shared payload to the page that will act on it. Images travel
+ * through the Cache API rather than sessionStorage: a photo shared from an
+ * Android gallery is routinely several megabytes, and base64 in a ~5MB session
+ * quota fails well before that.
+ */
+export async function stashPwaShareHandoff(payload: PwaShareHandoffInput): Promise<boolean> {
+  if (payload.type === 'text') {
+    return writeSession({ type: 'text', data: payload.data });
+  }
+
+  if ('caches' in window) {
+    try {
+      const cache = await caches.open(HANDOFF_CACHE);
+      await cache.put(
+        HANDOFF_BLOB_KEY,
+        new Response(payload.blob, {
+          headers: { 'Content-Type': payload.blob.type || 'application/octet-stream' },
+        }),
+      );
+      if (writeSession({ type: 'image', ref: 'cache', name: payload.name })) return true;
+      await cache.delete(HANDOFF_BLOB_KEY);
+    } catch {
+      // Fall through to the inline copy below.
+    }
+  }
+
   try {
-    const raw = sessionStorage.getItem(PWA_SHARE_SESSION_KEY);
-    if (!raw) return null;
-    sessionStorage.removeItem(PWA_SHARE_SESSION_KEY);
-    const parsed = JSON.parse(raw);
-    if (parsed?.type !== 'text' && parsed?.type !== 'image') return null;
-    if (typeof parsed.data !== 'string') return null;
-    return parsed as PwaShareHandoff;
+    const dataUrl = await blobToDataUrl(payload.blob);
+    return writeSession({ type: 'image', data: dataUrl, name: payload.name });
+  } catch {
+    return false;
+  }
+}
+
+async function readHandoff(): Promise<PwaShareHandoff | null> {
+  let raw: string | null = null;
+  try {
+    raw = sessionStorage.getItem(PWA_SHARE_SESSION_KEY);
+    if (raw) sessionStorage.removeItem(PWA_SHARE_SESSION_KEY);
   } catch {
     return null;
   }
+  if (!raw) return null;
+
+  let parsed: StoredHandoff;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+
+  if (parsed?.type === 'text') {
+    return typeof parsed.data === 'string' ? { type: 'text', data: parsed.data } : null;
+  }
+  if (parsed?.type !== 'image') return null;
+
+  if ('data' in parsed && typeof parsed.data === 'string') {
+    return { type: 'image', data: parsed.data, name: parsed.name };
+  }
+
+  if (!('caches' in window)) return null;
+  try {
+    const cache = await caches.open(HANDOFF_CACHE);
+    const res = await cache.match(HANDOFF_BLOB_KEY);
+    if (!res) return null;
+    const dataUrl = await blobToDataUrl(await res.blob());
+    await cache.delete(HANDOFF_BLOB_KEY);
+    return { type: 'image', data: dataUrl, name: parsed.name };
+  } catch {
+    return null;
+  }
+}
+
+export function consumePwaShareHandoff(): Promise<PwaShareHandoff | null> {
+  if (consumed) return Promise.resolve(consumed.value);
+  if (!inFlight) {
+    inFlight = readHandoff()
+      .then((value) => {
+        consumed = { value };
+        return value;
+      })
+      .catch(() => {
+        consumed = { value: null };
+        return null;
+      });
+  }
+  return inFlight;
 }

--- a/src/pages/AssistantPage.tsx
+++ b/src/pages/AssistantPage.tsx
@@ -794,10 +794,9 @@ export function AssistantPage() {
   }, [navigate, applyToComposer]);
 
   useEffect(() => {
-    const shared = consumePwaShareHandoff();
-    if (shared) {
-      applyToComposer(shared);
-    }
+    void consumePwaShareHandoff().then((shared) => {
+      if (shared) applyToComposer(shared);
+    });
   }, [applyToComposer]);
 
   useEffect(() => {

--- a/src/pages/ExtensionImport.tsx
+++ b/src/pages/ExtensionImport.tsx
@@ -206,12 +206,14 @@ export default function ExtensionImport() {
 
     window.addEventListener('message', handleMessage);
 
-    const shared = consumePwaShareHandoff();
-    if (shared) {
+    let released = false;
+    void consumePwaShareHandoff().then((shared) => {
+      if (released || !shared) return;
       applyPayload({ type: shared.type, data: shared.data, name: shared.name });
-    }
+    });
 
     return () => {
+      released = true;
       window.removeEventListener('message', handleMessage);
       clearTimeout(timer);
     };

--- a/src/pages/SharePage.tsx
+++ b/src/pages/SharePage.tsx
@@ -1,40 +1,141 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { Image as ImageIcon, Type, Layers, Folder, MessageCircle, Loader2, AlertTriangle } from 'lucide-react';
 import { toast } from 'sonner';
 import { PageHeader } from '../components/PageHeader';
-import { stashPwaShareHandoff, type PwaShareHandoff } from '../lib/pwa-share';
+import { stashPwaShareHandoff, type PwaShareHandoffInput } from '../lib/pwa-share';
 
 const SHARE_CACHE = 'remix-studio-share-v1';
-const META_KEY = '/__share-cache/meta.json';
+const SHARE_PREFIX = '/__share-cache/';
+const META_KEY = `${SHARE_PREFIX}meta.json`;
+
+// A share lands here within a second of being sent. Anything older is left
+// over from a session that never finished, and is cleared rather than shown.
+const SHARE_MAX_AGE_MS = 15 * 60 * 1000;
 
 type FileMeta = {
   key: string;
   name: string;
   type: string;
+  size?: number;
+};
+
+type ShareDiagnostics = {
+  fieldNames?: string[];
+  fileCount?: number;
+  unreadableFiles?: number;
+  contentType?: string;
 };
 
 type ShareMeta = {
   text: string;
   title: string;
   url: string;
+  extras?: string[];
   files: FileMeta[];
+  diagnostics?: ShareDiagnostics;
+  receivedAt?: number;
+};
+
+type SharedImage = {
+  name: string;
+  type: string;
+  blob: Blob;
+  objectUrl: string;
 };
 
 type LoadedShare = {
   text: string;
   title: string;
   url: string;
-  images: { name: string; dataUrl: string }[];
+  images: SharedImage[];
+  diagnostics: ShareDiagnostics;
+  /** Files the worker recorded that were no longer readable from the cache. */
+  missingFiles: number;
 };
 
-function blobToDataUrl(blob: Blob): Promise<string> {
-  return new Promise((resolve, reject) => {
-    const reader = new FileReader();
-    reader.onloadend = () => resolve(String(reader.result || ''));
-    reader.onerror = () => reject(new Error('Failed to read blob'));
-    reader.readAsDataURL(blob);
-  });
+async function openShareCache(): Promise<Cache | null> {
+  if (!('caches' in window)) return null;
+  try {
+    return await caches.open(SHARE_CACHE);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Reads the payload the service worker stashed. Nothing is deleted here: the
+ * page can mount more than once for a single share (a remount while auth
+ * resolves, React's double-invoked effects in development, a pull-to-refresh),
+ * and a read that consumed the payload left the second pass rendering an empty
+ * preview. The cache is cleared once the share has actually been acted on.
+ */
+async function loadShare(): Promise<LoadedShare | null> {
+  const cache = await openShareCache();
+  if (!cache) return null;
+
+  const metaRes = await cache.match(META_KEY);
+  if (!metaRes) return null;
+
+  const meta = (await metaRes.json()) as ShareMeta;
+
+  if (meta.receivedAt && Date.now() - meta.receivedAt > SHARE_MAX_AGE_MS) {
+    await clearShare();
+    return null;
+  }
+
+  const images: SharedImage[] = [];
+  let missingFiles = 0;
+  for (const file of meta.files || []) {
+    const fileRes = await cache.match(`${SHARE_PREFIX}${file.key}`);
+    if (!fileRes) {
+      missingFiles += 1;
+      continue;
+    }
+    const blob = await fileRes.blob();
+    images.push({
+      name: file.name || '',
+      type: file.type || blob.type,
+      blob,
+      objectUrl: URL.createObjectURL(blob),
+    });
+  }
+
+  const textParts = [meta.text, ...(meta.extras || [])].filter(Boolean);
+
+  return {
+    text: textParts.join('\n').trim(),
+    title: meta.title || '',
+    url: meta.url || '',
+    images,
+    diagnostics: meta.diagnostics || {},
+    missingFiles,
+  };
+}
+
+async function clearShare(): Promise<void> {
+  const cache = await openShareCache();
+  if (!cache) return;
+  try {
+    const keys = await cache.keys();
+    await Promise.all(keys.map((req) => cache.delete(req)));
+  } catch {
+    // A share that outlives its cache entry is harmless; it ages out.
+  }
+}
+
+function describeDiagnostics(share: LoadedShare): string {
+  const { unreadableFiles, fieldNames } = share.diagnostics;
+  if (share.missingFiles > 0) {
+    return `The shared ${share.missingFiles === 1 ? 'file' : 'files'} could not be read back from storage. Sharing again usually works.`;
+  }
+  if (unreadableFiles) {
+    return `The other app offered ${unreadableFiles === 1 ? 'a file' : `${unreadableFiles} files`} that the browser could not open. Try sharing from the gallery, or save the image first and share the saved copy.`;
+  }
+  if (fieldNames && fieldNames.length > 0) {
+    return `The share arrived with no content in it (fields received: ${fieldNames.join(', ')}).`;
+  }
+  return 'The share arrived with nothing in it.';
 }
 
 export default function SharePage() {
@@ -43,99 +144,78 @@ export default function SharePage() {
   const swError = searchParams.get('error');
   const [status, setStatus] = useState<'loading' | 'loaded' | 'empty'>('loading');
   const [share, setShare] = useState<LoadedShare | null>(null);
+  const [handingOff, setHandingOff] = useState(false);
+  const shareRef = useRef<LoadedShare | null>(null);
 
   useEffect(() => {
     let cancelled = false;
-    async function load() {
-      if (!('caches' in window)) {
-        if (!cancelled) setStatus('empty');
-        return;
-      }
-      try {
-        const cache = await caches.open(SHARE_CACHE);
-        const metaRes = await cache.match(META_KEY);
-        if (!metaRes) {
-          if (!cancelled) setStatus('empty');
+    loadShare()
+      .then((loaded) => {
+        if (cancelled) {
+          loaded?.images.forEach((img) => URL.revokeObjectURL(img.objectUrl));
           return;
         }
-        const meta = (await metaRes.json()) as ShareMeta;
-        const images: { name: string; dataUrl: string }[] = [];
-        for (const file of meta.files || []) {
-          const fileRes = await cache.match(`/__share-cache/${file.key}`);
-          if (!fileRes) continue;
-          const blob = await fileRes.blob();
-          const dataUrl = await blobToDataUrl(blob);
-          images.push({ name: file.name, dataUrl });
-        }
-
-        // Clean up cache so refreshes don't replay
-        await cache.delete(META_KEY);
-        for (const file of meta.files || []) {
-          await cache.delete(`/__share-cache/${file.key}`);
-        }
-
-        if (cancelled) return;
-        setShare({
-          text: meta.text || '',
-          title: meta.title || '',
-          url: meta.url || '',
-          images,
-        });
-        setStatus('loaded');
-      } catch (e) {
+        // A payload with neither text nor an image is a failed share, not a
+        // share of nothing: it gets the diagnostic screen rather than an empty
+        // preview with buttons that cannot do anything.
+        const usable = loaded && (loaded.images.length > 0 || loaded.text || loaded.title || loaded.url);
+        shareRef.current = loaded;
+        setShare(loaded);
+        setStatus(usable ? 'loaded' : 'empty');
+      })
+      .catch(() => {
         if (!cancelled) setStatus('empty');
-      }
-    }
-    load();
+      });
     return () => {
       cancelled = true;
     };
   }, []);
 
-  const buildHandoff = (): PwaShareHandoff | null => {
+  useEffect(() => {
+    return () => {
+      shareRef.current?.images.forEach((img) => URL.revokeObjectURL(img.objectUrl));
+    };
+  }, []);
+
+  const buildHandoff = (): PwaShareHandoffInput | null => {
     if (!share) return null;
     if (share.images.length > 0) {
       const img = share.images[0];
       const name = img.name || share.title || share.text || 'Shared image';
-      return { type: 'image', data: img.dataUrl, name };
+      return { type: 'image', blob: img.blob, name };
     }
-    const textParts = [share.title, share.text, share.url].filter(Boolean);
-    const combined = textParts.join('\n').trim();
-    if (combined) {
-      return { type: 'text', data: combined };
-    }
+    const combined = [share.title, share.text, share.url].filter(Boolean).join('\n').trim();
+    if (combined) return { type: 'text', data: combined };
     return null;
   };
 
-  const handoffOrNotify = (payload: PwaShareHandoff | null) => {
+  const handOff = async (destination: string, extraCount: string) => {
+    if (handingOff) return;
+    const payload = buildHandoff();
     if (!payload) {
       toast.error('Nothing to share');
-      return false;
+      return;
     }
-    const ok = stashPwaShareHandoff(payload);
-    if (!ok) {
-      toast.error('Shared content is too large to hand off');
-      return false;
+    if (share && share.images.length > 1) {
+      toast.warning(`Only the first of ${share.images.length} images will be ${extraCount}`);
     }
-    return true;
+    setHandingOff(true);
+    try {
+      const ok = await stashPwaShareHandoff(payload);
+      if (!ok) {
+        toast.error('Shared content is too large to hand off');
+        return;
+      }
+      await clearShare();
+      navigate(destination);
+    } finally {
+      setHandingOff(false);
+    }
   };
 
-  const handleSendToImport = (destination: 'library' | 'project') => {
-    const payload = buildHandoff();
-    if (share && share.images.length > 1) {
-      toast.warning(`Only the first of ${share.images.length} images will be saved`);
-    }
-    if (!handoffOrNotify(payload)) return;
-    navigate(`/import?destination=${destination}`);
-  };
-
-  const handleSendToChat = () => {
-    const payload = buildHandoff();
-    if (share && share.images.length > 1) {
-      toast.warning(`Only the first of ${share.images.length} images will be attached`);
-    }
-    if (!handoffOrNotify(payload)) return;
-    navigate('/assistant');
+  const handleCancel = () => {
+    void clearShare();
+    navigate('/');
   };
 
   if (status === 'loading') {
@@ -148,20 +228,22 @@ export default function SharePage() {
   }
 
   if (status === 'empty' || !share) {
+    const failed = Boolean(swError) || Boolean(share);
+    const detail = swError
+      ? `Something went wrong handling the shared content: ${swError}`
+      : share
+        ? describeDiagnostics(share)
+        : 'Share text or an image to Remix Studio from another app to see it here.';
     return (
       <div className="h-full flex flex-col p-4 md:p-8 items-center justify-center min-h-[60vh] text-center space-y-4">
-        <div className={`w-16 h-16 rounded-full flex items-center justify-center ${swError ? 'bg-red-100 dark:bg-red-950/40' : 'bg-neutral-100 dark:bg-neutral-800'}`}>
-          {swError ? <AlertTriangle className="w-8 h-8 text-red-500" /> : <ImageIcon className="w-8 h-8 text-neutral-400" />}
+        <div className={`w-16 h-16 rounded-full flex items-center justify-center ${failed ? 'bg-red-100 dark:bg-red-950/40' : 'bg-neutral-100 dark:bg-neutral-800'}`}>
+          {failed ? <AlertTriangle className="w-8 h-8 text-red-500" /> : <ImageIcon className="w-8 h-8 text-neutral-400" />}
         </div>
         <h2 className="text-xl font-bold text-neutral-900 dark:text-white">
-          {swError ? 'Share Failed' : 'No Shared Content'}
+          {failed ? 'Share Failed' : 'No Shared Content'}
         </h2>
-        <p className="text-neutral-500 dark:text-neutral-400 max-w-md text-sm">
-          {swError
-            ? `Something went wrong handling the shared content: ${swError}`
-            : 'Share text or an image to Remix Studio from another app to see it here.'}
-        </p>
-        <button onClick={() => navigate('/')} className="px-6 py-2 bg-blue-600 text-white text-sm font-bold rounded-xl shadow hover:bg-blue-700 transition-all mt-4">
+        <p className="text-neutral-500 dark:text-neutral-400 max-w-md text-sm">{detail}</p>
+        <button onClick={handleCancel} className="px-6 py-2 bg-blue-600 text-white text-sm font-bold rounded-xl shadow hover:bg-blue-700 transition-all mt-4">
           Go to Home
         </button>
       </div>
@@ -177,7 +259,7 @@ export default function SharePage() {
         <PageHeader
           title="Shared with Remix Studio"
           description="Choose where to send this content."
-          backLink={{ label: 'Cancel', onClick: () => navigate('/') }}
+          backLink={{ label: 'Cancel', onClick: handleCancel }}
         />
 
         <div className="space-y-3 rounded-lg border border-neutral-200/70 bg-white/70 p-5 shadow-sm backdrop-blur-xl dark:border-white/10 dark:bg-neutral-900/55">
@@ -194,10 +276,10 @@ export default function SharePage() {
           </div>
           <div className="flex min-h-[200px] items-center justify-center overflow-hidden rounded-lg border border-neutral-200 bg-neutral-50 p-4 dark:border-white/10 dark:bg-neutral-950">
             {hasImage ? (
-              <img src={share.images[0].dataUrl} alt="Shared preview" className="max-h-[400px] max-w-full rounded-lg object-contain" />
+              <img src={share.images[0].objectUrl} alt="Shared preview" className="max-h-[400px] max-w-full rounded-lg object-contain" />
             ) : (
               <div className="w-full overflow-auto whitespace-pre-wrap rounded-lg bg-white p-4 font-mono text-sm dark:bg-neutral-900 max-h-[400px]">
-                {previewText || '(empty)'}
+                {previewText}
               </div>
             )}
           </div>
@@ -206,26 +288,34 @@ export default function SharePage() {
               {previewText}
             </div>
           )}
+          {share.missingFiles > 0 && (
+            <div className="rounded-lg bg-amber-500/10 p-3 text-xs text-amber-700 dark:text-amber-300">
+              {share.missingFiles === 1 ? 'One shared file' : `${share.missingFiles} shared files`} could not be read back and {share.missingFiles === 1 ? 'is' : 'are'} not included.
+            </div>
+          )}
         </div>
 
         <div className="grid gap-3 sm:grid-cols-3">
           <button
-            onClick={() => handleSendToImport('library')}
-            className="flex items-center justify-center gap-3 rounded-xl border border-neutral-200 bg-white px-5 py-4 text-sm font-bold text-neutral-900 shadow-sm transition-all hover:bg-neutral-50 active:scale-[0.98] dark:border-white/10 dark:bg-neutral-900 dark:text-white dark:hover:bg-neutral-800"
+            onClick={() => handOff('/import?destination=library', 'saved')}
+            disabled={handingOff}
+            className="flex items-center justify-center gap-3 rounded-xl border border-neutral-200 bg-white px-5 py-4 text-sm font-bold text-neutral-900 shadow-sm transition-all hover:bg-neutral-50 active:scale-[0.98] disabled:opacity-60 dark:border-white/10 dark:bg-neutral-900 dark:text-white dark:hover:bg-neutral-800"
           >
             <Layers className="h-5 w-5 text-blue-500" />
             Save to Library
           </button>
           <button
-            onClick={() => handleSendToImport('project')}
-            className="flex items-center justify-center gap-3 rounded-xl border border-neutral-200 bg-white px-5 py-4 text-sm font-bold text-neutral-900 shadow-sm transition-all hover:bg-neutral-50 active:scale-[0.98] dark:border-white/10 dark:bg-neutral-900 dark:text-white dark:hover:bg-neutral-800"
+            onClick={() => handOff('/import?destination=project', 'saved')}
+            disabled={handingOff}
+            className="flex items-center justify-center gap-3 rounded-xl border border-neutral-200 bg-white px-5 py-4 text-sm font-bold text-neutral-900 shadow-sm transition-all hover:bg-neutral-50 active:scale-[0.98] disabled:opacity-60 dark:border-white/10 dark:bg-neutral-900 dark:text-white dark:hover:bg-neutral-800"
           >
             <Folder className="h-5 w-5 text-blue-500" />
             Save to Project
           </button>
           <button
-            onClick={handleSendToChat}
-            className="flex items-center justify-center gap-3 rounded-xl bg-blue-600 px-5 py-4 text-sm font-bold text-white shadow-lg shadow-blue-600/20 transition-all hover:bg-blue-700 active:scale-[0.98]"
+            onClick={() => handOff('/assistant', 'attached')}
+            disabled={handingOff}
+            className="flex items-center justify-center gap-3 rounded-xl bg-blue-600 px-5 py-4 text-sm font-bold text-white shadow-lg shadow-blue-600/20 transition-all hover:bg-blue-700 active:scale-[0.98] disabled:opacity-60"
           >
             <MessageCircle className="h-5 w-5" />
             Start a Chat


### PR DESCRIPTION
## Summary
This PR significantly improves the PWA share target implementation by adding comprehensive diagnostics, better error handling, and support for large image files through the Cache API instead of base64 encoding.

## Key Changes

### SharePage.tsx
- **Refactored share loading**: Extracted cache operations into dedicated `loadShare()`, `openShareCache()`, and `clearShare()` functions for better testability and reusability
- **Added share diagnostics**: Implemented `ShareDiagnostics` type to track field names, file counts, unreadable files, and content type from the service worker
- **Improved error messaging**: Added `describeDiagnostics()` function to provide user-friendly explanations for failed or incomplete shares
- **Blob-based image handling**: Changed from base64 data URLs to blob objects with `URL.createObjectURL()` for better memory efficiency with large images
- **Added handoff state management**: Introduced `handingOff` state and `shareRef` to prevent multiple simultaneous handoffs and properly clean up object URLs
- **Enhanced empty state handling**: Distinguished between failed shares (with diagnostics) and truly empty shares, showing appropriate error messages
- **Added missing file warnings**: Display warnings when shared files could not be read back from cache

### sw.js (Service Worker)
- **Improved payload parsing**: Rewrote `readSharedPayload()` to handle arbitrary field names and gracefully fall back to raw text if form parsing fails
- **Added GET support**: Implemented `handleShareGet()` to support share targets declared as GET requests (for older WebAPK manifests)
- **Enhanced diagnostics collection**: Captures field names, file counts, unreadable files, and content type for the landing page to report
- **Better error resilience**: Separates payload parsing from cache writing to avoid losing previous shares on parse failures
- **Flexible field handling**: Preserves non-standard field names in `extras` array so custom sharing apps still work

### pwa-share.ts
- **Async handoff stashing**: Changed `stashPwaShareHandoff()` to async to support Cache API operations
- **Blob support**: Added `PwaShareHandoffInput` type accepting blobs for images, with automatic conversion to data URLs as fallback
- **Cache-based image transfer**: Large images now travel through the Cache API (avoiding sessionStorage size limits) with automatic fallback to base64
- **Memoized consumption**: Implemented `consumed` and `inFlight` tracking to handle multiple mount attempts for the same navigation
- **Improved type safety**: Added `StoredHandoff` type to distinguish between different storage formats

### ExtensionImport.tsx & AssistantPage.tsx
- **Async consumption**: Updated to handle `consumePwaShareHandoff()` as a Promise with proper cleanup handling
- **Release flag**: Added `released` flag to prevent applying payloads after component unmount

## Notable Implementation Details

- **Share cache expiration**: Shares older than 15 minutes are automatically cleared to prevent stale content from being shown
- **Dual storage strategy**: Images use Cache API when available (for large files) with sessionStorage fallback for compatibility
- **Graceful degradation**: Service worker handles multiple payload formats (FormData, URLSearchParams, raw text) to support various sharing sources
- **Memory management**: Proper cleanup of object URLs and cache entries to prevent memory leaks
- **Diagnostic preservation**: Share diagnostics are captured even when files fail to load, allowing the UI to explain what went wrong

https://claude.ai/code/session_01JQfEiXCxwmX7HVeDUcBium